### PR TITLE
workspace: reduce retained entities and ai-chat payload clones

### DIFF
--- a/app/ai-chat/src/components/template_edit_dialog.rs
+++ b/app/ai-chat/src/components/template_edit_dialog.rs
@@ -494,7 +494,7 @@ impl Render for PromptListForm {
                 i18n.t("button-add-prompt"),
             )
         };
-        let this = cx.entity().clone();
+        let this = cx.entity().downgrade();
         let prompt_fields = self
             .prompt_rows
             .iter()
@@ -512,7 +512,7 @@ impl Render for PromptListForm {
                                 Button::new(("prompt-delete", index))
                                     .label(delete_label.clone())
                                     .on_click(move |_, _window, cx| {
-                                        this.update(cx, |form, cx| {
+                                        let _ = this.update(cx, |form, cx| {
                                             form.remove_prompt_row(index, cx);
                                         });
                                     }),
@@ -543,7 +543,7 @@ impl Render for PromptListForm {
                     .child(Label::new(prompts_label))
                     .child(Button::new("prompt-add").label(add_prompt_label).on_click(
                         move |_, window, cx| {
-                            this.update(cx, |form, cx| {
+                            let _ = this.update(cx, |form, cx| {
                                 form.add_prompt_row(window, cx);
                             });
                         },

--- a/app/ai-chat/src/database/model/messages.rs
+++ b/app/ai-chat/src/database/model/messages.rs
@@ -7,21 +7,21 @@ use time::OffsetDateTime;
 
 #[derive(Insertable)]
 #[diesel(table_name = messages)]
-pub struct SqlNewMessage {
+pub struct SqlNewMessage<'a> {
     pub(in super::super) conversation_id: i32,
-    pub(in super::super) conversation_path: String,
-    pub(in super::super) role: String,
-    pub(in super::super) content: String,
-    pub(in super::super) send_content: serde_json::Value,
-    pub(in super::super) status: String,
+    pub(in super::super) conversation_path: &'a str,
+    pub(in super::super) role: &'a str,
+    pub(in super::super) content: &'a str,
+    pub(in super::super) send_content: &'a serde_json::Value,
+    pub(in super::super) status: &'a str,
     pub(in super::super) created_time: OffsetDateTime,
     pub(in super::super) updated_time: OffsetDateTime,
     pub(in super::super) start_time: OffsetDateTime,
     pub(in super::super) end_time: OffsetDateTime,
-    pub(in super::super) error: Option<String>,
+    pub(in super::super) error: Option<&'a str>,
 }
 
-impl SqlNewMessage {
+impl SqlNewMessage<'_> {
     pub fn insert(&self, conn: &mut SqliteConnection) -> AiChatResult<SqlMessage> {
         let sql_message = diesel::insert_into(messages::table)
             .values(self)
@@ -96,7 +96,7 @@ impl SqlMessage {
     }
     pub fn update_send_content(
         id: i32,
-        send_content: serde_json::Value,
+        send_content: &serde_json::Value,
         time: OffsetDateTime,
         conn: &mut SqliteConnection,
     ) -> AiChatResult<()> {

--- a/app/ai-chat/src/database/service/messages.rs
+++ b/app/ai-chat/src/database/service/messages.rs
@@ -158,22 +158,22 @@ impl TryFrom<SqlMessage> for Message {
     }
 }
 
-#[derive(Deserialize, Debug)]
-pub struct NewMessage {
+#[derive(Debug, Clone, Copy)]
+pub struct NewMessage<'a> {
     pub conversation_id: i32,
     pub role: Role,
-    pub content: Content,
-    pub send_content: serde_json::Value,
+    pub content: &'a Content,
+    pub send_content: &'a serde_json::Value,
     pub status: Status,
-    pub error: Option<String>,
+    pub error: Option<&'a str>,
 }
 
-impl NewMessage {
+impl<'a> NewMessage<'a> {
     pub fn new(
         conversation_id: i32,
         role: Role,
-        content: Content,
-        send_content: serde_json::Value,
+        content: &'a Content,
+        send_content: &'a serde_json::Value,
         status: Status,
     ) -> Self {
         Self {
@@ -186,8 +186,8 @@ impl NewMessage {
         }
     }
 
-    pub fn with_error(mut self, error: impl Into<String>) -> Self {
-        self.error = Some(error.into());
+    pub fn with_error(mut self, error: &'a str) -> Self {
+        self.error = Some(error);
         self
     }
 }
@@ -201,20 +201,23 @@ impl Message {
             send_content,
             status,
             error,
-        }: NewMessage,
+        }: NewMessage<'_>,
         conn: &mut SqliteConnection,
     ) -> AiChatResult<Message> {
         conn.immediate_transaction(|conn| {
             let time = OffsetDateTime::now_utc();
             let SqlConversation { path, .. } = SqlConversation::find(conversation_id, conn)?;
+            let role = role.to_string();
+            let content = serde_json::to_string(content)?;
+            let status = status.to_string();
 
             let new_message = SqlNewMessage {
                 conversation_id,
-                conversation_path: path,
-                role: role.to_string(),
-                content: serde_json::to_string(&content)?,
+                conversation_path: &path,
+                role: &role,
+                content: &content,
                 send_content,
-                status: status.to_string(),
+                status: &status,
                 created_time: time,
                 updated_time: time,
                 start_time: time,
@@ -255,7 +258,7 @@ impl Message {
     }
     pub fn update_send_content(
         id: i32,
-        send_content: serde_json::Value,
+        send_content: &serde_json::Value,
         conn: &mut SqliteConnection,
     ) -> AiChatResult<()> {
         let time = OffsetDateTime::now_utc();

--- a/app/ai-chat/src/llm/provider.rs
+++ b/app/ai-chat/src/llm/provider.rs
@@ -93,27 +93,20 @@ pub trait Adapter: Sync {
             .ok_or_else(|| AiChatError::AdapterSettingsNotFound(self.name().to_string()))?
             .clone();
         let settings = serde_json::to_value(settings)?;
-        self.get_template_inputs(&settings)
+        self.get_template_inputs(settings)
     }
-    fn get_template_inputs(&self, settings: &serde_json::Value) -> AiChatResult<Vec<InputItem>>;
+    fn get_template_inputs(&self, settings: serde_json::Value) -> AiChatResult<Vec<InputItem>>;
     fn request_body(
         &self,
         template: &serde_json::Value,
         history_messages: Vec<Message>,
     ) -> AiChatResult<serde_json::Value>;
-    fn fetch(
+    fn fetch_by_request_body<'a>(
         &self,
         config: AiChatConfig,
         settings: toml::Value,
-        template: serde_json::Value,
-        history_messages: Vec<Message>,
-    ) -> BoxStream<'static, AiChatResult<String>>;
-    fn fetch_by_request_body(
-        &self,
-        config: AiChatConfig,
-        settings: toml::Value,
-        request_body: serde_json::Value,
-    ) -> BoxStream<'static, AiChatResult<String>>;
+        request_body: &'a serde_json::Value,
+    ) -> BoxStream<'a, AiChatResult<String>>;
     fn setting_group(&self) -> SettingGroup;
     fn description_items(&self, template: &ConversationTemplate) -> Vec<DescriptionItem> {
         description_items_default(template)

--- a/app/ai-chat/src/llm/provider/openai.rs
+++ b/app/ai-chat/src/llm/provider/openai.rs
@@ -254,8 +254,8 @@ impl Adapter for OpenAIAdapter {
         setting_inputs
     }
 
-    fn get_template_inputs(&self, settings: &serde_json::Value) -> AiChatResult<Vec<InputItem>> {
-        let settings: OpenAISettings = serde_json::from_value(settings.clone())?;
+    fn get_template_inputs(&self, settings: serde_json::Value) -> AiChatResult<Vec<InputItem>> {
+        let settings: OpenAISettings = serde_json::from_value(settings)?;
         get_openai_template_inputs(&settings.models)
     }
 
@@ -264,39 +264,19 @@ impl Adapter for OpenAIAdapter {
         template: &serde_json::Value,
         history_messages: Vec<Message>,
     ) -> AiChatResult<serde_json::Value> {
-        let template: OpenAIConversationTemplate = serde_json::from_value(template.clone())?;
+        let template = OpenAIConversationTemplate::deserialize(template)?;
         Ok(serde_json::to_value(Self::get_body(
             &template,
             history_messages,
         ))?)
     }
 
-    fn fetch(
+    fn fetch_by_request_body<'a>(
         &self,
         config: AiChatConfig,
         settings: toml::Value,
-        template: serde_json::Value,
-        history_messages: Vec<Message>,
-    ) -> BoxStream<'static, AiChatResult<String>> {
-        async_stream::try_stream! {
-            let template = serde_json::from_value(template)?;
-            let settings = settings.try_into()?;
-            let body = Self::get_body(&template, history_messages);
-            let client = Self::get_reqwest_client(&config, &settings)?;
-            let response=client.post(settings.url.clone()).json(&body).send().await?;
-            let response = response.json::<ResponsesCreateResponse>().await?;
-            let content = response.output_text();
-            yield content
-        }
-        .boxed()
-    }
-
-    fn fetch_by_request_body(
-        &self,
-        config: AiChatConfig,
-        settings: toml::Value,
-        request_body: serde_json::Value,
-    ) -> BoxStream<'static, AiChatResult<String>> {
+        request_body: &'a serde_json::Value,
+    ) -> BoxStream<'a, AiChatResult<String>> {
         async_stream::try_stream! {
             let settings = settings.try_into()?;
             let client = Self::get_reqwest_client(&config, &settings)?;

--- a/app/ai-chat/src/llm/provider/openai_stream.rs
+++ b/app/ai-chat/src/llm/provider/openai_stream.rs
@@ -115,8 +115,8 @@ impl Adapter for OpenAIStreamAdapter {
         OpenAIAdapter.get_setting_inputs()
     }
 
-    fn get_template_inputs(&self, settings: &serde_json::Value) -> AiChatResult<Vec<InputItem>> {
-        let settings: OpenAIStreamSettings = serde_json::from_value(settings.clone())?;
+    fn get_template_inputs(&self, settings: serde_json::Value) -> AiChatResult<Vec<InputItem>> {
+        let settings: OpenAIStreamSettings = serde_json::from_value(settings)?;
         get_openai_template_inputs(&settings.models)
     }
 
@@ -125,57 +125,19 @@ impl Adapter for OpenAIStreamAdapter {
         template: &serde_json::Value,
         history_messages: Vec<Message>,
     ) -> AiChatResult<serde_json::Value> {
-        let template: OpenAIConversationTemplate = serde_json::from_value(template.clone())?;
+        let template = OpenAIConversationTemplate::deserialize(template)?;
         Ok(serde_json::to_value(Self::get_body(
             &template,
             history_messages,
         ))?)
     }
 
-    fn fetch(
+    fn fetch_by_request_body<'a>(
         &self,
         config: AiChatConfig,
         settings: toml::Value,
-        template: serde_json::Value,
-        history_messages: Vec<Message>,
-    ) -> BoxStream<'static, AiChatResult<String>> {
-        async_stream::try_stream! {
-            let template = serde_json::from_value(template)?;
-            let settings = settings.try_into()?;
-            let body = Self::get_body(&template, history_messages);
-            let client = Self::get_reqwest_client(&config, &settings)?;
-            let mut es = client.post(settings.url.as_str()).json(&body).eventsource()?;
-            while let Some(event) = es.next().await {
-                match event {
-                    Ok(Event::Open) => {},
-                    Ok(Event::Message(message)) => {
-                        let message = message.data;
-                        if message == "[DONE]" {
-                            es.close();
-                            break;
-                        } else if let Some(content) = parse_response_stream_event(&message)? {
-                            yield content;
-                        }
-                    }
-                    Err(err) => {
-                        es.close();
-                        if is_normal_stream_end(&err) {
-                            break;
-                        }
-                        Err::<(), AiChatError>(err.into())?;
-                    }
-                }
-            }
-        }
-        .boxed()
-    }
-
-    fn fetch_by_request_body(
-        &self,
-        config: AiChatConfig,
-        settings: toml::Value,
-        request_body: serde_json::Value,
-    ) -> BoxStream<'static, AiChatResult<String>> {
+        request_body: &'a serde_json::Value,
+    ) -> BoxStream<'a, AiChatResult<String>> {
         async_stream::try_stream! {
             let settings = settings.try_into()?;
             let client = Self::get_reqwest_client(&config, &settings)?;

--- a/app/ai-chat/src/llm/runner.rs
+++ b/app/ai-chat/src/llm/runner.rs
@@ -1,4 +1,4 @@
-use super::{Adapter, Message, adapter_by_name};
+use super::{Adapter, adapter_by_name};
 use crate::{
     config::AiChatConfig,
     database::Content,
@@ -9,15 +9,10 @@ use futures::pin_mut;
 
 pub trait FetchRunner {
     fn get_adapter(&self) -> &str;
-    fn get_template(&self) -> &serde_json::Value;
     fn get_config(&self) -> &AiChatConfig;
-    fn get_history(&self) -> Vec<Message>;
+    fn request_body(&self) -> &serde_json::Value;
     fn adapter(&self) -> AiChatResult<&'static dyn Adapter> {
         adapter_by_name(self.get_adapter())
-    }
-    fn request_body(&self) -> AiChatResult<serde_json::Value> {
-        self.adapter()?
-            .request_body(self.get_template(), self.get_history())
     }
     async fn get_new_user_content(
         send_content: String,
@@ -54,9 +49,7 @@ pub trait FetchRunner {
                 .get_adapter_settings(adapter.name())
                 .ok_or(AiChatError::AdapterSettingsNotFound(adapter.name().to_string()))?;
             let settings = settings.clone();
-            let template = self.get_template().clone();
-            let history = self.get_history();
-            let stream = adapter.fetch(config, settings, template, history);
+            let stream = adapter.fetch_by_request_body(config, settings, self.request_body());
             pin_mut!(stream);
             for await item in stream {
                 yield item?;
@@ -80,18 +73,14 @@ mod tests {
             "noop"
         }
 
-        fn get_template(&self) -> &serde_json::Value {
-            static TEMPLATE: OnceLock<serde_json::Value> = OnceLock::new();
-            TEMPLATE.get_or_init(|| serde_json::Value::Null)
-        }
-
         fn get_config(&self) -> &crate::config::AiChatConfig {
             static CONFIG: OnceLock<crate::config::AiChatConfig> = OnceLock::new();
             CONFIG.get_or_init(crate::config::AiChatConfig::default)
         }
 
-        fn get_history(&self) -> Vec<crate::llm::Message> {
-            Vec::new()
+        fn request_body(&self) -> &serde_json::Value {
+            static TEMPLATE: OnceLock<serde_json::Value> = OnceLock::new();
+            TEMPLATE.get_or_init(|| serde_json::Value::Null)
         }
     }
 

--- a/app/ai-chat/src/store/runtime.rs
+++ b/app/ai-chat/src/store/runtime.rs
@@ -280,12 +280,12 @@ impl ChatData {
                 let mut new_message = NewMessage::new(
                     conversation.id,
                     initial_message.role,
-                    initial_message.content.clone(),
-                    initial_message.send_content.clone(),
+                    &initial_message.content,
+                    &initial_message.send_content,
                     initial_message.status,
                 );
                 if let Some(error) = initial_message.error.as_ref() {
-                    new_message = new_message.with_error(error.clone());
+                    new_message = new_message.with_error(error);
                 }
                 let message = Message::insert(new_message, conn)?;
                 conversation.messages.push(message);

--- a/app/ai-chat/src/views/home/sidebar/folder_item.rs
+++ b/app/ai-chat/src/views/home/sidebar/folder_item.rs
@@ -142,6 +142,9 @@ impl RenderOnce for FolderTreeItem {
                                         .group_hover(format!("folder-group-{id}"), |style| {
                                             style.opacity(1.)
                                         })
+                                        .on_click(|_, _, cx| {
+                                            cx.stop_propagation();
+                                        })
                                         .dropdown_menu({
                                             let folder = folder.clone();
                                             move |menu, window, cx| {

--- a/app/ai-chat/src/views/home/tabs/conversation_panel.rs
+++ b/app/ai-chat/src/views/home/tabs/conversation_panel.rs
@@ -348,7 +348,7 @@ impl ConversationPanelView {
                 adapter.name().to_string(),
             ))?
             .clone();
-        let stream = adapter.fetch_by_request_body(context.config, settings, context.request_body);
+        let stream = adapter.fetch_by_request_body(context.config, settings, &context.request_body);
         pin_mut!(stream);
         while let Some(message) = stream.next().await {
             match message {
@@ -459,20 +459,20 @@ impl ConversationPanelView {
                 user_content.send_content().to_string(),
                 cx,
             )?;
-            let send_content = runner.request_body()?;
+            let send_content = runner.request_body();
             let (user_message, assistant_message) =
                 cx.read_global_result(|db: &Db, _window, _cx| {
                     let conn = &mut db.get()?;
                     Message::update_content(user_message_id, &user_content, conn)?;
-                    Message::update_send_content(user_message_id, send_content.clone(), conn)?;
+                    Message::update_send_content(user_message_id, send_content, conn)?;
                     Message::update_status(user_message_id, Status::Normal, conn)?;
                     let user_message = Message::find(user_message_id, conn)?;
                     let assistant_message = Message::insert(
                         NewMessage::new(
                             context.conversation_id,
                             Role::Assistant,
-                            Content::Text(String::new()),
-                            send_content.clone(),
+                            &Content::Text(String::new()),
+                            send_content,
                             Status::Loading,
                         ),
                         conn,
@@ -504,7 +504,7 @@ impl ConversationPanelView {
             user_content.send_content().to_string(),
             cx,
         )?;
-        let send_content = runner.request_body()?;
+        let send_content = runner.request_body();
         let (user_message, assistant_message) =
             cx.read_global_result(|db: &Db, _window, _cx| {
                 let conn = &mut db.get()?;
@@ -512,8 +512,8 @@ impl ConversationPanelView {
                     NewMessage::new(
                         context.conversation_id,
                         Role::User,
-                        user_content.clone(),
-                        send_content.clone(),
+                        &user_content,
+                        send_content,
                         Status::Normal,
                     ),
                     conn,
@@ -522,8 +522,8 @@ impl ConversationPanelView {
                     NewMessage::new(
                         context.conversation_id,
                         Role::Assistant,
-                        Content::Text(String::new()),
-                        send_content.clone(),
+                        &Content::Text(String::new()),
+                        send_content,
                         Status::Loading,
                     ),
                     conn,
@@ -550,12 +550,20 @@ impl ConversationPanelView {
             let template = ConversationTemplate::find(conversation.template_id, conn)?;
             Ok::<_, AiChatError>((conversation, template))
         })??;
+        let adapter_name = template.adapter.clone();
+        let request_body = build_request_body(
+            &adapter_name,
+            &template.template,
+            template.prompts,
+            template.mode,
+            &conversation.messages,
+            user_message_role,
+            &user_message_content,
+        )?;
         Ok(Runner {
             config,
-            template,
-            history_messages: conversation.messages,
-            user_message_role,
-            user_message_content,
+            adapter_name,
+            request_body,
         })
     }
 
@@ -570,8 +578,8 @@ impl ConversationPanelView {
                 NewMessage::new(
                     conversation_id,
                     Role::User,
-                    Content::Text(request_text.to_string()),
-                    serde_json::json!({}),
+                    &Content::Text(request_text.to_string()),
+                    &serde_json::json!({}),
                     Status::Loading,
                 ),
                 conn,
@@ -902,65 +910,75 @@ impl Render for ConversationPanelView {
 
 struct Runner {
     config: AiChatConfig,
-    template: ConversationTemplate,
-    history_messages: Vec<Message>,
-    user_message_role: Role,
-    user_message_content: String,
+    adapter_name: String,
+    request_body: serde_json::Value,
 }
 
 impl FetchRunner for Runner {
     fn get_adapter(&self) -> &str {
-        &self.template.adapter
-    }
-
-    fn get_template(&self) -> &serde_json::Value {
-        &self.template.template
+        &self.adapter_name
     }
 
     fn get_config(&self) -> &AiChatConfig {
         &self.config
     }
 
-    fn get_history(&self) -> Vec<crate::llm::Message> {
-        use crate::llm::Message as FetchMessage;
-        let mut prompts_messages = self
-            .template
-            .prompts
-            .iter()
-            .map(|prompt| FetchMessage::new(prompt.role, prompt.prompt.clone()))
-            .collect::<Vec<_>>();
-
-        match self.template.mode {
-            Mode::Contextual => {
-                let history_messages = self
-                    .history_messages
-                    .iter()
-                    .filter(|message| message.status == Status::Normal)
-                    .map(|message| {
-                        FetchMessage::new(message.role, message.content.send_content().to_string())
-                    });
-                prompts_messages.extend(history_messages);
-            }
-            Mode::Single => {}
-            Mode::AssistantOnly => {
-                let history_messages = self
-                    .history_messages
-                    .iter()
-                    .filter(|message| message.status == Status::Normal)
-                    .filter(|message| message.role == Role::Assistant)
-                    .map(|message| {
-                        FetchMessage::new(message.role, message.content.send_content().to_string())
-                    });
-                prompts_messages.extend(history_messages);
-            }
-        }
-
-        prompts_messages.push(FetchMessage::new(
-            self.user_message_role,
-            self.user_message_content.clone(),
-        ));
-        prompts_messages
+    fn request_body(&self) -> &serde_json::Value {
+        &self.request_body
     }
+}
+
+fn build_history_messages(
+    prompts: Vec<crate::database::ConversationTemplatePrompt>,
+    mode: Mode,
+    history_messages: &[Message],
+    user_message_role: Role,
+    user_message_content: &str,
+) -> Vec<crate::llm::Message> {
+    use crate::llm::Message as FetchMessage;
+
+    let mut request_messages = prompts
+        .into_iter()
+        .map(|prompt| FetchMessage::new(prompt.role, prompt.prompt))
+        .collect::<Vec<_>>();
+
+    request_messages.extend(
+        history_messages
+            .iter()
+            .filter(|message| message.status == Status::Normal)
+            .filter(|message| match mode {
+                Mode::Contextual => true,
+                Mode::Single => false,
+                Mode::AssistantOnly => message.role == Role::Assistant,
+            })
+            .map(|message| {
+                FetchMessage::new(message.role, message.content.send_content().to_string())
+            }),
+    );
+    request_messages.push(FetchMessage::new(
+        user_message_role,
+        user_message_content.to_string(),
+    ));
+    request_messages
+}
+
+fn build_request_body(
+    adapter_name: &str,
+    template: &serde_json::Value,
+    prompts: Vec<crate::database::ConversationTemplatePrompt>,
+    mode: Mode,
+    history_messages: &[Message],
+    user_message_role: Role,
+    user_message_content: &str,
+) -> AiChatResult<serde_json::Value> {
+    let history = build_history_messages(
+        prompts,
+        mode,
+        history_messages,
+        user_message_role,
+        user_message_content,
+    );
+    adapter_by_name(adapter_name)?.request_body(template, history)
 }
 
 #[cfg(test)]
@@ -1021,43 +1039,39 @@ mod tests {
 
     #[test]
     fn get_history_contextual_includes_all_normal_messages_and_user() {
-        let template = make_template(Mode::Contextual);
-        let history_messages = vec![
-            make_message(
-                1,
-                Role::User,
-                Status::Normal,
-                Content::Text("u1".to_string()),
-            ),
-            make_message(
-                2,
-                Role::Assistant,
-                Status::Normal,
-                Content::Extension {
-                    source: "src".to_string(),
-                    extension_name: "ext".to_string(),
-                    content: "a1".to_string(),
-                },
-            ),
-            make_message(
-                3,
-                Role::User,
-                Status::Error,
-                Content::Text("bad".to_string()),
-            ),
-        ];
-        let runner = Runner {
-            config: AiChatConfig::default(),
-            template,
-            history_messages,
-            user_message_role: Role::User,
-            user_message_content: "latest".to_string(),
-        };
-        let history = runner.get_history();
-        let contents = history
-            .into_iter()
-            .map(|message| (message.role, message.content))
-            .collect::<Vec<_>>();
+        let contents = build_history_messages(
+            make_template(Mode::Contextual).prompts,
+            Mode::Contextual,
+            &[
+                make_message(
+                    1,
+                    Role::User,
+                    Status::Normal,
+                    Content::Text("u1".to_string()),
+                ),
+                make_message(
+                    2,
+                    Role::Assistant,
+                    Status::Normal,
+                    Content::Extension {
+                        source: "src".to_string(),
+                        extension_name: "ext".to_string(),
+                        content: "a1".to_string(),
+                    },
+                ),
+                make_message(
+                    3,
+                    Role::User,
+                    Status::Error,
+                    Content::Text("bad".to_string()),
+                ),
+            ],
+            Role::User,
+            "latest",
+        )
+        .into_iter()
+        .map(|message| (message.role, message.content))
+        .collect::<Vec<_>>();
         assert_eq!(
             contents,
             vec![
@@ -1072,25 +1086,21 @@ mod tests {
 
     #[test]
     fn get_history_single_only_prompts_and_user() {
-        let template = make_template(Mode::Single);
-        let history_messages = vec![make_message(
-            1,
-            Role::Assistant,
-            Status::Normal,
-            Content::Text("a1".to_string()),
-        )];
-        let runner = Runner {
-            config: AiChatConfig::default(),
-            template,
-            history_messages,
-            user_message_role: Role::User,
-            user_message_content: "latest".to_string(),
-        };
-        let history = runner.get_history();
-        let contents = history
-            .into_iter()
-            .map(|message| message.content)
-            .collect::<Vec<_>>();
+        let contents = build_history_messages(
+            make_template(Mode::Single).prompts,
+            Mode::Single,
+            &[make_message(
+                1,
+                Role::Assistant,
+                Status::Normal,
+                Content::Text("a1".to_string()),
+            )],
+            Role::User,
+            "latest",
+        )
+        .into_iter()
+        .map(|message| message.content)
+        .collect::<Vec<_>>();
         assert_eq!(
             contents,
             vec![
@@ -1103,39 +1113,35 @@ mod tests {
 
     #[test]
     fn get_history_assistant_only_filters_roles() {
-        let template = make_template(Mode::AssistantOnly);
-        let history_messages = vec![
-            make_message(
-                1,
-                Role::User,
-                Status::Normal,
-                Content::Text("u1".to_string()),
-            ),
-            make_message(
-                2,
-                Role::Assistant,
-                Status::Normal,
-                Content::Text("a1".to_string()),
-            ),
-            make_message(
-                3,
-                Role::Assistant,
-                Status::Error,
-                Content::Text("bad".to_string()),
-            ),
-        ];
-        let runner = Runner {
-            config: AiChatConfig::default(),
-            template,
-            history_messages,
-            user_message_role: Role::User,
-            user_message_content: "latest".to_string(),
-        };
-        let history = runner.get_history();
-        let contents = history
-            .into_iter()
-            .map(|message| (message.role, message.content))
-            .collect::<Vec<_>>();
+        let contents = build_history_messages(
+            make_template(Mode::AssistantOnly).prompts,
+            Mode::AssistantOnly,
+            &[
+                make_message(
+                    1,
+                    Role::User,
+                    Status::Normal,
+                    Content::Text("u1".to_string()),
+                ),
+                make_message(
+                    2,
+                    Role::Assistant,
+                    Status::Normal,
+                    Content::Text("a1".to_string()),
+                ),
+                make_message(
+                    3,
+                    Role::Assistant,
+                    Status::Error,
+                    Content::Text("bad".to_string()),
+                ),
+            ],
+            Role::User,
+            "latest",
+        )
+        .into_iter()
+        .map(|message| (message.role, message.content))
+        .collect::<Vec<_>>();
         assert_eq!(
             contents,
             vec![

--- a/app/ai-chat/src/views/temporary/detail.rs
+++ b/app/ai-chat/src/views/temporary/detail.rs
@@ -52,7 +52,7 @@ pub struct TemporaryMessage {
     pub id: usize,
     pub role: Role,
     pub content: Content,
-    pub send_content: serde_json::Value,
+    pub send_content: Rc<serde_json::Value>,
     pub status: Status,
     pub error: Option<String>,
     pub created_time: OffsetDateTime,
@@ -218,7 +218,7 @@ impl TemporaryMessage {
         self.updated_time = now;
         self.end_time = now;
     }
-    fn resolve_extension(&mut self, content: Content, send_content: serde_json::Value) {
+    fn resolve_extension(&mut self, content: Content, send_content: Rc<serde_json::Value>) {
         let now = OffsetDateTime::now_utc();
         self.content = content;
         self.send_content = send_content;
@@ -443,7 +443,7 @@ impl TemplateDetailView {
             .map(|message| AddConversationMessage {
                 role: message.role,
                 content: message.content,
-                send_content: message.send_content,
+                send_content: (*message.send_content).clone(),
                 status: message.status,
                 error: message.error,
             })
@@ -459,7 +459,7 @@ impl TemplateDetailView {
         now: OffsetDateTime,
         role: Role,
         content: Content,
-        send_content: serde_json::Value,
+        send_content: Rc<serde_json::Value>,
         status: Status,
         error: Option<String>,
     ) -> &mut TemporaryMessage {
@@ -571,7 +571,7 @@ impl TemplateDetailView {
             else {
                 return (
                     None,
-                    serde_json::Value::Null,
+                    Rc::new(serde_json::Value::Null),
                     Some(AiChatError::StreamError(
                         "temporary assistant message not found".to_string(),
                     )),
@@ -580,7 +580,7 @@ impl TemplateDetailView {
             if message.role != Role::Assistant {
                 return (
                     None,
-                    serde_json::Value::Null,
+                    Rc::new(serde_json::Value::Null),
                     Some(AiChatError::StreamError(
                         "temporary message is not assistant".to_string(),
                     )),
@@ -646,7 +646,7 @@ impl TemplateDetailView {
                 now,
                 Role::User,
                 Content::Text(request_text.clone()),
-                serde_json::json!({}),
+                Rc::new(serde_json::json!({})),
                 Status::Loading,
                 None,
             )
@@ -697,14 +697,14 @@ impl TemplateDetailView {
                 content.send_content().to_string(),
                 cx,
             )?;
-            let send_content = runner.request_body()?;
+            let send_content = runner.request_body.clone();
             let assistant_message_id = state.update_result(cx, |this, _cx| {
                 if let Some(message) = this
                     .messages
                     .iter_mut()
                     .find(|message| message.id == user_message_id)
                 {
-                    message.resolve_extension(content.clone(), send_content.clone());
+                    message.resolve_extension(content, send_content.clone());
                 }
                 this.add_message(
                     now,
@@ -746,7 +746,7 @@ impl TemplateDetailView {
             content.send_content().to_string(),
             cx,
         )?;
-        let send_content = runner.request_body()?;
+        let send_content = runner.request_body.clone();
         let assistant_message_id = state.update_in_result(cx, |this, window, cx| {
             this.input_state.update(cx, |input, cx| {
                 input.set_value("", window, cx);
@@ -755,7 +755,7 @@ impl TemplateDetailView {
                 .add_message(
                     now,
                     Role::User,
-                    content.clone(),
+                    content,
                     send_content.clone(),
                     Status::Normal,
                     None,
@@ -787,15 +787,22 @@ impl TemplateDetailView {
         user_message_content: String,
         cx: &mut AsyncWindowContext,
     ) -> AiChatResult<Runner> {
-        let template = state.read_with_result(cx, |this, _cx| this.template.clone())?;
-        let messages = state.read_with_result(cx, |this, _cx| this.messages.clone())?;
-        Ok(Runner {
-            config,
-            template,
-            messages,
-            user_message_role,
-            user_message_content,
-        })
+        state.read_with_result(cx, |this, _cx| {
+            let adapter_name = this.template.adapter.clone();
+            let request_body = build_request_body(
+                &adapter_name,
+                &this.template.template,
+                &this.template.prompts,
+                &this.messages,
+                user_message_role,
+                &user_message_content,
+            )?;
+            Ok(Runner {
+                config,
+                adapter_name,
+                request_body: Rc::new(request_body),
+            })
+        })?
     }
 
     async fn stream_fetch(
@@ -832,7 +839,7 @@ impl TemplateDetailView {
         state: WeakEntity<Self>,
         config: AiChatConfig,
         adapter_name: String,
-        request_body: serde_json::Value,
+        request_body: Rc<serde_json::Value>,
         assistant_message_id: usize,
         cx: &mut AsyncWindowContext,
     ) -> AiChatResult<()> {
@@ -843,7 +850,7 @@ impl TemplateDetailView {
                 adapter.name().to_string(),
             ))?
             .clone();
-        let stream = adapter.fetch_by_request_body(config, settings, request_body);
+        let stream = adapter.fetch_by_request_body(config, settings, request_body.as_ref());
         pin_mut!(stream);
         while let Some(message) = stream.next().await {
             match message {
@@ -889,49 +896,63 @@ struct PreparedTemporaryFetch {
 
 struct Runner {
     config: AiChatConfig,
-    template: ConversationTemplate,
-    messages: Vec<TemporaryMessage>,
-    user_message_role: Role,
-    user_message_content: String,
+    adapter_name: String,
+    request_body: Rc<serde_json::Value>,
 }
 
 impl FetchRunner for Runner {
     fn get_adapter(&self) -> &str {
-        &self.template.adapter
-    }
-
-    fn get_template(&self) -> &serde_json::Value {
-        &self.template.template
+        &self.adapter_name
     }
 
     fn get_config(&self) -> &crate::config::AiChatConfig {
         &self.config
     }
 
-    fn get_history(&self) -> Vec<crate::llm::Message> {
-        use crate::llm::Message as FetchMessage;
-        let mut prompts = self
-            .template
-            .prompts
-            .iter()
-            .map(|prompt| FetchMessage::new(prompt.role, prompt.prompt.clone()))
-            .collect::<Vec<_>>();
+    fn request_body(&self) -> &serde_json::Value {
+        self.request_body.as_ref()
+    }
+}
 
-        let messages = self
-            .messages
+fn build_history_messages(
+    prompts: &[crate::database::ConversationTemplatePrompt],
+    messages: &[TemporaryMessage],
+    user_message_role: Role,
+    user_message_content: &str,
+) -> Vec<crate::llm::Message> {
+    use crate::llm::Message as FetchMessage;
+
+    let mut request_messages = prompts
+        .iter()
+        .map(|prompt| FetchMessage::new(prompt.role, prompt.prompt.clone()))
+        .collect::<Vec<_>>();
+
+    request_messages.extend(
+        messages
             .iter()
             .filter(|message| message.status == Status::Normal)
             .map(|message| {
                 FetchMessage::new(message.role, message.content.send_content().to_string())
-            });
+            }),
+    );
+    request_messages.push(FetchMessage::new(
+        user_message_role,
+        user_message_content.to_string(),
+    ));
+    request_messages
+}
 
-        prompts.extend(messages);
-        prompts.push(FetchMessage::new(
-            self.user_message_role,
-            self.user_message_content.clone(),
-        ));
-        prompts
-    }
+fn build_request_body(
+    adapter_name: &str,
+    template: &serde_json::Value,
+    prompts: &[crate::database::ConversationTemplatePrompt],
+    messages: &[TemporaryMessage],
+    user_message_role: Role,
+    user_message_content: &str,
+) -> AiChatResult<serde_json::Value> {
+    let history =
+        build_history_messages(prompts, messages, user_message_role, user_message_content);
+    adapter_by_name(adapter_name)?.request_body(template, history)
 }
 
 impl Render for TemplateDetailView {
@@ -1025,32 +1046,10 @@ impl Render for TemplateDetailView {
 
 #[cfg(test)]
 mod tests {
-    use super::{Runner, TemporaryMessage};
-    use crate::{
-        config::AiChatConfig,
-        database::{Content, ConversationTemplate, ConversationTemplatePrompt, Mode, Role, Status},
-        llm::FetchRunner,
-    };
+    use super::{TemporaryMessage, build_history_messages};
+    use crate::database::{Content, ConversationTemplatePrompt, Role, Status};
+    use std::rc::Rc;
     use time::OffsetDateTime;
-
-    fn make_template() -> ConversationTemplate {
-        let now = OffsetDateTime::now_utc();
-        ConversationTemplate {
-            id: 1,
-            name: "temporary".to_string(),
-            icon: "i".to_string(),
-            description: None,
-            mode: Mode::Contextual,
-            adapter: "openai".to_string(),
-            template: serde_json::json!({"model": "gpt-test"}),
-            prompts: vec![ConversationTemplatePrompt {
-                prompt: "system".to_string(),
-                role: Role::Developer,
-            }],
-            created_time: now,
-            updated_time: now,
-        }
-    }
 
     fn make_message(role: Role, status: Status, content: Content) -> TemporaryMessage {
         let now = OffsetDateTime::now_utc();
@@ -1058,7 +1057,7 @@ mod tests {
             id: 1,
             role,
             content,
-            send_content: serde_json::json!({}),
+            send_content: Rc::new(serde_json::json!({})),
             status,
             error: None,
             created_time: now,
@@ -1070,10 +1069,12 @@ mod tests {
 
     #[test]
     fn runner_history_appends_current_user_message() {
-        let runner = Runner {
-            config: AiChatConfig::default(),
-            template: make_template(),
-            messages: vec![
+        let history = build_history_messages(
+            &[ConversationTemplatePrompt {
+                prompt: "system".to_string(),
+                role: Role::Developer,
+            }],
+            &[
                 make_message(
                     Role::Assistant,
                     Status::Normal,
@@ -1081,15 +1082,12 @@ mod tests {
                 ),
                 make_message(Role::User, Status::Error, Content::Text("bad".to_string())),
             ],
-            user_message_role: Role::User,
-            user_message_content: "latest".to_string(),
-        };
-
-        let history = runner
-            .get_history()
-            .into_iter()
-            .map(|message| (message.role, message.content))
-            .collect::<Vec<_>>();
+            Role::User,
+            "latest",
+        )
+        .into_iter()
+        .map(|message| (message.role, message.content))
+        .collect::<Vec<_>>();
 
         assert_eq!(
             history,

--- a/app/feiwen/src/views/fetch.rs
+++ b/app/feiwen/src/views/fetch.rs
@@ -103,7 +103,7 @@ struct Runner<'a> {
     start_page: u32,
     end_page: u32,
     cookie: String,
-    form: Entity<FetchForm>,
+    form: WeakEntity<FetchForm>,
     conn: PooledConnection<ConnectionManager<SqliteConnection>>,
     cx: &'a mut AsyncApp,
 }
@@ -474,7 +474,7 @@ impl FetchView {
         let start_page = form.start_page;
         let end_page = form.end_page;
         let cookie = form.cookie.clone();
-        let form = subscriber.clone();
+        let form = subscriber.downgrade();
         let task = cx.spawn(async move |_, cx| {
             let span = tracing::info_span!("send", url, start_page, end_page, cookie);
             let mut runner = Runner {

--- a/app/novel-download/src/views/worksapce.rs
+++ b/app/novel-download/src/views/worksapce.rs
@@ -96,7 +96,7 @@ impl EventEmitter<WorkspaceEvent> for Workspace {}
 
 struct Runner<'a> {
     novel_id: String,
-    workspace: Entity<Workspace>,
+    workspace: WeakEntity<Workspace>,
     cx: &'a mut AsyncApp,
 }
 
@@ -244,10 +244,11 @@ impl WorkspaceView {
         cx.notify();
     }
     fn fetch(&mut self, subscriber: Entity<Workspace>, cx: &mut Context<Self>, novel_id: String) {
+        let workspace = subscriber.downgrade();
         let task = cx.spawn(async move |_, cx| {
             let mut runner = Runner {
                 novel_id: novel_id.clone(),
-                workspace: subscriber,
+                workspace,
                 cx,
             };
             Compat::new(async move {


### PR DESCRIPTION
## Summary

- reduce redundant payload/message cloning in `ai-chat` request preparation and temporary conversation flows
- stop the `ai-chat` folder action menu from toggling folder expansion
- downgrade long-lived async UI references in `feiwen` and `novel-download` to `WeakEntity`

## Motivation

- `ai-chat` was still cloning large request payloads and temporary message state on hot send/resend paths
- clicking the folder more-actions button in the sidebar also triggered folder expand/collapse
- background runners in `feiwen` and `novel-download` held strong entity references longer than needed

## Changes

- changed `ai-chat` adapter request-body generation to work from borrowed template values and prebuilt request bodies
- made temporary detail payloads share `Rc<serde_json::Value>` instead of cloning full JSON values across user/assistant messages
- changed message insert/update paths to accept borrowed payloads and borrowed `NewMessage` content
- updated prompt form callbacks and background runners to use weak entity handles where appropriate
- added folder menu click propagation stop in the ai-chat sidebar

## Validation

- [ ] `cargo build`
- [ ] `cargo test`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Manual verification completed for the affected app or flow

Validation details:

```text
cargo check -p ai-chat --quiet
pass

cargo test -p ai-chat views::temporary::detail::tests::runner_history_appends_current_user_message -- --exact
pass

cargo test -p ai-chat views::home::tabs::conversation_panel::tests::get_history_contextual_includes_all_normal_messages_and_user -- --exact
pass

Manual verification intent: ai-chat folder menu click no longer toggles folder expansion; temporary/detail and conversation-panel request-building paths preserve history output while reducing deep clones.

Not run: full workspace cargo build/test/clippy.
```

## Risks

- `ai-chat` temporary conversation state now shares request payload ownership with `Rc`, so save/export paths rely on explicit cloning only at persistence boundaries
- full workspace regression coverage is still pending

## Related Issues

- Closes #17
- Related to #17