### PR TITLE
ai-chat: refine sidebar conversation drag targets

### DIFF
--- a/app/ai-chat/src/views/home/sidebar/conversation_item.rs
+++ b/app/ai-chat/src/views/home/sidebar/conversation_item.rs
@@ -1,7 +1,4 @@
-use super::conversation_tree::{
-    DragConversationTreeItem, DropState, SidebarConversationNode, folder_drop_state,
-    reset_drop_target, root_drop_state, set_drop_target, target_for_conversation_row,
-};
+use super::conversation_tree::{DragConversationTreeItem, SidebarConversationNode};
 use crate::{
     components::delete_confirm::open_delete_confirm_dialog,
     store::{ChatData, ChatDataEvent},
@@ -22,7 +19,6 @@ pub(super) struct ConversationTreeItem {
     collapsed: bool,
     depth: usize,
     active_conversation_id: Option<i32>,
-    target_folder: Option<(i32, SharedString)>,
     root_drop_target: bool,
 }
 
@@ -32,7 +28,6 @@ impl ConversationTreeItem {
         collapsed: bool,
         depth: usize,
         active_conversation_id: Option<i32>,
-        target_folder: Option<(i32, SharedString)>,
         root_drop_target: bool,
     ) -> Self {
         Self {
@@ -40,7 +35,6 @@ impl ConversationTreeItem {
             collapsed,
             depth,
             active_conversation_id,
-            target_folder,
             root_drop_target,
         }
     }
@@ -53,8 +47,6 @@ impl RenderOnce for ConversationTreeItem {
         let title = conversation.title.clone();
         let padding_left = px((self.depth as f32) * 14. + 26.);
         let is_active = self.active_conversation_id == Some(id);
-        let target_folder = self.target_folder.clone();
-        let is_root_conversation = target_folder.is_none();
         let root_drop_target = self.root_drop_target;
 
         h_flex()
@@ -105,40 +97,6 @@ impl RenderOnce for ConversationTreeItem {
                                 }),
                         ),
                 )
-            })
-            .on_drag_move::<DragConversationTreeItem>({
-                let target_folder = target_folder.clone();
-                move |event, window, cx| {
-                    let target = target_for_conversation_row(
-                        event.drag(cx),
-                        target_folder
-                            .as_ref()
-                            .map(|(folder_id, folder_path)| (*folder_id, folder_path.as_ref())),
-                    );
-                    if event.bounds.contains(&event.event.position) {
-                        match target {
-                            Some(target) => set_drop_target(window, cx, target),
-                            None => reset_drop_target(window, cx),
-                        }
-                    } else if is_root_conversation && let Some(target) = target {
-                        super::conversation_tree::clear_drop_target(window, cx, target);
-                    }
-                }
-            })
-            .on_drop({
-                let target_folder = target_folder.clone();
-                move |drag: &DragConversationTreeItem, window, cx| {
-                    cx.stop_propagation();
-                    reset_drop_target(window, cx);
-                    if let Some((folder_id, folder_path)) = target_folder.as_ref() {
-                        if folder_drop_state(drag, *folder_id, folder_path) != DropState::Valid {
-                            return;
-                        }
-                        drag.move_to_folder(*folder_id, cx);
-                    } else if root_drop_state(drag) == DropState::Valid {
-                        drag.move_to_root(cx);
-                    }
-                }
             })
             .cursor_pointer()
             .on_click(move |_this, _window, cx| {

--- a/app/ai-chat/src/views/home/sidebar/conversation_tree.rs
+++ b/app/ai-chat/src/views/home/sidebar/conversation_tree.rs
@@ -41,6 +41,10 @@ impl ActiveDropTarget {
     fn folder(id: i32, invalid: bool) -> Self {
         Self::Folder { id, invalid }
     }
+
+    pub(super) fn is_root(self) -> bool {
+        matches!(self, Self::Root)
+    }
 }
 
 const DROP_TARGET_KEY: (&str, usize) = ("conversation-tree-drop-target", 0);
@@ -53,8 +57,8 @@ pub(super) struct SidebarConversationNode {
     pub(super) icon: SharedString,
 }
 
-impl SidebarConversationNode {
-    fn from_conversation(conversation: &Conversation) -> Self {
+impl From<&Conversation> for SidebarConversationNode {
+    fn from(conversation: &Conversation) -> Self {
         Self {
             id: conversation.id,
             folder_id: conversation.folder_id,
@@ -74,8 +78,8 @@ pub(super) struct SidebarFolderNode {
     pub(super) conversations: Vec<SidebarConversationNode>,
 }
 
-impl SidebarFolderNode {
-    fn from_folder(folder: &Folder) -> Self {
+impl From<&Folder> for SidebarFolderNode {
+    fn from(folder: &Folder) -> Self {
         Self {
             id: folder.id,
             parent_id: folder.parent_id,
@@ -88,14 +92,11 @@ impl SidebarFolderNode {
 }
 
 fn project_folders(folders: &[Folder]) -> Vec<SidebarFolderNode> {
-    folders.iter().map(SidebarFolderNode::from_folder).collect()
+    folders.iter().map(Into::into).collect()
 }
 
 fn project_conversations(conversations: &[Conversation]) -> Vec<SidebarConversationNode> {
-    conversations
-        .iter()
-        .map(SidebarConversationNode::from_conversation)
-        .collect()
+    conversations.iter().map(Into::into).collect()
 }
 
 #[derive(IntoElement)]
@@ -142,11 +143,15 @@ impl Collapsible for ConversationTree {
 
 impl RenderOnce for ConversationTree {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let collapsed = self.collapsed;
+        let active_conversation_id = self.active_conversation_id;
+        let folders = self.folders;
+        let conversations = self.conversations;
         let root_label = self.root_label.clone();
         let drop_target =
             window.use_keyed_state(DROP_TARGET_KEY, cx, |_, _| Option::<ActiveDropTarget>::None);
         let active_drop_target = *drop_target.read(cx);
-        let root_is_highlighted = active_drop_target == Some(ActiveDropTarget::Root);
+        let root_is_highlighted = active_drop_target.is_some_and(ActiveDropTarget::is_root);
         v_flex()
             .id("conversation-tree")
             .focusable()
@@ -192,41 +197,45 @@ impl RenderOnce for ConversationTree {
                     });
                 }
             })
-            .children(
-                self.folders
-                    .into_iter()
-                    .map(|folder| {
-                        FolderTreeItem::new(
-                            folder,
-                            self.collapsed,
-                            0,
-                            self.active_conversation_id,
-                            active_drop_target,
-                        )
-                        .into_any_element()
-                    })
-                    .chain(self.conversations.into_iter().map(|conversation| {
-                        ConversationTreeItem::new(
-                            conversation,
-                            self.collapsed,
-                            0,
-                            self.active_conversation_id,
-                            None,
-                            active_drop_target == Some(ActiveDropTarget::Root),
-                        )
-                        .into_any_element()
-                    })),
-            )
+            .children(folders.into_iter().map(|folder| {
+                FolderTreeItem::new(
+                    folder,
+                    collapsed,
+                    0,
+                    active_conversation_id,
+                    active_drop_target,
+                )
+                .into_any_element()
+            }))
             .child(
-                div()
-                    .min_h(px(52.))
+                v_flex()
                     .w_full()
-                    .flex()
-                    .items_center()
-                    .justify_center()
-                    .text_sm()
-                    .text_color(cx.theme().muted_foreground)
-                    .child(root_label)
+                    .gap_1()
+                    .when(!conversations.is_empty(), |this| {
+                        this.child(v_flex().gap_1().children(conversations.into_iter().map(
+                            move |conversation| {
+                                ConversationTreeItem::new(
+                                    conversation,
+                                    collapsed,
+                                    0,
+                                    active_conversation_id,
+                                    root_is_highlighted,
+                                )
+                                .into_any_element()
+                            },
+                        )))
+                    })
+                    .child(
+                        div()
+                            .min_h(px(52.))
+                            .w_full()
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .text_sm()
+                            .text_color(cx.theme().muted_foreground)
+                            .child(root_label),
+                    )
                     .on_drag_move::<DragConversationTreeItem>({
                         move |event, window, cx| {
                             let target = target_for_root(event.drag(cx));
@@ -235,6 +244,8 @@ impl RenderOnce for ConversationTree {
                                     Some(target) => set_drop_target(window, cx, target),
                                     None => reset_drop_target(window, cx),
                                 }
+                            } else if let Some(target) = target {
+                                clear_drop_target(window, cx, target);
                             }
                         }
                     })
@@ -389,6 +400,16 @@ pub(super) fn target_for_root(drag: &DragConversationTreeItem) -> Option<ActiveD
     }
 }
 
+pub(super) fn target_for_conversation_group(
+    drag: &DragConversationTreeItem,
+    target_folder: Option<(i32, &str)>,
+) -> Option<ActiveDropTarget> {
+    match target_folder {
+        Some((folder_id, folder_path)) => target_for_folder(drag, folder_id, folder_path),
+        None => target_for_root(drag),
+    }
+}
+
 pub(super) fn target_for_folder(
     drag: &DragConversationTreeItem,
     target_folder_id: i32,
@@ -398,16 +419,6 @@ pub(super) fn target_for_folder(
         DropState::Valid => Some(ActiveDropTarget::folder(target_folder_id, false)),
         DropState::InvalidDescendant => Some(ActiveDropTarget::folder(target_folder_id, true)),
         DropState::Noop => None,
-    }
-}
-
-pub(super) fn target_for_conversation_row(
-    drag: &DragConversationTreeItem,
-    target_folder: Option<(i32, &str)>,
-) -> Option<ActiveDropTarget> {
-    match target_folder {
-        Some((folder_id, folder_path)) => target_for_folder(drag, folder_id, folder_path),
-        None => target_for_root(drag),
     }
 }
 
@@ -488,7 +499,7 @@ mod tests {
     use super::{
         ActiveDropTarget, DragConversationTreeItem, DragConversationTreeKind, DropState,
         folder_block_drop_target, folder_drop_state, project_conversations, project_folders,
-        root_drop_state, target_for_conversation_row, target_for_folder, target_for_root,
+        root_drop_state, target_for_conversation_group, target_for_folder, target_for_root,
     };
     use crate::database::{Content, Conversation, Folder, Message, Role, Status};
     use gpui::SharedString;
@@ -689,20 +700,23 @@ mod tests {
     }
 
     #[test]
-    fn conversation_row_target_does_not_fall_back_to_root_for_folder_noop_drag() {
+    fn conversation_group_target_uses_root_for_root_group_gaps() {
         let drag = conversation_drag(7, Some(2));
         assert_eq!(
-            target_for_conversation_row(&drag, Some((2, "/root/folder"))),
-            None
+            target_for_conversation_group(&drag, None),
+            Some(ActiveDropTarget::Root)
         );
     }
 
     #[test]
-    fn conversation_row_target_uses_root_only_for_root_rows() {
+    fn conversation_group_target_uses_folder_for_folder_group_gaps() {
         let drag = conversation_drag(7, Some(2));
         assert_eq!(
-            target_for_conversation_row(&drag, None),
-            Some(ActiveDropTarget::Root)
+            target_for_conversation_group(&drag, Some((3, "/root/folder"))),
+            Some(ActiveDropTarget::Folder {
+                id: 3,
+                invalid: false
+            })
         );
     }
 

--- a/app/ai-chat/src/views/home/sidebar/folder_item.rs
+++ b/app/ai-chat/src/views/home/sidebar/folder_item.rs
@@ -1,10 +1,8 @@
-use super::{
-    conversation_item::ConversationTreeItem,
-    conversation_tree::{
-        ActiveDropTarget, DragConversationTreeItem, DropState, SidebarFolderNode,
-        folder_block_drop_target, folder_drop_state, reset_drop_target, set_drop_target,
-        target_for_folder,
-    },
+use super::conversation_item::ConversationTreeItem;
+use super::conversation_tree::{
+    ActiveDropTarget, DragConversationTreeItem, DropState, SidebarFolderNode,
+    folder_block_drop_target, folder_drop_state, reset_drop_target, set_drop_target,
+    target_for_conversation_group, target_for_folder,
 };
 use crate::{
     components::{
@@ -58,11 +56,11 @@ impl RenderOnce for FolderTreeItem {
         let path = folder.path.clone();
         let active_drop_target = self.active_drop_target;
         let block_drop_target = folder_block_drop_target(active_drop_target, id);
-        let root_drop_target = active_drop_target == Some(ActiveDropTarget::Root);
+        let root_drop_target = active_drop_target.is_some_and(ActiveDropTarget::is_root);
         let open_state = window.use_keyed_state(
             ("conversation-tree-folder-open", id as usize),
             cx,
-            |_, _| true,
+            |_, _| false,
         );
         let is_open = !self.collapsed && *open_state.read(cx);
         let padding_left = px((self.depth as f32) * 14.);
@@ -201,33 +199,63 @@ impl RenderOnce for FolderTreeItem {
                 }
             })
             .when(is_open, |this| {
+                let has_conversations = !folder.conversations.is_empty();
+                let child_folders = folder.folders;
+                let child_conversations = folder.conversations;
+                let conversation_group = v_flex()
+                    .gap_1()
+                    .children(child_conversations.into_iter().map(|conversation| {
+                        ConversationTreeItem::new(
+                            conversation,
+                            self.collapsed,
+                            self.depth + 1,
+                            self.active_conversation_id,
+                            root_drop_target,
+                        )
+                        .into_any_element()
+                    }))
+                    .on_drag_move::<DragConversationTreeItem>({
+                        let path = path.clone();
+                        move |event, window, cx| {
+                            let target = target_for_conversation_group(
+                                event.drag(cx),
+                                Some((id, path.as_ref())),
+                            );
+                            if event.bounds.contains(&event.event.position) {
+                                match target {
+                                    Some(target) => set_drop_target(window, cx, target),
+                                    None => reset_drop_target(window, cx),
+                                }
+                            } else if let Some(target) = target {
+                                super::conversation_tree::clear_drop_target(window, cx, target);
+                            }
+                        }
+                    })
+                    .on_drop({
+                        let path = path.clone();
+                        move |drag: &DragConversationTreeItem, window, cx| {
+                            cx.stop_propagation();
+                            reset_drop_target(window, cx);
+                            if folder_drop_state(drag, id, &path) != DropState::Valid {
+                                return;
+                            }
+                            drag.move_to_folder(id, cx);
+                        }
+                    });
                 this.child(
-                    v_flex().gap_1().children(
-                        folder
-                            .folders
-                            .into_iter()
-                            .map(|child| {
-                                FolderTreeItem::new(
-                                    child,
-                                    self.collapsed,
-                                    self.depth + 1,
-                                    self.active_conversation_id,
-                                    active_drop_target,
-                                )
-                                .into_any_element()
-                            })
-                            .chain(folder.conversations.into_iter().map(|conversation| {
-                                ConversationTreeItem::new(
-                                    conversation,
-                                    self.collapsed,
-                                    self.depth + 1,
-                                    self.active_conversation_id,
-                                    Some((id, path.clone())),
-                                    root_drop_target,
-                                )
-                                .into_any_element()
-                            })),
-                    ),
+                    v_flex()
+                        .gap_1()
+                        .children(child_folders.into_iter().map(|child| {
+                            FolderTreeItem::new(
+                                child,
+                                self.collapsed,
+                                self.depth + 1,
+                                self.active_conversation_id,
+                                active_drop_target,
+                            )
+                            .into_any_element()
+                        }))
+                        .when(has_conversations, |this| this.child(conversation_group)),
                 )
             })
     }


### PR DESCRIPTION
## Summary

- Refine `ai-chat` sidebar drag-and-drop handling and remove the conversation tree deep-clone regression.
- Affected app: `ai-chat`

## Motivation

- Fix the sidebar performance regression introduced by cloning full conversation trees, including message history, on render.
- Fix inconsistent drag-target feedback in the sidebar, especially around folder/root conversation gaps and root conversation rows.

## Changes

- Project sidebar folders and conversations into lightweight internal nodes instead of cloning full `Conversation` and `Folder` trees.
- Move conversation drop handling from individual conversation rows to group-level root/folder drop zones.
- Unify the root conversation area and the root label/blank area into one root drop zone so gaps keep the root highlight.
- Default folders to collapsed in the sidebar.
- Replace local `from_xxx` helpers for the sidebar projection nodes with `From<&Conversation>` and `From<&Folder>`.
- Add and update sidebar tests to cover projection behavior and drag-target resolution.

## Validation

- [x] `cargo build`
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
Ran:
- cargo build -p ai-chat
- cargo test -p ai-chat
- cargo clippy -p ai-chat --all-targets --all-features -- -D warnings

Result:
- All three commands passed on March 6, 2026.
- Manual UI verification was not run in this session.
```

## Risks

- Sidebar drag feedback now depends on container-level drop zones rather than per-row drop receivers; any future per-row reorder semantics would need separate handling.
- Folder default-open behavior changed to default-collapsed.

## Related Issues

- Closes #13
