### PR TITLE
ai-chat: add sidebar conversation and folder editing

### DIFF
--- a/app/ai-chat/locales/en-US/main.ftl
+++ b/app/ai-chat/locales/en-US/main.ftl
@@ -24,10 +24,13 @@ section-information = Information
 alert-error-title = Error
 message-status-paused = Paused
 
-button-add = Add
-button-add-prompt = Add Prompt
-button-cancel = Cancel
+dialog-edit-folder-title = Edit Folder
+dialog-edit-conversation-title = Edit Conversation
+notify-update-folder-failed = Update Folder Failed
+notify-update-conversation-failed = Update Conversation Failed
+
 button-configure = Config
+button-cancel = Cancel
 button-create = Create
 button-delete = Delete
 button-edit = Edit

--- a/app/ai-chat/locales/en-US/main.ftl
+++ b/app/ai-chat/locales/en-US/main.ftl
@@ -24,6 +24,8 @@ section-information = Information
 alert-error-title = Error
 message-status-paused = Paused
 
+button-add = Add
+button-add-prompt = Add Prompt
 dialog-edit-folder-title = Edit Folder
 dialog-edit-conversation-title = Edit Conversation
 notify-update-folder-failed = Update Folder Failed

--- a/app/ai-chat/locales/zh-CN/main.ftl
+++ b/app/ai-chat/locales/zh-CN/main.ftl
@@ -24,6 +24,8 @@ section-information = 信息
 alert-error-title = 错误
 message-status-paused = 已暂停
 
+button-add = 添加
+button-add-prompt = 添加提示词
 dialog-edit-folder-title = 编辑文件夹
 dialog-edit-conversation-title = 编辑会话
 notify-update-folder-failed = 更新文件夹失败

--- a/app/ai-chat/locales/zh-CN/main.ftl
+++ b/app/ai-chat/locales/zh-CN/main.ftl
@@ -24,10 +24,13 @@ section-information = 信息
 alert-error-title = 错误
 message-status-paused = 已暂停
 
-button-add = 添加
-button-add-prompt = 添加提示词
-button-cancel = 取消
+dialog-edit-folder-title = 编辑文件夹
+dialog-edit-conversation-title = 编辑会话
+notify-update-folder-failed = 更新文件夹失败
+notify-update-conversation-failed = 更新会话失败
+
 button-configure = 配置
+button-cancel = 取消
 button-create = 创建
 button-delete = 删除
 button-edit = 编辑

--- a/app/ai-chat/src/components/add_conversation.rs
+++ b/app/ai-chat/src/components/add_conversation.rs
@@ -4,44 +4,88 @@ use crate::{
 };
 use gpui::*;
 use gpui_component::{
-    WindowExt,
     button::{Button, ButtonVariants},
     form::{field, v_form},
     input::{Input, InputState},
+    WindowExt,
 };
 use std::ops::Deref;
-use tracing::{Level, event};
+use tracing::{event, Level};
 
-pub fn add_conversation_dialog(parent_id: Option<i32>, window: &mut Window, cx: &mut App) {
-    add_conversation_dialog_with_messages(parent_id, None, window, cx);
+#[derive(Clone)]
+enum ConversationDialogMode {
+    Add {
+        parent_id: Option<i32>,
+        initial_messages: Option<Vec<AddConversationMessage>>,
+    },
+    Edit {
+        conversation_id: i32,
+    },
 }
 
-pub fn add_conversation_dialog_with_messages(
-    parent_id: Option<i32>,
-    initial_messages: Option<Vec<AddConversationMessage>>,
+fn open_conversation_dialog(
+    mode: ConversationDialogMode,
     window: &mut Window,
     cx: &mut App,
 ) {
-    let span = tracing::info_span!("add_conversation action");
+    let span = tracing::info_span!("conversation_dialog action");
     let _enter = span.enter();
-    event!(Level::INFO, "add_conversation action");
 
+    let is_edit = matches!(mode, ConversationDialogMode::Edit { .. });
     let (dialog_title, name_label, icon_label, info_label, cancel_label, submit_label) = {
         let i18n = cx.global::<I18n>();
-        (
-            i18n.t("dialog-add-conversation-title"),
-            i18n.t("field-name"),
-            i18n.t("field-icon"),
-            i18n.t("field-info"),
-            i18n.t("button-cancel"),
-            i18n.t("button-submit"),
-        )
+        if is_edit {
+            (
+                i18n.t("dialog-edit-conversation-title"),
+                i18n.t("field-name"),
+                i18n.t("field-icon"),
+                i18n.t("field-info"),
+                i18n.t("button-cancel"),
+                i18n.t("button-submit"),
+            )
+        } else {
+            (
+                i18n.t("dialog-add-conversation-title"),
+                i18n.t("field-name"),
+                i18n.t("field-icon"),
+                i18n.t("field-info"),
+                i18n.t("button-cancel"),
+                i18n.t("button-submit"),
+            )
+        }
     };
 
     let name_input = cx.new(|cx| InputState::new(window, cx).placeholder(name_label.clone()));
     let icon_input = cx.new(|cx| InputState::new(window, cx).placeholder(icon_label.clone()));
     let info_input = cx.new(|cx| InputState::new(window, cx).placeholder(info_label.clone()));
-    window.open_dialog(cx, move |dialog, _, _| {
+
+    if let ConversationDialogMode::Edit { conversation_id } = &mode {
+        let chat_data = cx.global::<ChatData>();
+        let Ok(chat_data) = chat_data.read(cx).as_ref() else {
+            event!(Level::ERROR, "Failed to read chat data for conversation edit dialog");
+            return;
+        };
+        let Some(conversation) = chat_data.conversation(*conversation_id) else {
+            event!(Level::ERROR, "Conversation {conversation_id} not found in chat data");
+            return;
+        };
+        let title = conversation.title.clone();
+        let icon = conversation.icon.clone();
+        let info = conversation.info.clone();
+        name_input.update(cx, |input, _cx| {
+            input.set_value(title.clone(), window, _cx);
+        });
+        icon_input.update(cx, |input, _cx| {
+            input.set_value(icon.clone(), window, _cx);
+        });
+        if let Some(info) = info {
+            info_input.update(cx, |input, _cx| {
+                input.set_value(info, window, _cx);
+            });
+        }
+    }
+
+    window.open_dialog(cx, move |dialog, _window, _cx| {
         dialog
             .title(dialog_title.clone())
             .child(
@@ -70,7 +114,7 @@ pub fn add_conversation_dialog_with_messages(
                 let info_input = info_input.clone();
                 let cancel_label = cancel_label.clone();
                 let submit_label = submit_label.clone();
-                let initial_messages = initial_messages.clone();
+                let mode = mode.clone();
                 move |_this, _state, _window, _cx| {
                     vec![
                         Button::new("cancel").label(cancel_label.clone()).on_click(
@@ -85,26 +129,36 @@ pub fn add_conversation_dialog_with_messages(
                                 let name_input = name_input.clone();
                                 let icon_input = icon_input.clone();
                                 let info_input = info_input.clone();
-                                let initial_messages = initial_messages.clone();
+                                let mode = mode.clone();
                                 move |_, window, cx| {
                                     let name = name_input.read(cx).value();
                                     let icon = icon_input.read(cx).value();
                                     let info = info_input.read(cx).value();
                                     if !name.is_empty() {
                                         let chat_data = cx.global::<ChatData>().deref().clone();
-                                        let initial_messages = initial_messages.clone();
+                                        let mode = mode.clone();
                                         chat_data.update(cx, move |_this, cx| {
-                                            cx.emit(ChatDataEvent::AddConversation {
-                                                name,
-                                                icon,
-                                                info: if info.is_empty() {
-                                                    None
-                                                } else {
-                                                    Some(info)
-                                                },
-                                                parent_id,
-                                                initial_messages: initial_messages.clone(),
-                                            });
+                                            let info = if info.is_empty() { None } else { Some(info) };
+                                            match mode {
+                                                ConversationDialogMode::Add {
+                                                    parent_id,
+                                                    initial_messages,
+                                                } => cx.emit(ChatDataEvent::AddConversation {
+                                                    name,
+                                                    icon,
+                                                    info,
+                                                    parent_id,
+                                                    initial_messages,
+                                                }),
+                                                ConversationDialogMode::Edit {
+                                                    conversation_id,
+                                                } => cx.emit(ChatDataEvent::UpdateConversation {
+                                                    id: conversation_id,
+                                                    title: name,
+                                                    icon,
+                                                    info,
+                                                }),
+                                            }
                                         });
                                     }
                                     window.close_dialog(cx);
@@ -114,4 +168,28 @@ pub fn add_conversation_dialog_with_messages(
                 }
             })
     });
+}
+
+pub fn open_add_conversation_dialog(
+    parent_id: Option<i32>,
+    initial_messages: Option<Vec<AddConversationMessage>>,
+    window: &mut Window,
+    cx: &mut App,
+) {
+    open_conversation_dialog(
+        ConversationDialogMode::Add {
+            parent_id,
+            initial_messages,
+        },
+        window,
+        cx,
+    );
+}
+
+pub fn open_edit_conversation_dialog(conversation_id: i32, window: &mut Window, cx: &mut App) {
+    open_conversation_dialog(
+        ConversationDialogMode::Edit { conversation_id },
+        window,
+        cx,
+    );
 }

--- a/app/ai-chat/src/components/add_folder.rs
+++ b/app/ai-chat/src/components/add_folder.rs
@@ -1,32 +1,66 @@
 use gpui::*;
 use gpui_component::{
-    WindowExt,
     button::{Button, ButtonVariants},
     form::{field, v_form},
     input::{Input, InputState},
+    WindowExt,
 };
 use std::ops::Deref;
-use tracing::{Level, event};
+use tracing::{event, Level};
 
 use crate::{
     i18n::I18n,
     state::{ChatData, ChatDataEvent},
 };
 
-pub fn add_folder_dialog(parent_id: Option<i32>, window: &mut Window, cx: &mut App) {
-    let span = tracing::info_span!("add_folder action");
+#[derive(Clone, Copy)]
+enum FolderDialogMode {
+    Add { parent_id: Option<i32> },
+    Edit { folder_id: i32 },
+}
+
+fn open_folder_dialog(mode: FolderDialogMode, window: &mut Window, cx: &mut App) {
+    let span = tracing::info_span!("folder_dialog action");
     let _enter = span.enter();
-    event!(Level::INFO, "add_folder action");
+
+    let is_edit = matches!(mode, FolderDialogMode::Edit { .. });
     let (name_label, dialog_title, cancel_label, submit_label) = {
         let i18n = cx.global::<I18n>();
-        (
-            i18n.t("field-name"),
-            i18n.t("dialog-add-folder-title"),
-            i18n.t("button-cancel"),
-            i18n.t("button-submit"),
-        )
+        if is_edit {
+            (
+                i18n.t("field-name"),
+                i18n.t("dialog-edit-folder-title"),
+                i18n.t("button-cancel"),
+                i18n.t("button-submit"),
+            )
+        } else {
+            (
+                i18n.t("field-name"),
+                i18n.t("dialog-add-folder-title"),
+                i18n.t("button-cancel"),
+                i18n.t("button-submit"),
+            )
+        }
     };
+
     let folder_input = cx.new(|cx| InputState::new(window, cx).placeholder(name_label.clone()));
+
+    if let FolderDialogMode::Edit { folder_id } = &mode {
+        let chat_data = cx.global::<ChatData>();
+        let Ok(chat_data) = chat_data.read(cx).as_ref() else {
+            event!(Level::ERROR, "Failed to read chat data for folder edit dialog");
+            return;
+        };
+        let Some(folder) = chat_data.folder(*folder_id) else {
+            event!(Level::ERROR, "Folder {folder_id} not found in chat data");
+            return;
+        };
+        let name = folder.name.clone();
+        folder_input.update(cx, |input, _cx| {
+            input.set_value(name.clone(), window, _cx);
+        });
+    }
+
     window.open_dialog(cx, move |dialog, _window, _cx| {
         dialog
             .title(dialog_title.clone())
@@ -42,6 +76,7 @@ pub fn add_folder_dialog(parent_id: Option<i32>, window: &mut Window, cx: &mut A
                 let folder_input = folder_input.clone();
                 let cancel_label = cancel_label.clone();
                 let submit_label = submit_label.clone();
+                let mode = mode;
                 move |_this, _state, _window, _cx| {
                     vec![
                         Button::new("cancel").label(cancel_label.clone()).on_click(
@@ -54,12 +89,26 @@ pub fn add_folder_dialog(parent_id: Option<i32>, window: &mut Window, cx: &mut A
                             .label(submit_label.clone())
                             .on_click({
                                 let folder_input = folder_input.clone();
+                                let mode = mode;
                                 move |_, window, cx| {
                                     let name = folder_input.read(cx).value();
                                     if !name.is_empty() {
                                         let chat_data = cx.global::<ChatData>().deref().clone();
-                                        chat_data.update(cx, |_this, cx| {
-                                            cx.emit(ChatDataEvent::AddFolder { name, parent_id });
+                                        chat_data.update(cx, move |_this, cx| {
+                                            match mode {
+                                                FolderDialogMode::Edit { folder_id } => {
+                                                    cx.emit(ChatDataEvent::UpdateFolder {
+                                                        id: folder_id,
+                                                        name,
+                                                    });
+                                                }
+                                                FolderDialogMode::Add { parent_id } => {
+                                                    cx.emit(ChatDataEvent::AddFolder {
+                                                        name,
+                                                        parent_id,
+                                                    });
+                                                }
+                                            }
                                         });
                                     }
                                     window.close_dialog(cx);
@@ -69,4 +118,12 @@ pub fn add_folder_dialog(parent_id: Option<i32>, window: &mut Window, cx: &mut A
                 }
             })
     });
+}
+
+pub fn open_add_folder_dialog(parent_id: Option<i32>, window: &mut Window, cx: &mut App) {
+    open_folder_dialog(FolderDialogMode::Add { parent_id }, window, cx);
+}
+
+pub fn open_edit_folder_dialog(folder_id: i32, window: &mut Window, cx: &mut App) {
+    open_folder_dialog(FolderDialogMode::Edit { folder_id }, window, cx);
 }

--- a/app/ai-chat/src/database/service/conversations.rs
+++ b/app/ai-chat/src/database/service/conversations.rs
@@ -165,8 +165,8 @@ impl Conversation {
             }
 
             let time = OffsetDateTime::now_utc();
+            let path_changed = new_path != conversation.path;
 
-            // Update conversation basic info
             SqlUpdateConversation {
                 id,
                 folder_id: conversation.folder_id,
@@ -178,16 +178,17 @@ impl Conversation {
             }
             .update(conn)?;
 
-            // Update all messages' conversation_path
-            for message in SqlMessage::query_by_conversation_id(id, conn)? {
-                SqlMessage::update_path(
-                    message.id,
-                    message.conversation_path,
-                    &conversation.path,
-                    &new_path,
-                    time,
-                    conn,
-                )?;
+            if path_changed {
+                for message in SqlMessage::query_by_conversation_id(id, conn)? {
+                    SqlMessage::update_path(
+                        message.id,
+                        message.conversation_path,
+                        &conversation.path,
+                        &new_path,
+                        time,
+                        conn,
+                    )?;
+                }
             }
 
             Self::from_sql_conversation(SqlConversation::find(id, conn)?, conn)

--- a/app/ai-chat/src/database/service/conversations.rs
+++ b/app/ai-chat/src/database/service/conversations.rs
@@ -3,10 +3,10 @@ use time::OffsetDateTime;
 
 use crate::{
     database::{
-        Message,
         model::{
             SqlConversation, SqlFolder, SqlMessage, SqlNewConversation, SqlUpdateConversation,
         },
+        Message,
     },
     errors::{AiChatError, AiChatResult},
 };
@@ -51,6 +51,7 @@ impl Conversation {
         let sql_conversation = SqlConversation::find(id, conn)?;
         Self::from_sql_conversation(sql_conversation, conn)
     }
+
     pub fn insert(
         NewConversation {
             title,
@@ -135,6 +136,62 @@ impl Conversation {
             Ok::<(), AiChatError>(())
         })?;
         Ok(())
+    }
+
+    pub fn update(
+        id: i32,
+        title: &str,
+        icon: &str,
+        info: Option<&str>,
+        conn: &mut SqliteConnection,
+    ) -> AiChatResult<Self> {
+        conn.immediate_transaction::<_, AiChatError, _>(|conn| {
+            let conversation = SqlConversation::find(id, conn)?;
+
+            // Calculate new path
+            let new_path = if let Some(folder_id) = conversation.folder_id {
+                let folder = SqlFolder::find(folder_id, conn)?;
+                format!("{}/{}", folder.path, title)
+            } else {
+                format!("/{title}")
+            };
+
+            // Check for path conflicts (only if title changed)
+            if conversation.title != title && SqlConversation::path_exists(&new_path, conn)? {
+                return Err(AiChatError::ConversationPathExists(new_path));
+            }
+            if SqlFolder::path_exists(&new_path, conn)? {
+                return Err(AiChatError::FolderPathExists(new_path));
+            }
+
+            let time = OffsetDateTime::now_utc();
+
+            // Update conversation basic info
+            SqlUpdateConversation {
+                id,
+                folder_id: conversation.folder_id,
+                path: new_path.clone(),
+                title,
+                icon,
+                updated_time: time,
+                info,
+            }
+            .update(conn)?;
+
+            // Update all messages' conversation_path
+            for message in SqlMessage::query_by_conversation_id(id, conn)? {
+                SqlMessage::update_path(
+                    message.id,
+                    message.conversation_path,
+                    &conversation.path,
+                    &new_path,
+                    time,
+                    conn,
+                )?;
+            }
+
+            Self::from_sql_conversation(SqlConversation::find(id, conn)?, conn)
+        })
     }
 
     pub fn move_to_folder(

--- a/app/ai-chat/src/database/service/folders.rs
+++ b/app/ai-chat/src/database/service/folders.rs
@@ -122,6 +122,67 @@ impl Folder {
         Ok(())
     }
 
+    pub fn update_name(
+        id: i32,
+        name: &str,
+        conn: &mut SqliteConnection,
+    ) -> AiChatResult<Self> {
+        conn.immediate_transaction::<_, AiChatError, _>(|conn| {
+            let folder = SqlFolder::find(id, conn)?;
+            if folder.name == name {
+                return Self::from_sql_folder(folder, conn);
+            }
+
+            let new_path = if let Some(parent_id) = folder.parent_id {
+                let parent = SqlFolder::find(parent_id, conn)?;
+                format!("{}/{}", parent.path, name)
+            } else {
+                format!("/{name}")
+            };
+
+            if SqlFolder::path_exists(&new_path, conn)? {
+                return Err(AiChatError::FolderPathExists(new_path));
+            }
+            if SqlConversation::path_exists(&new_path, conn)? {
+                return Err(AiChatError::ConversationPathExists(new_path));
+            }
+
+            let old_path = folder.path.clone();
+            let time = OffsetDateTime::now_utc();
+
+            SqlUpdateFolder {
+                id,
+                name,
+                path: new_path.clone(),
+                parent_id: folder.parent_id,
+                updated_time: time,
+            }
+            .update(conn)?;
+
+            for child in SqlFolder::find_by_path_pre(&old_path, conn)? {
+                SqlUpdateFolder::from_new_path(&child, &old_path, &new_path, time).update(conn)?;
+            }
+
+            for conversation in SqlConversation::find_by_path_pre(&old_path, conn)? {
+                SqlUpdateConversation::from_new_path(&conversation, &old_path, &new_path, time)
+                    .update(conn)?;
+            }
+
+            for message in SqlMessage::find_by_path_pre(&old_path, conn)? {
+                SqlMessage::update_path(
+                    message.id,
+                    message.conversation_path,
+                    &old_path,
+                    &new_path,
+                    time,
+                    conn,
+                )?;
+            }
+
+            Self::from_sql_folder(SqlFolder::find(id, conn)?, conn)
+        })
+    }
+
     pub fn move_to_parent(
         id: i32,
         new_parent_id: Option<i32>,

--- a/app/ai-chat/src/state/store/runtime.rs
+++ b/app/ai-chat/src/state/store/runtime.rs
@@ -8,11 +8,11 @@ use crate::{
 };
 use gpui::*;
 use gpui_component::{
-    WindowExt,
     notification::{Notification, NotificationType},
+    WindowExt,
 };
 use std::ops::Deref;
-use tracing::{Level, event};
+use tracing::{event, Level};
 
 #[derive(Debug)]
 pub enum ChatDataEvent {
@@ -26,6 +26,16 @@ pub enum ChatDataEvent {
     AddFolder {
         name: SharedString,
         parent_id: Option<i32>,
+    },
+    UpdateFolder {
+        id: i32,
+        name: SharedString,
+    },
+    UpdateConversation {
+        id: i32,
+        title: SharedString,
+        icon: SharedString,
+        info: Option<SharedString>,
     },
     MoveConversation {
         conversation_id: i32,
@@ -82,6 +92,8 @@ impl ChatData {
         let (
             add_conversation_failed,
             add_folder_failed,
+            update_folder_failed,
+            update_conversation_failed,
             delete_message_failed,
             delete_conversation_failed,
             delete_folder_failed,
@@ -92,6 +104,8 @@ impl ChatData {
             (
                 i18n.t("notify-add-conversation-failed").into(),
                 i18n.t("notify-add-folder-failed").into(),
+                i18n.t("notify-update-folder-failed").into(),
+                i18n.t("notify-update-conversation-failed").into(),
                 i18n.t("notify-delete-message-failed").into(),
                 i18n.t("notify-delete-conversation-failed").into(),
                 i18n.t("notify-delete-folder-failed").into(),
@@ -128,6 +142,32 @@ impl ChatData {
                 window,
                 add_folder_failed,
                 "add folder",
+                cx,
+            ),
+            ChatDataEvent::UpdateFolder { id, name } => Self::handle_event_result(
+                Self::update_folder(state, *id, name, cx),
+                window,
+                update_folder_failed,
+                "update folder",
+                cx,
+            ),
+            ChatDataEvent::UpdateConversation {
+                id,
+                title,
+                icon,
+                info,
+            } => Self::handle_event_result(
+                Self::update_conversation(
+                    state,
+                    *id,
+                    title,
+                    icon,
+                    info.as_ref().map(|x| x.as_str()),
+                    cx,
+                ),
+                window,
+                update_conversation_failed,
+                "update conversation",
                 cx,
             ),
             ChatDataEvent::MoveConversation {
@@ -354,6 +394,40 @@ impl ChatData {
         state.update(cx, |data, _cx| {
             if let Ok(data) = data {
                 data.clear_conversation_messages(conversation_id);
+            }
+        });
+        Ok(())
+    }
+
+    fn update_folder(
+        state: &Entity<AiChatResult<ChatDataInner>>,
+        id: i32,
+        name: &str,
+        cx: &mut Context<HomeView>,
+    ) -> AiChatResult<()> {
+        let conn = &mut cx.global::<Db>().get()?;
+        let folder = Folder::update_name(id, name, conn)?;
+        state.update(cx, |data, _cx| {
+            if let Ok(data) = data {
+                data.update_folder(id, folder);
+            }
+        });
+        Ok(())
+    }
+
+    fn update_conversation(
+        state: &Entity<AiChatResult<ChatDataInner>>,
+        id: i32,
+        title: &str,
+        icon: &str,
+        info: Option<&str>,
+        cx: &mut Context<HomeView>,
+    ) -> AiChatResult<()> {
+        let conn = &mut cx.global::<Db>().get()?;
+        let conversation = Conversation::update(id, title, icon, info, conn)?;
+        state.update(cx, |data, _cx| {
+            if let Ok(data) = data {
+                data.update_conversation(id, conversation);
             }
         });
         Ok(())

--- a/app/ai-chat/src/state/store/runtime.rs
+++ b/app/ai-chat/src/state/store/runtime.rs
@@ -427,8 +427,11 @@ impl ChatData {
         let conversation = Conversation::update(id, title, icon, info, conn)?;
         state.update(cx, |data, _cx| {
             if let Ok(data) = data {
-                data.update_conversation(id, conversation);
+                data.update_conversation(id, conversation.clone());
             }
+        });
+        cx.global::<WorkspaceStore>().deref().clone().update(cx, |workspace, cx| {
+            workspace.sync_conversation_metadata(&conversation, cx);
         });
         Ok(())
     }

--- a/app/ai-chat/src/state/store/tree.rs
+++ b/app/ai-chat/src/state/store/tree.rs
@@ -146,10 +146,35 @@ impl ChatDataInner {
         }
         self.add_folder(updated);
     }
+
+    pub(crate) fn update_folder(&mut self, id: i32, updated: Folder) {
+        if Self::take_folder(&mut self.folders, id).is_none() {
+            return;
+        }
+        self.add_folder(updated);
+    }
+
+    pub(crate) fn update_conversation(&mut self, id: i32, updated: Conversation) {
+        if Self::take_conversation(&mut self.folders, &mut self.conversations, id).is_none() {
+            return;
+        }
+        self.add_conversation(updated);
+    }
 }
 
 // Resolves conversations and manages tab ordering and activation.
 impl ChatDataInner {
+    fn find_folder(folders: &[Folder], id: i32) -> Option<&Folder> {
+        for folder in folders {
+            if folder.id == id {
+                return Some(folder);
+            }
+            if let Some(folder) = Self::find_folder(&folder.folders, id) {
+                return Some(folder);
+            }
+        }
+        None
+    }
     fn get_conversation<'a>(
         folders: &'a [Folder],
         conversations: &'a [Conversation],
@@ -194,6 +219,10 @@ impl ChatDataInner {
     }
     pub(crate) fn conversation(&self, conversation_id: i32) -> Option<&Conversation> {
         Self::get_conversation(&self.folders, &self.conversations, conversation_id)
+    }
+
+    pub(crate) fn folder(&self, folder_id: i32) -> Option<&Folder> {
+        Self::find_folder(&self.folders, folder_id)
     }
 
     pub(crate) fn folder_ids(&self) -> BTreeSet<i32> {
@@ -648,6 +677,57 @@ mod tests {
         assert_eq!(data.folders.len(), 1);
         let root = ChatDataInner::get_folder(&mut data.folders, 1).unwrap();
         assert_eq!(root.parent_id, None);
+    }
+
+    #[test]
+    fn update_folder_replaces_nested_folder_in_place() {
+        let mut data = empty_chat_data();
+        let mut root = folder(1, None);
+        root.folders.push(folder(2, Some(1)));
+        data.folders.push(root);
+
+        let mut updated = folder(2, Some(1));
+        updated.name = "Renamed Folder".to_string();
+        updated.path = "/folder/1/renamed-folder".to_string();
+
+        data.update_folder(2, updated);
+
+        let folder = ChatDataInner::get_folder(&mut data.folders, 2).unwrap();
+        assert_eq!(folder.name, "Renamed Folder");
+        assert_eq!(folder.path, "/folder/1/renamed-folder");
+    }
+
+    #[test]
+    fn update_conversation_replaces_nested_conversation_in_place() {
+        let mut data = empty_chat_data();
+        let mut root = folder(1, None);
+        root.conversations.push(conversation(2, Some(1)));
+        data.folders.push(root);
+
+        let mut updated = conversation(2, Some(1));
+        updated.title = "Renamed Conversation".to_string();
+        updated.path = "/folder/1/renamed-conversation".to_string();
+        updated.info = Some("updated info".to_string());
+
+        data.update_conversation(2, updated);
+
+        let conversation = ChatDataInner::get_conversation(&data.folders, &data.conversations, 2)
+            .unwrap();
+        assert_eq!(conversation.title, "Renamed Conversation");
+        assert_eq!(conversation.path, "/folder/1/renamed-conversation");
+        assert_eq!(conversation.info.as_deref(), Some("updated info"));
+    }
+
+    #[test]
+    fn folder_lookup_recurses_through_nested_tree() {
+        let mut data = empty_chat_data();
+        let mut root = folder(1, None);
+        let child = folder(2, Some(1));
+        root.folders.push(child);
+        data.folders.push(root);
+
+        let folder = data.folder(2).expect("folder should exist");
+        assert_eq!(folder.id, 2);
     }
 
     #[test]

--- a/app/ai-chat/src/state/workspace.rs
+++ b/app/ai-chat/src/state/workspace.rs
@@ -10,6 +10,7 @@ use self::{
 pub(crate) use self::persistence::ConversationDraft;
 
 use crate::{
+    database::Conversation,
     state::{ChatData, ChatDataInner},
     views::home::{ConversationPanelView, ConversationTabView},
 };
@@ -229,6 +230,28 @@ impl WorkspaceState {
         self.sync_persisted_tabs();
         self.schedule_save(cx);
         cx.notify();
+    }
+
+    pub(crate) fn sync_conversation_metadata(
+        &mut self,
+        conversation: &Conversation,
+        cx: &mut Context<Self>,
+    ) {
+        let mut updated = false;
+        for tab in &mut self.tabs {
+            if tab.kind != tabs::TabKind::Conversation(conversation.id) {
+                continue;
+            }
+            tab.icon = conversation.icon.clone().into();
+            tab.name = conversation.title.clone().into();
+            if let tabs::TabPanel::Conversation(panel) = &tab.panel {
+                panel.update(cx, |panel, cx| panel.sync_metadata(conversation, cx));
+            }
+            updated = true;
+        }
+        if updated {
+            cx.notify();
+        }
     }
 
     pub(crate) fn remove_template_detail_tab(&mut self, template_id: i32, cx: &mut Context<Self>) {

--- a/app/ai-chat/src/views/home/sidebar.rs
+++ b/app/ai-chat/src/views/home/sidebar.rs
@@ -1,5 +1,7 @@
 use crate::{
-    components::{add_conversation::add_conversation_dialog, add_folder::add_folder_dialog},
+    components::{
+        add_conversation::open_add_conversation_dialog, add_folder::open_add_folder_dialog,
+    },
     errors::AiChatResult,
     i18n::I18n,
     state::{ChatData, ChatDataInner, WorkspaceState, WorkspaceStore},
@@ -7,13 +9,12 @@ use crate::{
 };
 use gpui::*;
 use gpui_component::{
-    Collapsible, IconName, Side,
     menu::ContextMenuExt,
     sidebar::{Sidebar, SidebarGroup, SidebarHeader, SidebarMenu, SidebarMenuItem},
-    v_flex,
+    v_flex, Collapsible, IconName, Side,
 };
 use std::ops::Deref;
-use tracing::{Level, event};
+use tracing::{event, Level};
 
 mod conversation_item;
 mod conversation_tree;
@@ -82,10 +83,10 @@ impl SidebarView {
     }
 
     fn add_conversation(&mut self, _: &Add, window: &mut Window, cx: &mut Context<Self>) {
-        add_conversation_dialog(None, window, cx);
+        open_add_conversation_dialog(None, None, window, cx);
     }
     fn add_folder(&mut self, _: &AddShift, window: &mut Window, cx: &mut Context<Self>) {
-        add_folder_dialog(None, window, cx);
+        open_add_folder_dialog(None, window, cx);
     }
 }
 

--- a/app/ai-chat/src/views/home/sidebar/conversation_item.rs
+++ b/app/ai-chat/src/views/home/sidebar/conversation_item.rs
@@ -1,15 +1,18 @@
 use super::conversation_tree::{DragConversationTreeItem, SidebarConversationNode};
 use crate::{
-    components::delete_confirm::open_delete_confirm_dialog,
+    components::{
+        add_conversation::open_edit_conversation_dialog, delete_confirm::open_delete_confirm_dialog,
+    },
+    i18n::I18n,
     state::{ChatData, ChatDataEvent, WorkspaceStore},
 };
 use gpui::{prelude::FluentBuilder as _, *};
 use gpui_component::{
-    ActiveTheme, IconName, Sizable,
     button::{Button, ButtonVariants},
     h_flex,
     label::Label,
     menu::{ContextMenuExt, DropdownMenu, PopupMenu, PopupMenuItem},
+    ActiveTheme, IconName, Sizable,
 };
 use std::ops::Deref;
 
@@ -128,11 +131,17 @@ pub(super) fn conversation_popup_menu(
     menu: PopupMenu,
     conversation: &SidebarConversationNode,
     _window: &mut Window,
-    _cx: &mut Context<PopupMenu>,
+    cx: &mut Context<PopupMenu>,
 ) -> PopupMenu {
     let id = conversation.id;
     let title = conversation.title.clone();
+    let i18n = cx.global::<I18n>();
     menu.item(
+        PopupMenuItem::new(i18n.t("button-edit")).on_click(move |_, window, cx| {
+            open_edit_conversation_dialog(id, window, cx);
+        }),
+    )
+    .item(
         PopupMenuItem::new("Delete")
             .icon(IconName::Delete)
             .on_click(move |_, window, cx| {

--- a/app/ai-chat/src/views/home/sidebar/conversation_tree.rs
+++ b/app/ai-chat/src/views/home/sidebar/conversation_tree.rs
@@ -1,15 +1,17 @@
 use super::{conversation_item::ConversationTreeItem, folder_item::FolderTreeItem};
 use crate::{
-    components::{add_conversation::add_conversation_dialog, add_folder::add_folder_dialog},
+    components::{
+        add_conversation::open_add_conversation_dialog, add_folder::open_add_folder_dialog,
+    },
     database::{Conversation, Folder},
     state::{ChatData, ChatDataEvent, ChatDataInner},
 };
 use gpui::{prelude::FluentBuilder as _, *};
 use gpui_component::{
-    ActiveTheme, Collapsible, Icon, IconName, Side, h_flex,
+    h_flex,
     label::Label,
     menu::{ContextMenuExt, PopupMenu, PopupMenuItem},
-    v_flex,
+    v_flex, ActiveTheme, Collapsible, Icon, IconName, Side,
 };
 use serde::Deserialize;
 use std::{collections::BTreeSet, ops::Deref};
@@ -483,12 +485,12 @@ fn root_context_menu(
         .item(
             PopupMenuItem::new("Add Conversation")
                 .icon(IconName::Plus)
-                .on_click(|_, window, cx| add_conversation_dialog(None, window, cx)),
+                .on_click(|_, window, cx| open_add_conversation_dialog(None, None, window, cx)),
         )
         .item(
             PopupMenuItem::new("Add Folder")
                 .icon(IconName::Plus)
-                .on_click(|_, window, cx| add_folder_dialog(None, window, cx)),
+                .on_click(|_, window, cx| open_add_folder_dialog(None, window, cx)),
         )
 }
 
@@ -507,9 +509,9 @@ pub(super) fn reset_drop_target(window: &mut Window, cx: &mut App) {
 #[cfg(test)]
 mod tests {
     use super::{
-        ActiveDropTarget, DragConversationTreeItem, DragConversationTreeKind, DropState,
         folder_block_drop_target, folder_drop_state, project_conversations, project_folders,
         root_drop_state, target_for_conversation_group, target_for_folder, target_for_root,
+        ActiveDropTarget, DragConversationTreeItem, DragConversationTreeKind, DropState,
     };
     use crate::database::{Content, Conversation, Folder, Message, Role, Status};
     use gpui::SharedString;

--- a/app/ai-chat/src/views/home/sidebar/folder_item.rs
+++ b/app/ai-chat/src/views/home/sidebar/folder_item.rs
@@ -1,23 +1,24 @@
 use super::conversation_item::ConversationTreeItem;
 use super::conversation_tree::{
-    ActiveDropTarget, DragConversationTreeItem, DropState, SidebarFolderNode,
     folder_block_drop_target, folder_drop_state, reset_drop_target, set_drop_target,
-    target_for_conversation_group, target_for_folder,
+    target_for_conversation_group, target_for_folder, ActiveDropTarget, DragConversationTreeItem,
+    DropState, SidebarFolderNode,
 };
 use crate::{
     components::{
-        add_conversation::add_conversation_dialog, add_folder::add_folder_dialog,
+        add_conversation::open_add_conversation_dialog,
+        add_folder::{open_add_folder_dialog, open_edit_folder_dialog},
         delete_confirm::open_delete_confirm_dialog,
     },
+    i18n::I18n,
     state::{ChatData, ChatDataEvent, WorkspaceStore},
 };
 use gpui::{prelude::FluentBuilder as _, *};
 use gpui_component::{
-    ActiveTheme, Icon, IconName, Sizable,
     button::{Button, ButtonVariants},
     h_flex,
     menu::{ContextMenuExt, DropdownMenu, PopupMenu, PopupMenuItem},
-    v_flex,
+    v_flex, ActiveTheme, Icon, IconName, Sizable,
 };
 use std::collections::BTreeSet;
 use std::ops::Deref;
@@ -266,19 +267,29 @@ pub(super) fn folder_popup_menu(
     menu: PopupMenu,
     folder: &SidebarFolderNode,
     _window: &mut Window,
-    _cx: &mut Context<PopupMenu>,
+    cx: &mut Context<PopupMenu>,
 ) -> PopupMenu {
     let id = folder.id;
     let name = folder.name.clone();
+    let i18n = cx.global::<I18n>();
     menu.item(
+        PopupMenuItem::new(i18n.t("button-edit")).on_click(move |_, window, cx| {
+            open_edit_folder_dialog(id, window, cx);
+        }),
+    )
+    .item(
         PopupMenuItem::new("Add Conversation")
             .icon(IconName::Plus)
-            .on_click(move |_, window, cx| add_conversation_dialog(Some(id), window, cx)),
+            .on_click(move |_, window, cx| {
+                open_add_conversation_dialog(Some(id), None, window, cx);
+            }),
     )
     .item(
         PopupMenuItem::new("Add Folder")
             .icon(IconName::Plus)
-            .on_click(move |_, window, cx| add_folder_dialog(Some(id), window, cx)),
+            .on_click(move |_, window, cx| {
+                open_add_folder_dialog(Some(id), window, cx);
+            }),
     )
     .item(PopupMenuItem::separator())
     .item(

--- a/app/ai-chat/src/views/home/tabs/conversation_panel.rs
+++ b/app/ai-chat/src/views/home/tabs/conversation_panel.rs
@@ -85,6 +85,17 @@ impl ConversationPanelView {
             chat_form.restore_draft(draft, window, cx)
         });
     }
+
+    pub(crate) fn sync_metadata(
+        &mut self,
+        conversation: &Conversation,
+        cx: &mut Context<Self>,
+    ) {
+        self.detail.conversation_icon = conversation.icon.clone().into();
+        self.detail.conversation_title = conversation.title.clone().into();
+        self.detail.conversation_info = conversation.info.clone().map(Into::into);
+        cx.notify();
+    }
 }
 
 impl ConversationDetailViewExt for ConversationPanelState {

--- a/app/ai-chat/src/views/temporary/detail.rs
+++ b/app/ai-chat/src/views/temporary/detail.rs
@@ -1,6 +1,6 @@
 use crate::{
     components::{
-        add_conversation::add_conversation_dialog_with_messages, chat_form::ChatFormSnapshot,
+        add_conversation::open_add_conversation_dialog, chat_form::ChatFormSnapshot,
         message::MessageViewExt,
     },
     database::{Content, Mode, Role, Status},
@@ -462,7 +462,7 @@ impl ConversationDetailViewExt for TemporaryDetailState {
                 error: message.error,
             })
             .collect::<Vec<_>>();
-        add_conversation_dialog_with_messages(None, Some(initial_messages), window, cx);
+        open_add_conversation_dialog(None, Some(initial_messages), window, cx);
     }
 }
 


### PR DESCRIPTION
## Summary

- add sidebar edit actions for `ai-chat` conversations and folders
- fix the dialog/add-edit flow so add and edit use explicit entry points instead of ambiguous `Option` parameters
- move edit-dialog prefill to in-memory `ChatData` rather than querying the database directly
- affected app: `ai-chat`

## Motivation

- the prior in-progress implementation for sidebar editing did not compile or pass tests
- popup menu add/edit flows were easy to misuse and already contained a parameter-order regression
- dialog components were coupled directly to database reads for prefill, which was unnecessary because the sidebar tree already held the active data

## Changes

- add `UpdateConversation` / `UpdateFolder` event handling and tree refresh logic in the `ai-chat` store
- implement conversation/folder rename update services, including path propagation and conflict checks
- add explicit add/edit dialog entry points and wire context menus to them
- prefill edit dialogs from `ChatData` instead of DB reads
- add tree tests for update and folder lookup paths
- add missing locale strings for edit dialogs, update failure notifications, and cancel button text

## Validation

- [x] `cargo build`
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
Ran:
- cargo build -p ai-chat
- cargo test -p ai-chat
- cargo clippy -p ai-chat --all-targets --all-features -- -D warnings

Result:
- build passed
- tests passed: 148 passed, 0 failed
- clippy passed with -D warnings

Not run:
- manual verification in the desktop app was not run in this session
```

## Risks

- rename flows still depend on path-based uniqueness semantics in the existing persistence model
- missing-node cases in edit dialogs currently log and abort; a follow-up could surface a user-visible notification instead

## Related Issues

- Closes #43
- Related to #43
