### PR TITLE
ai-chat: mark extension prepare failures as errors

### DIFF
--- a/app/ai-chat/src/views/home/tabs/conversation_panel.rs
+++ b/app/ai-chat/src/views/home/tabs/conversation_panel.rs
@@ -346,8 +346,7 @@ impl ConversationPanelView {
                 adapter.name().to_string(),
             ))?
             .clone();
-        let stream =
-            adapter.fetch_by_request_body(context.config, settings, context.request_body);
+        let stream = adapter.fetch_by_request_body(context.config, settings, context.request_body);
         pin_mut!(stream);
         while let Some(message) = stream.next().await {
             match message {
@@ -428,58 +427,66 @@ impl ConversationPanelView {
             }
         })?;
 
-        let extension_runner = match context
+        let Some(extension_runner) = context
             .extension_container
             .get_extension(extension_name)
             .await
-        {
-            Ok(extension_runner) => extension_runner,
-            Err(error) => {
-                Self::record_extension_error(state, user_message_id, context, error, cx).await?;
-                return Ok(None);
-            }
+            .map(Some)
+            .or_else(|error| {
+                Self::record_extension_error(state.clone(), user_message_id, context, error, cx)
+                    .map(|()| None)
+            })?
+        else {
+            return Ok(None);
         };
-        let user_content = match Runner::get_new_user_content(request_text, Some(extension_runner))
+        let Some(user_content) = Runner::get_new_user_content(request_text, Some(extension_runner))
             .await
-        {
-            Ok(content) => content,
-            Err(error) => {
-                Self::record_extension_error(state, user_message_id, context, error, cx).await?;
-                return Ok(None);
-            }
+            .map(Some)
+            .or_else(|error| {
+                Self::record_extension_error(state.clone(), user_message_id, context, error, cx)
+                    .map(|()| None)
+            })?
+        else {
+            return Ok(None);
         };
-        let runner = Self::build_runner(
-            context.conversation_id,
-            context.config.clone(),
-            Role::User,
-            user_content.send_content().to_string(),
-            cx,
-        )?;
-        let send_content = runner.request_body()?;
-        let (user_message, assistant_message) =
-            cx.read_global_result(|db: &Db, _window, _cx| {
-                let conn = &mut db.get()?;
-                Message::update_content(user_message_id, &user_content, conn)?;
-                Message::update_send_content(user_message_id, send_content.clone(), conn)?;
-                Message::update_status(user_message_id, Status::Normal, conn)?;
-                let user_message = Message::find(user_message_id, conn)?;
-                let assistant_message = Message::insert(
-                    NewMessage::new(
-                        context.conversation_id,
-                        Role::Assistant,
-                        Content::Text(String::new()),
-                        send_content.clone(),
-                        Status::Loading,
-                    ),
-                    conn,
-                )?;
-                Ok::<_, AiChatError>((user_message, assistant_message))
-            })??;
-        Ok(Some(PreparedFetch {
-            runner,
-            user_message,
-            assistant_message,
-        }))
+        (|| -> AiChatResult<PreparedFetch> {
+            let runner = Self::build_runner(
+                context.conversation_id,
+                context.config.clone(),
+                Role::User,
+                user_content.send_content().to_string(),
+                cx,
+            )?;
+            let send_content = runner.request_body()?;
+            let (user_message, assistant_message) =
+                cx.read_global_result(|db: &Db, _window, _cx| {
+                    let conn = &mut db.get()?;
+                    Message::update_content(user_message_id, &user_content, conn)?;
+                    Message::update_send_content(user_message_id, send_content.clone(), conn)?;
+                    Message::update_status(user_message_id, Status::Normal, conn)?;
+                    let user_message = Message::find(user_message_id, conn)?;
+                    let assistant_message = Message::insert(
+                        NewMessage::new(
+                            context.conversation_id,
+                            Role::Assistant,
+                            Content::Text(String::new()),
+                            send_content.clone(),
+                            Status::Loading,
+                        ),
+                        conn,
+                    )?;
+                    Ok::<_, AiChatError>((user_message, assistant_message))
+                })??;
+            Ok(PreparedFetch {
+                runner,
+                user_message,
+                assistant_message,
+            })
+        })()
+        .map(Some)
+        .or_else(|error| {
+            Self::record_extension_error(state, user_message_id, context, error, cx).map(|()| None)
+        })
     }
 
     fn prepare_plain_fetch(
@@ -718,7 +725,7 @@ impl ConversationPanelView {
         Ok(())
     }
 
-    async fn record_extension_error(
+    fn record_extension_error(
         state: WeakEntity<Self>,
         user_message_id: i32,
         context: &FetchContext,

--- a/app/ai-chat/src/views/temporary/detail.rs
+++ b/app/ai-chat/src/views/temporary/detail.rs
@@ -656,48 +656,74 @@ impl TemplateDetailView {
             this.bind_running_task_messages(Some(user_message_id), None);
         })?;
 
-        let extension_runner = match extension_container.get_extension(extension_name).await {
-            Ok(extension_runner) => extension_runner,
-            Err(error) => {
-                Self::record_extension_error(state, user_message_id, extension_name, error, cx)?;
-                return Ok(None);
-            }
+        let Some(extension_runner) = extension_container
+            .get_extension(extension_name)
+            .await
+            .map(Some)
+            .or_else(|error| {
+                Self::record_extension_error(
+                    state.clone(),
+                    user_message_id,
+                    extension_name,
+                    error,
+                    cx,
+                )
+                .map(|()| None)
+            })?
+        else {
+            return Ok(None);
         };
-        let content = match Runner::get_new_user_content(request_text, Some(extension_runner)).await
-        {
-            Ok(content) => content,
-            Err(error) => {
-                Self::record_extension_error(state, user_message_id, extension_name, error, cx)?;
-                return Ok(None);
-            }
+        let Some(content) = Runner::get_new_user_content(request_text, Some(extension_runner))
+            .await
+            .map(Some)
+            .or_else(|error| {
+                Self::record_extension_error(
+                    state.clone(),
+                    user_message_id,
+                    extension_name,
+                    error,
+                    cx,
+                )
+                .map(|()| None)
+            })?
+        else {
+            return Ok(None);
         };
-        let runner = Self::build_runner(state.clone(), config, cx)?;
-        let send_content = runner.request_body_with_message(Role::User, content.send_content())?;
-        let assistant_message_id = state.update_result(cx, |this, _cx| {
-            if let Some(message) = this
-                .messages
-                .iter_mut()
-                .find(|message| message.id == user_message_id)
-            {
-                message.resolve_extension(content.clone(), send_content.clone());
-            }
-            this.add_message(
-                now,
-                Role::Assistant,
-                Content::Text(String::new()),
-                send_content.clone(),
-                Status::Loading,
-                None,
-            )
-            .id
-        })?;
-        state.update_result(cx, |this, _cx| {
-            this.bind_running_task_messages(Some(user_message_id), Some(assistant_message_id));
-        })?;
-        Ok(Some(PreparedTemporaryFetch {
-            runner,
-            assistant_message_id,
-        }))
+        (|| -> AiChatResult<PreparedTemporaryFetch> {
+            let runner = Self::build_runner(state.clone(), config, cx)?;
+            let send_content =
+                runner.request_body_with_message(Role::User, content.send_content())?;
+            let assistant_message_id = state.update_result(cx, |this, _cx| {
+                if let Some(message) = this
+                    .messages
+                    .iter_mut()
+                    .find(|message| message.id == user_message_id)
+                {
+                    message.resolve_extension(content.clone(), send_content.clone());
+                }
+                this.add_message(
+                    now,
+                    Role::Assistant,
+                    Content::Text(String::new()),
+                    send_content.clone(),
+                    Status::Loading,
+                    None,
+                )
+                .id
+            })?;
+            state.update_result(cx, |this, _cx| {
+                this.bind_running_task_messages(Some(user_message_id), Some(assistant_message_id));
+            })?;
+            Ok(PreparedTemporaryFetch {
+                runner,
+                assistant_message_id,
+            })
+        })()
+        .map(Some)
+        .or_else(|error| {
+            Self::record_extension_error(state, user_message_id, extension_name, error, cx)
+                .map(|()| None)
+        })
     }
 
     fn prepare_plain_fetch(


### PR DESCRIPTION
## Summary

- Fix `ai-chat` extension send flows so prepare-stage failures mark the pending user message as `Error` instead of leaving it stuck in `Loading`
- Apply the same error handling to both the conversation panel and temporary detail flow
- Which app or crate is affected: `ai-chat`

## Motivation

- Follow up the review feedback from #5: request-body generation and other prepare-stage failures could leave a dangling loading message with no terminal state

## Changes

- Route extension prepare-step failures through `record_extension_error` in `conversation_panel`
- Mirror the same prepare-step failure handling in `temporary/detail`
- Keep the implementation concise by using `Result` combinators instead of a custom helper

## Validation

- [x] `cargo build`
- [x] `cargo test`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
cargo test -p ai-chat conversation_panel -- --nocapture
cargo test -p ai-chat temporary::detail -- --nocapture
cargo test -p ai-chat -- --nocapture
cargo build -p ai-chat
cargo clippy -p ai-chat --all-targets -- -D warnings

All commands passed.
Manual verification not run.
`cargo clippy --all-features` was not run; the scoped `ai-chat` clippy command above was run instead.
```

## Risks

- The behavior change is limited to extension-backed send preparation failures.
- If `record_extension_error` itself fails, the outer fetch task still falls back to the existing top-level task cleanup path.

## Related Issues

- Follow-up to #5
