### PR TITLE
fix(ai-chat): follow mouse display for temporary and screenshot windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
- "toml 1.0.7+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "unic-langid",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
 ]
@@ -548,7 +548,7 @@ dependencies = [
  "url",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.11",
+ "wayland-protocols 0.32.12",
  "zbus",
 ]
 
@@ -947,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -957,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -1060,7 +1060,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn 2.0.117",
 ]
@@ -1079,7 +1079,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn 2.0.117",
 ]
@@ -1467,7 +1467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eadd868a2ce9ca38de7eeafdcec9c7065ef89b42b32f0839278d55f35c54d1ff"
 dependencies = [
  "heck 0.4.1",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "proc-macro2",
  "quote",
@@ -1480,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1654,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -2409,9 +2409,9 @@ checksum = "8f215f9b7224f49fb73256115331f677d868b34d18b65dbe4db392e6021eea90"
 
 [[package]]
 name = "deflate64"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
 name = "der"
@@ -2984,9 +2984,9 @@ dependencies = [
 
 [[package]]
 name = "embed-resource"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ec73ddcf6b7f23173d5c3c5a32b5507dc0a734de7730aa14abc5d5e296bb5f"
+checksum = "63a1d0de4f2249aa0ff5884d7080814f446bb241a559af6c170a41e878ed2d45"
 dependencies = [
  "cc",
  "memchr",
@@ -3406,7 +3406,7 @@ dependencies = [
  "fluent-syntax",
  "intl-memoizer",
  "intl_pluralrules",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "self_cell",
  "smallvec",
  "unic-langid",
@@ -3472,9 +3472,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.10.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
+checksum = "2d9237c6d82152100c691fb77ea18037b402bcc7257d2c876a4ffac81bc22a1c"
 dependencies = [
  "bytemuck",
 ]
@@ -4215,8 +4215,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae39dc6d3d201be97e4bc08d96dbef2bc5b5c3d5734e05786e8cc3043342351c"
 dependencies = [
- "indexmap 2.13.0",
- "rustc-hash 2.1.1",
+ "indexmap 2.13.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -4389,7 +4389,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -4408,7 +4408,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -4686,9 +4686,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4700,7 +4700,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -4727,7 +4726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
@@ -4749,7 +4748,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -4759,7 +4758,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.5.3",
+ "windows-registry 0.6.1",
 ]
 
 [[package]]
@@ -4798,12 +4797,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -4811,9 +4811,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -4824,9 +4824,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -4838,15 +4838,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -4858,15 +4858,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -4994,9 +4994,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -5090,9 +5090,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
@@ -5117,9 +5117,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -5214,9 +5214,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -5227,7 +5227,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -5236,9 +5236,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -5252,10 +5274,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -5443,9 +5467,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -5475,9 +5499,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -5541,7 +5565,7 @@ dependencies = [
  "tracing",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.11",
+ "wayland-protocols 0.32.12",
  "wayland-protocols-wlr",
 ]
 
@@ -5565,9 +5589,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -5668,9 +5692,9 @@ dependencies = [
 
 [[package]]
 name = "lyon_tessellation"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a35a7dd71b845ff317ce1834c4185506b79790294bde397df8d5c23031e357"
+checksum = "8e43b7e44161571868f5c931d12583592c223c5583eef86b08aa02b7048a3552"
 dependencies = [
  "float_next_after",
  "lyon_path",
@@ -5899,9 +5923,9 @@ checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -5933,7 +5957,7 @@ dependencies = [
  "half",
  "hashbrown 0.15.5",
  "hexf-parse",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "num-traits",
  "once_cell",
@@ -6140,9 +6164,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -6595,7 +6619,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "hashbrown 0.14.5",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "memchr",
  "ruzstd",
 ]
@@ -7283,7 +7307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "quick-xml 0.38.4",
  "serde",
  "time",
@@ -7366,9 +7390,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -7419,7 +7443,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.5+spec-1.1.0",
+ "toml_edit 0.25.10+spec-1.1.0",
 ]
 
 [[package]]
@@ -7554,7 +7578,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustls 0.23.37",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -7565,9 +7589,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -7575,7 +7599,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
@@ -7845,9 +7869,9 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
+checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
 dependencies = [
  "bytemuck",
  "font-types",
@@ -8008,7 +8032,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
@@ -8272,9 +8296,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -8357,7 +8381,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -8441,7 +8465,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -8477,9 +8501,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -8556,9 +8580,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -8591,7 +8615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "ref-cast",
  "schemars_derive",
  "serde",
@@ -8760,7 +8784,7 @@ dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
  "precomputed-hash",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "servo_arc",
  "smallvec",
 ]
@@ -8773,9 +8797,9 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -8857,7 +8881,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "itoa",
  "memchr",
  "serde",
@@ -8871,7 +8895,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e033097bf0d2b59a62b42c18ebbb797503839b26afdda2c4e1415cb6c813540"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "itoa",
  "memchr",
  "ryu",
@@ -8900,9 +8924,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -8929,7 +8953,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -8956,7 +8980,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "itoa",
  "ryu",
  "serde",
@@ -9073,9 +9097,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simd_helpers"
@@ -9109,9 +9133,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skrifa"
-version = "0.37.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
+checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
 dependencies = [
  "bytemuck",
  "read-fonts",
@@ -9440,15 +9464,15 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sval"
-version = "2.17.0"
+version = "2.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1aaf178a50bbdd86043fce9bf0a5867007d9b382db89d1c96ccae4601ff1ff9"
+checksum = "2eb9318255ebd817902d7e279d8f8e39b35b1b9954decd5eb9ea0e30e5fd2b6a"
 
 [[package]]
 name = "sval_buffer"
-version = "2.17.0"
+version = "2.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89273e48f03807ebf51c4d81c52f28d35ffa18a593edf97e041b52de143df89"
+checksum = "12571299185e653fdb0fbfe36cd7f6529d39d4e747a60b15a3f34574b7b97c61"
 dependencies = [
  "sval",
  "sval_ref",
@@ -9456,18 +9480,18 @@ dependencies = [
 
 [[package]]
 name = "sval_dynamic"
-version = "2.17.0"
+version = "2.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0430f4e18e7eba21a49d10d25a8dec3ce0e044af40b162347e99a8e3c3ced864"
+checksum = "39526f24e997706c0de7f03fb7371f7f5638b66a504ded508e20ad173d0a3677"
 dependencies = [
  "sval",
 ]
 
 [[package]]
 name = "sval_fmt"
-version = "2.17.0"
+version = "2.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835f51b9d7331b9d7fc48fc716c02306fa88c4a076b1573531910c91a525882d"
+checksum = "933dd3bb26965d682280fcc49400ac2a05036f4ee1e6dbd61bf8402d5a5c3a54"
 dependencies = [
  "itoa",
  "ryu",
@@ -9476,9 +9500,9 @@ dependencies = [
 
 [[package]]
 name = "sval_json"
-version = "2.17.0"
+version = "2.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13cbfe3ef406ee2366e7e8ab3678426362085fa9eaedf28cb878a967159dced3"
+checksum = "a0cda08f6d5c9948024a6551077557b1fdcc3880ff2f20ae839667d2ec2d87ed"
 dependencies = [
  "itoa",
  "ryu",
@@ -9487,9 +9511,9 @@ dependencies = [
 
 [[package]]
 name = "sval_nested"
-version = "2.17.0"
+version = "2.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b20358af4af787c34321a86618c3cae12eabdd0e9df22cd9dd2c6834214c518"
+checksum = "88d49d5e6c1f9fd0e53515819b03a97ca4eb1bff5c8ee097c43391c09ecfb19f"
 dependencies = [
  "sval",
  "sval_buffer",
@@ -9498,18 +9522,18 @@ dependencies = [
 
 [[package]]
 name = "sval_ref"
-version = "2.17.0"
+version = "2.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5e500f8eb2efa84f75e7090f7fc43f621b9f8b6cde571c635b3855f97b332a"
+checksum = "14f876c5a78405375b4e19cbb9554407513b59c93dea12dc6a4af4e1d30899ca"
 dependencies = [
  "sval",
 ]
 
 [[package]]
 name = "sval_serde"
-version = "2.17.0"
+version = "2.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2032ae39b11dcc6c18d5fbc50a661ea191cac96484c59ccf49b002261ca2c1"
+checksum = "5f9ccd3b7f7200239a655e517dd3fd48d960b9111ad24bd6a5e055bef17607c7"
 dependencies = [
  "serde_core",
  "sval",
@@ -9534,9 +9558,9 @@ dependencies = [
 
 [[package]]
 name = "swash"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47846491253e976bdd07d0f9cc24b7daf24720d11309302ccbbc6e6b6e53550a"
+checksum = "842f3cd369c2ba38966204f983eaa5e54a8e84a7d7159ed36ade2b6c335aae64"
 dependencies = [
  "skrifa",
  "yazi",
@@ -9694,14 +9718,14 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "7.0.7"
+version = "7.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c8f33736f986f16d69b6cb8b03f55ddcad5c41acc4ccc39dd88e84aa805e7f"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
 dependencies = [
  "cfg-expr",
  "heck 0.5.0",
  "pkg-config",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "version-compare",
 ]
 
@@ -10050,9 +10074,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "serde_core",
@@ -10061,9 +10085,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -10076,9 +10100,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
@@ -10091,9 +10115,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10163,28 +10187,28 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "serde_core",
- "serde_spanned 1.0.4",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.14",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "serde_core",
- "serde_spanned 1.0.4",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -10207,9 +10231,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -10220,33 +10244,33 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.14",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
+version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "indexmap 2.13.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -10257,9 +10281,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -10601,9 +10625,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f715f73a0687261ddb686f0d64a1e5af57bd199c4d12be5fdda6676ce1885bf9"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -10764,7 +10788,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -10781,9 +10805,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "typewit"
-version = "1.14.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c1ae7cc0fdb8b842d65d127cb981574b0d2b249b74d1c7a2986863dc134f71"
+checksum = "bc19094686c694eb41b3b99dcc2f2975d4b078512fa22ae6c63f7ca318bdcff7"
 dependencies = [
  "typewit_proc_macros",
 ]
@@ -10956,9 +10980,9 @@ checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-vo"
@@ -11002,9 +11026,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab5172ab0c2b6d01a9bb4f9332f7c1211193ea002742188040d09ea4eafe867"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "log",
@@ -11020,9 +11044,9 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
  "http 1.4.0",
@@ -11108,9 +11132,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -11261,9 +11285,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -11274,23 +11298,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -11298,9 +11318,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -11311,9 +11331,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -11335,7 +11355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -11374,15 +11394,15 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "semver",
 ]
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa75f400b7f719bcd68b3f47cd939ba654cedeef690f486db71331eec4c6a406"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs 1.2.1",
@@ -11394,9 +11414,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.13"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab51d9f7c071abeee76007e2b742499e535148035bb835f97aaed1338cf516c3"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags 2.11.0",
  "rustix 1.1.4",
@@ -11406,9 +11426,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.13"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b3298683470fbdc6ca40151dfc48c8f2fd4c41a26e13042f801f85002384091"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
 dependencies = [
  "rustix 1.1.4",
  "wayland-client",
@@ -11429,9 +11449,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.11"
+version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23b5df31ceff1328f06ac607591d5ba360cf58f90c8fad4ac8d3a55a3c4aec7"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -11454,22 +11474,22 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78248e4cc0eff8163370ba5c158630dcae1f3497a586b826eca2ef5f348d6235"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.11",
+ "wayland-protocols 0.32.12",
  "wayland-scanner",
 ]
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.9"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
  "quick-xml 0.39.2",
@@ -11478,9 +11498,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-server"
-version = "0.31.12"
+version = "0.31.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63736a4a73e781cf6a736aa32c5d6773c3eb5389197562742a8c611b49b5e359"
+checksum = "cc1846eb04c49182e04f4a099e2a830a2b745610bbc1d61246e206f29c7000a0"
 dependencies = [
  "bitflags 2.11.0",
  "downcast-rs 1.2.1",
@@ -11491,9 +11511,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374f6b70e8e0d6bf9461a32988fd553b59ff630964924dad6e4a4eb6bd538d17"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "libc",
@@ -11505,9 +11525,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -11937,6 +11957,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12307,18 +12338,18 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -12349,7 +12380,7 @@ version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0986a8b1d586b7d3e4fe3d9ea39fb451ae22869dcea4aa109d287a374d866087"
 dependencies = [
- "toml 1.0.7+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "version_check",
 ]
 
@@ -12396,7 +12427,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -12427,7 +12458,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "serde",
  "serde_derive",
@@ -12446,7 +12477,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "semver",
  "serde",
@@ -12464,9 +12495,9 @@ checksum = "beffa227304dbaea3ad6a06ac674f9bc83a3dec3b7f63eeb442de37e7cb6bb01"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -12718,7 +12749,7 @@ dependencies = [
  "tauri-bundler",
  "tauri-utils",
  "thiserror 2.0.18",
- "toml 1.0.7+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "walkdir",
@@ -12771,9 +12802,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -12782,9 +12813,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12821,7 +12852,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 0.7.14",
+ "winnow 0.7.15",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -12849,7 +12880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
- "winnow 0.7.14",
+ "winnow 0.7.15",
  "zvariant",
 ]
 
@@ -12907,7 +12938,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls 0.27.7",
  "hyper-util",
  "ipnet",
@@ -12998,18 +13029,18 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13018,18 +13049,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13059,9 +13090,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -13070,9 +13101,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "serde",
  "yoke",
@@ -13082,9 +13113,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13112,7 +13143,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "memchr",
  "zopfli",
 ]
@@ -13197,9 +13228,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.12"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]
@@ -13214,7 +13245,7 @@ dependencies = [
  "enumflags2",
  "serde",
  "url",
- "winnow 0.7.14",
+ "winnow 0.7.15",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -13242,5 +13273,5 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
- "winnow 0.7.14",
+ "winnow 0.7.15",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11642,6 +11642,7 @@ dependencies = [
  "gpui",
  "objc2 0.6.4",
  "objc2-app-kit",
+ "objc2-foundation",
  "raw-window-handle",
  "thiserror 2.0.18",
  "windows 0.62.2",

--- a/app/ai-chat/Cargo.toml
+++ b/app/ai-chat/Cargo.toml
@@ -69,7 +69,7 @@ tracing-subscriber = { version = "0.3.23", features = ["local-time"] }
 
 # http request
 reqwest = { version = "0.13.2", features = ["json", "stream"] }
-tokio = { version = "1.50.0", features = [
+tokio = { version = "1.51.0", features = [
   "rt",
   "rt-multi-thread",
   "sync",
@@ -86,7 +86,7 @@ smol = "2.0.2"
 get-selected-text = "0.1.6"
 
 # config
-toml = "1.0.7"
+toml = "1.1.2"
 
 # hotkey
 global-hotkey = { version = "0.7.0", features = ["serde", "tracing"] }
@@ -96,7 +96,7 @@ anyhow = "1.0.102"
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
 image = { version = "0.25.10", default-features = false }
-xcap = "0.9.1"
+xcap = "0.9.3"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winresource = "0.1"

--- a/app/ai-chat/src/capture.rs
+++ b/app/ai-chat/src/capture.rs
@@ -1,3 +1,4 @@
+use gpui::{Pixels, Point};
 use platform_ext::ocr::ImageFrame;
 use thiserror::Error;
 
@@ -7,6 +8,7 @@ use xcap::Monitor;
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct CaptureDisplay {
     pub id_hint: u32,
+    pub origin: Point<Pixels>,
     pub width_px: u32,
     pub height_px: u32,
     pub scale_factor: f32,
@@ -238,6 +240,7 @@ mod tests {
     fn display() -> CaptureDisplay {
         CaptureDisplay {
             id_hint: 1,
+            origin: gpui::point(gpui::px(0.0), gpui::px(0.0)),
             width_px: 1920,
             height_px: 1080,
             scale_factor: 1.0,

--- a/app/ai-chat/src/capture.rs
+++ b/app/ai-chat/src/capture.rs
@@ -27,9 +27,9 @@ impl CaptureRect {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Error, PartialEq)]
 pub(crate) enum CaptureError {
+    #[cfg(not(any(target_os = "windows", target_os = "macos")))]
     #[error("capture is unsupported on this platform")]
     UnsupportedPlatform,
     #[error("capture was cancelled")]

--- a/app/ai-chat/src/components/add_conversation.rs
+++ b/app/ai-chat/src/components/add_conversation.rs
@@ -4,13 +4,13 @@ use crate::{
 };
 use gpui::*;
 use gpui_component::{
+    WindowExt,
     button::{Button, ButtonVariants},
     form::{field, v_form},
     input::{Input, InputState},
-    WindowExt,
 };
 use std::ops::Deref;
-use tracing::{event, Level};
+use tracing::{Level, event};
 
 #[derive(Clone)]
 enum ConversationDialogMode {
@@ -23,11 +23,7 @@ enum ConversationDialogMode {
     },
 }
 
-fn open_conversation_dialog(
-    mode: ConversationDialogMode,
-    window: &mut Window,
-    cx: &mut App,
-) {
+fn open_conversation_dialog(mode: ConversationDialogMode, window: &mut Window, cx: &mut App) {
     let span = tracing::info_span!("conversation_dialog action");
     let _enter = span.enter();
 
@@ -62,11 +58,17 @@ fn open_conversation_dialog(
     if let ConversationDialogMode::Edit { conversation_id } = &mode {
         let chat_data = cx.global::<ChatData>();
         let Ok(chat_data) = chat_data.read(cx).as_ref() else {
-            event!(Level::ERROR, "Failed to read chat data for conversation edit dialog");
+            event!(
+                Level::ERROR,
+                "Failed to read chat data for conversation edit dialog"
+            );
             return;
         };
         let Some(conversation) = chat_data.conversation(*conversation_id) else {
-            event!(Level::ERROR, "Conversation {conversation_id} not found in chat data");
+            event!(
+                Level::ERROR,
+                "Conversation {conversation_id} not found in chat data"
+            );
             return;
         };
         let title = conversation.title.clone();
@@ -138,7 +140,8 @@ fn open_conversation_dialog(
                                         let chat_data = cx.global::<ChatData>().deref().clone();
                                         let mode = mode.clone();
                                         chat_data.update(cx, move |_this, cx| {
-                                            let info = if info.is_empty() { None } else { Some(info) };
+                                            let info =
+                                                if info.is_empty() { None } else { Some(info) };
                                             match mode {
                                                 ConversationDialogMode::Add {
                                                     parent_id,
@@ -187,9 +190,5 @@ pub fn open_add_conversation_dialog(
 }
 
 pub fn open_edit_conversation_dialog(conversation_id: i32, window: &mut Window, cx: &mut App) {
-    open_conversation_dialog(
-        ConversationDialogMode::Edit { conversation_id },
-        window,
-        cx,
-    );
+    open_conversation_dialog(ConversationDialogMode::Edit { conversation_id }, window, cx);
 }

--- a/app/ai-chat/src/components/add_folder.rs
+++ b/app/ai-chat/src/components/add_folder.rs
@@ -1,12 +1,12 @@
 use gpui::*;
 use gpui_component::{
+    WindowExt,
     button::{Button, ButtonVariants},
     form::{field, v_form},
     input::{Input, InputState},
-    WindowExt,
 };
 use std::ops::Deref;
-use tracing::{event, Level};
+use tracing::{Level, event};
 
 use crate::{
     i18n::I18n,
@@ -48,7 +48,10 @@ fn open_folder_dialog(mode: FolderDialogMode, window: &mut Window, cx: &mut App)
     if let FolderDialogMode::Edit { folder_id } = &mode {
         let chat_data = cx.global::<ChatData>();
         let Ok(chat_data) = chat_data.read(cx).as_ref() else {
-            event!(Level::ERROR, "Failed to read chat data for folder edit dialog");
+            event!(
+                Level::ERROR,
+                "Failed to read chat data for folder edit dialog"
+            );
             return;
         };
         let Some(folder) = chat_data.folder(*folder_id) else {
@@ -94,20 +97,18 @@ fn open_folder_dialog(mode: FolderDialogMode, window: &mut Window, cx: &mut App)
                                     let name = folder_input.read(cx).value();
                                     if !name.is_empty() {
                                         let chat_data = cx.global::<ChatData>().deref().clone();
-                                        chat_data.update(cx, move |_this, cx| {
-                                            match mode {
-                                                FolderDialogMode::Edit { folder_id } => {
-                                                    cx.emit(ChatDataEvent::UpdateFolder {
-                                                        id: folder_id,
-                                                        name,
-                                                    });
-                                                }
-                                                FolderDialogMode::Add { parent_id } => {
-                                                    cx.emit(ChatDataEvent::AddFolder {
-                                                        name,
-                                                        parent_id,
-                                                    });
-                                                }
+                                        chat_data.update(cx, move |_this, cx| match mode {
+                                            FolderDialogMode::Edit { folder_id } => {
+                                                cx.emit(ChatDataEvent::UpdateFolder {
+                                                    id: folder_id,
+                                                    name,
+                                                });
+                                            }
+                                            FolderDialogMode::Add { parent_id } => {
+                                                cx.emit(ChatDataEvent::AddFolder {
+                                                    name,
+                                                    parent_id,
+                                                });
                                             }
                                         });
                                     }

--- a/app/ai-chat/src/components/hotkey_input.rs
+++ b/app/ai-chat/src/components/hotkey_input.rs
@@ -1,6 +1,6 @@
 use gpui::{prelude::FluentBuilder, *};
 use gpui_component::{
-    ActiveTheme, IconName, Size, Sizable, StyledExt,
+    ActiveTheme, IconName, Sizable, Size, StyledExt,
     button::{Button, ButtonVariants},
     h_flex,
 };

--- a/app/ai-chat/src/database.rs
+++ b/app/ai-chat/src/database.rs
@@ -24,9 +24,7 @@ pub use service::{
     NewConversation, NewConversationTemplate, NewFolder, NewMessage, UrlCitation,
 };
 #[allow(unused_imports)]
-pub use service::{
-    GlobalShortcutBinding, NewGlobalShortcutBinding, UpdateGlobalShortcutBinding,
-};
+pub use service::{GlobalShortcutBinding, NewGlobalShortcutBinding, UpdateGlobalShortcutBinding};
 pub use types::{Mode, Role, ShortcutInputSource, Status};
 
 const DATABASE_FILE_V1: &str = "history.sqlite3";

--- a/app/ai-chat/src/database/service/conversations.rs
+++ b/app/ai-chat/src/database/service/conversations.rs
@@ -3,10 +3,10 @@ use time::OffsetDateTime;
 
 use crate::{
     database::{
+        Message,
         model::{
             SqlConversation, SqlFolder, SqlMessage, SqlNewConversation, SqlUpdateConversation,
         },
-        Message,
     },
     errors::{AiChatError, AiChatResult},
 };

--- a/app/ai-chat/src/database/service/folders.rs
+++ b/app/ai-chat/src/database/service/folders.rs
@@ -122,11 +122,7 @@ impl Folder {
         Ok(())
     }
 
-    pub fn update_name(
-        id: i32,
-        name: &str,
-        conn: &mut SqliteConnection,
-    ) -> AiChatResult<Self> {
+    pub fn update_name(id: i32, name: &str, conn: &mut SqliteConnection) -> AiChatResult<Self> {
         conn.immediate_transaction::<_, AiChatError, _>(|conn| {
             let folder = SqlFolder::find(id, conn)?;
             if folder.name == name {

--- a/app/ai-chat/src/database/service/global_shortcut_bindings.rs
+++ b/app/ai-chat/src/database/service/global_shortcut_bindings.rs
@@ -158,8 +158,7 @@ mod tests {
     use super::{GlobalShortcutBinding, NewGlobalShortcutBinding, UpdateGlobalShortcutBinding};
     use crate::{
         database::{
-            CREATE_TABLE_SQL, Mode, ShortcutInputSource,
-            model::SqlNewConversationTemplate,
+            CREATE_TABLE_SQL, Mode, ShortcutInputSource, model::SqlNewConversationTemplate,
         },
         errors::AiChatError,
     };

--- a/app/ai-chat/src/database/service/global_shortcut_bindings.rs
+++ b/app/ai-chat/src/database/service/global_shortcut_bindings.rs
@@ -12,7 +12,6 @@ use diesel::SqliteConnection;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
-#[allow(dead_code)]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct GlobalShortcutBinding {
     pub id: i32,
@@ -63,7 +62,6 @@ impl TryFrom<SqlGlobalShortcutBinding> for GlobalShortcutBinding {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
 pub struct NewGlobalShortcutBinding {
     pub hotkey: String,
@@ -81,7 +79,6 @@ pub struct NewGlobalShortcutBinding {
     pub input_source: ShortcutInputSource,
 }
 
-#[allow(dead_code)]
 impl GlobalShortcutBinding {
     pub fn find(id: i32, conn: &mut SqliteConnection) -> AiChatResult<Self> {
         SqlGlobalShortcutBinding::find(id, conn)?.try_into()
@@ -139,7 +136,6 @@ impl GlobalShortcutBinding {
     }
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
 pub struct UpdateGlobalShortcutBinding {
     pub hotkey: String,

--- a/app/ai-chat/src/database/types/shortcut_input_source.rs
+++ b/app/ai-chat/src/database/types/shortcut_input_source.rs
@@ -2,7 +2,6 @@ use std::{fmt::Display, str::FromStr};
 
 use crate::errors::AiChatError;
 
-#[allow(dead_code)]
 #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Debug, Clone, Copy)]
 pub enum ShortcutInputSource {
     #[serde(rename = "selection_or_clipboard")]

--- a/app/ai-chat/src/hotkey.rs
+++ b/app/ai-chat/src/hotkey.rs
@@ -3,6 +3,7 @@ use crate::{
     database::{Db, GlobalShortcutBinding, NewGlobalShortcutBinding, UpdateGlobalShortcutBinding},
     errors::AiChatResult,
     i18n::I18n,
+    screen::{TEMPORARY_WINDOW_SIZE, recentered_bounds_for_display, target_display_id},
     state::{AiChatConfig, ConversationDraft, ModelStore},
     views::{screenshot_overlay, temporary::TemporaryView},
 };
@@ -142,11 +143,25 @@ impl GlobalHotkeyState {
         self.front_app = None;
     }
 
-    fn show_temporary_window(&mut self, window: &mut Window) {
+    fn show_temporary_window_on_mouse_display(
+        &mut self,
+        window: &mut Window,
+        cx: &App,
+    ) {
         self.delay_close = None;
         #[cfg(target_os = "macos")]
         if self.front_app.is_none() {
             self.front_app = record_frontmost_app();
+        }
+        let target_display_id = target_display_id(cx);
+        let target_bounds = recentered_bounds_for_display(
+            target_display_id,
+            window.bounds().size,
+            TEMPORARY_WINDOW_SIZE,
+            cx,
+        );
+        if let Err(err) = window.move_and_resize(target_bounds, target_display_id) {
+            event!(Level::ERROR, error = ?err, "Failed to reposition temporary window");
         }
         if let Err(err) = window.show() {
             window.activate_window();
@@ -160,6 +175,7 @@ impl GlobalHotkeyState {
         if self.front_app.is_none() {
             self.front_app = record_frontmost_app();
         }
+        let target_display_id = target_display_id(cx);
         match cx.open_window(
             WindowOptions {
                 kind: WindowKind::Floating,
@@ -168,9 +184,10 @@ impl GlobalHotkeyState {
                     appears_transparent: true,
                     traffic_light_position: Some(point(px(-100.), px(-100.))),
                 }),
+                display_id: target_display_id,
                 window_bounds: Some(WindowBounds::Windowed(Bounds::centered(
-                    cx.primary_display().map(|display| display.id()),
-                    size(px(800.), px(600.)),
+                    target_display_id,
+                    TEMPORARY_WINDOW_SIZE,
                     cx,
                 ))),
                 is_resizable: false,
@@ -196,8 +213,8 @@ impl GlobalHotkeyState {
     fn ensure_temporary_window_visible(&mut self, cx: &mut App) -> Option<WindowHandle<Root>> {
         let window =
             Self::find_temporary_window(cx).or_else(|| self.create_temporary_window(cx))?;
-        let _ = window.update(cx, |_, window, _cx| {
-            self.show_temporary_window(window);
+        let _ = window.update(cx, |_, window, cx| {
+            self.show_temporary_window_on_mouse_display(window, cx);
         });
         Some(window)
     }
@@ -382,7 +399,7 @@ impl GlobalHotkeyState {
                     if window.is_visible().unwrap_or(false) {
                         self.delay_or_hide_temporary_window(window, cx);
                     } else {
-                        self.show_temporary_window(window);
+                        self.show_temporary_window_on_mouse_display(window, cx);
                     }
                 }) {
                     event!(Level::ERROR, "Failed to update temporary window: {:?}", err);

--- a/app/ai-chat/src/hotkey.rs
+++ b/app/ai-chat/src/hotkey.rs
@@ -143,11 +143,7 @@ impl GlobalHotkeyState {
         self.front_app = None;
     }
 
-    fn show_temporary_window_on_mouse_display(
-        &mut self,
-        window: &mut Window,
-        cx: &App,
-    ) {
+    fn show_temporary_window_on_mouse_display(&mut self, window: &mut Window, cx: &App) {
         self.delay_close = None;
         #[cfg(target_os = "macos")]
         if self.front_app.is_none() {

--- a/app/ai-chat/src/llm.rs
+++ b/app/ai-chat/src/llm.rs
@@ -1,8 +1,11 @@
-mod provider;
 mod preset;
+mod provider;
 mod runner;
 mod types;
 
+pub(crate) use preset::{
+    apply_ext_setting, build_request_template, ext_settings as preset_ext_settings,
+};
 #[cfg(test)]
 pub(crate) use provider::ProviderModelCapability;
 #[cfg(test)]
@@ -12,9 +15,6 @@ pub(crate) use provider::{
     OllamaProvider, OllamaSettings, OpenAIProvider, OpenAISettings, Provider, ProviderModel,
     ProviderModelsFailure, available_models, provider_by_name, provider_is_configured,
     provider_names, provider_setting_groups,
-};
-pub(crate) use preset::{
-    apply_ext_setting, build_request_template, ext_settings as preset_ext_settings,
 };
 pub(crate) use runner::FetchRunner;
 pub(crate) use types::Message;

--- a/app/ai-chat/src/llm/preset.rs
+++ b/app/ai-chat/src/llm/preset.rs
@@ -52,10 +52,13 @@ mod tests {
     #[test]
     fn build_request_template_replays_openai_reasoning_settings() -> anyhow::Result<()> {
         let model = ProviderModel::new("OpenAI", "gpt-5.2-pro", ProviderModelCapability::Streaming);
-        let template = build_request_template(&model, Some(&json!({
-            "model": "gpt-5.2-pro",
-            "reasoning": { "effort": "xhigh" }
-        })))?;
+        let template = build_request_template(
+            &model,
+            Some(&json!({
+                "model": "gpt-5.2-pro",
+                "reasoning": { "effort": "xhigh" }
+            })),
+        )?;
 
         assert_eq!(template["reasoning"]["effort"], "xhigh");
         Ok(())
@@ -63,16 +66,19 @@ mod tests {
 
     #[test]
     fn build_request_template_replays_ollama_ext_settings() -> anyhow::Result<()> {
-        let model =
-            ProviderModel::new("Ollama", "gpt-oss", ProviderModelCapability::Streaming).with_metadata(json!({
+        let model = ProviderModel::new("Ollama", "gpt-oss", ProviderModelCapability::Streaming)
+            .with_metadata(json!({
                 "capabilities": ["completion", "thinking", "tools"],
                 "family": "gptoss",
                 "families": ["gptoss"]
             }));
-        let template = build_request_template(&model, Some(&json!({
-            "think": "high",
-            "web_search": true
-        })))?;
+        let template = build_request_template(
+            &model,
+            Some(&json!({
+                "think": "high",
+                "web_search": true
+            })),
+        )?;
 
         assert_eq!(template["think"], "high");
         assert_eq!(template["web_search"], true);
@@ -82,10 +88,13 @@ mod tests {
     #[test]
     fn build_request_template_skips_invalid_saved_ext_settings() -> anyhow::Result<()> {
         let model = ProviderModel::new("OpenAI", "gpt-5.2-pro", ProviderModelCapability::Streaming);
-        let template = build_request_template(&model, Some(&json!({
-            "model": "gpt-5.2-pro",
-            "reasoning": { "effort": "invalid" }
-        })))?;
+        let template = build_request_template(
+            &model,
+            Some(&json!({
+                "model": "gpt-5.2-pro",
+                "reasoning": { "effort": "invalid" }
+            })),
+        )?;
 
         assert_eq!(template["model"], "gpt-5.2-pro");
         assert_ne!(template["reasoning"]["effort"], "invalid");

--- a/app/ai-chat/src/main.rs
+++ b/app/ai-chat/src/main.rs
@@ -16,8 +16,8 @@ use tracing::{Level, event, level_filters::LevelFilter};
 use tracing_subscriber::{Layer, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 mod assets;
-mod components;
 mod capture;
+mod components;
 mod database;
 mod errors;
 mod gpui_ext;

--- a/app/ai-chat/src/main.rs
+++ b/app/ai-chat/src/main.rs
@@ -24,6 +24,7 @@ mod gpui_ext;
 mod hotkey;
 mod i18n;
 mod llm;
+mod screen;
 mod state;
 mod views;
 

--- a/app/ai-chat/src/screen.rs
+++ b/app/ai-chat/src/screen.rs
@@ -1,0 +1,183 @@
+use gpui::{App, Bounds, DisplayId, Pixels, PlatformDisplay, Point, Size, point, px, size};
+use std::rc::Rc;
+
+pub(crate) const TEMPORARY_WINDOW_SIZE: Size<Pixels> = size(px(800.), px(600.));
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct DisplaySnapshot {
+    pub id: u32,
+    pub bounds: Bounds<Pixels>,
+    pub is_primary: bool,
+}
+
+pub(crate) fn target_display(cx: &App) -> Option<Rc<dyn PlatformDisplay>> {
+    let displays = cx.displays();
+    if displays.is_empty() {
+        return None;
+    }
+
+    if let Some(display_id) = platform_ext::app::current_mouse_display_id()
+        && let Some(display) = displays
+            .iter()
+            .find(|display| u32::from(display.id()) == display_id)
+    {
+        return Some(display.clone());
+    }
+
+    let snapshots = display_snapshots(cx);
+    if let Some((x, y)) = platform_ext::app::current_mouse_location()
+        && let Some(display_id) = display_id_for_mouse_location(&snapshots, point(px(x), px(y)))
+        && let Some(display) = displays
+            .iter()
+            .find(|display| u32::from(display.id()) == display_id)
+    {
+        return Some(display.clone());
+    }
+
+    cx.primary_display().or_else(|| displays.into_iter().next())
+}
+
+pub(crate) fn target_display_id(cx: &App) -> Option<DisplayId> {
+    target_display(cx).map(|display| display.id())
+}
+
+pub(crate) fn centered_bounds_for_display(
+    display_id: Option<DisplayId>,
+    size: Size<Pixels>,
+    cx: &App,
+) -> Bounds<Pixels> {
+    Bounds::centered(display_id, size, cx)
+}
+
+pub(crate) fn recentered_bounds_for_display(
+    display_id: Option<DisplayId>,
+    current_size: Size<Pixels>,
+    fallback_size: Size<Pixels>,
+    cx: &App,
+) -> Bounds<Pixels> {
+    let size = display_id
+        .and_then(|display_id| cx.find_display(display_id))
+        .map(|display| preserve_or_fallback_size(current_size, display.bounds().size, fallback_size))
+        .unwrap_or(fallback_size);
+
+    centered_bounds_for_display(display_id, size, cx)
+}
+
+fn preserve_or_fallback_size(
+    current_size: Size<Pixels>,
+    display_size: Size<Pixels>,
+    fallback_size: Size<Pixels>,
+) -> Size<Pixels> {
+    if current_size.width <= px(0.)
+        || current_size.height <= px(0.)
+        || current_size.width > display_size.width
+        || current_size.height > display_size.height
+    {
+        fallback_size
+    } else {
+        current_size
+    }
+}
+
+fn display_snapshots(cx: &App) -> Vec<DisplaySnapshot> {
+    let primary_id = cx.primary_display().map(|display| u32::from(display.id()));
+    cx.displays()
+        .into_iter()
+        .map(|display| DisplaySnapshot {
+            id: u32::from(display.id()),
+            bounds: display.bounds(),
+            is_primary: primary_id == Some(u32::from(display.id())),
+        })
+        .collect()
+}
+
+fn display_id_for_mouse_location(
+    displays: &[DisplaySnapshot],
+    mouse_location: Point<Pixels>,
+) -> Option<u32> {
+    displays
+        .iter()
+        .find(|display| display.bounds.contains(&mouse_location))
+        .map(|display| display.id)
+        .or_else(|| {
+            displays
+                .iter()
+                .find(|display| display.is_primary)
+                .map(|display| display.id)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DisplaySnapshot, TEMPORARY_WINDOW_SIZE, display_id_for_mouse_location,
+        preserve_or_fallback_size,
+    };
+    use gpui::{Bounds, point, px, size};
+
+    fn snapshot(
+        id: u32,
+        origin_x: f32,
+        origin_y: f32,
+        width: f32,
+        height: f32,
+        is_primary: bool,
+    ) -> DisplaySnapshot {
+        DisplaySnapshot {
+            id,
+            bounds: Bounds::new(
+                point(px(origin_x), px(origin_y)),
+                size(px(width), px(height)),
+            ),
+            is_primary,
+        }
+    }
+
+    #[test]
+    fn mouse_location_selects_matching_display() {
+        let displays = vec![
+            snapshot(1, 0.0, 0.0, 1440.0, 900.0, true),
+            snapshot(2, 1440.0, 0.0, 1920.0, 1080.0, false),
+        ];
+
+        assert_eq!(
+            display_id_for_mouse_location(&displays, point(px(1800.0), px(300.0))),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn mouse_location_falls_back_to_primary_display() {
+        let displays = vec![
+            snapshot(1, 0.0, 0.0, 1440.0, 900.0, true),
+            snapshot(2, 1440.0, 0.0, 1920.0, 1080.0, false),
+        ];
+
+        assert_eq!(
+            display_id_for_mouse_location(&displays, point(px(-100.0), px(-100.0))),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn preserve_existing_size_when_it_fits_target_display() {
+        let current = size(px(960.0), px(720.0));
+        let display = size(px(1920.0), px(1080.0));
+
+        assert_eq!(
+            preserve_or_fallback_size(current, display, TEMPORARY_WINDOW_SIZE),
+            current
+        );
+    }
+
+    #[test]
+    fn fallback_size_is_used_when_existing_window_is_too_large() {
+        let current = size(px(2400.0), px(1400.0));
+        let display = size(px(1920.0), px(1080.0));
+
+        assert_eq!(
+            preserve_or_fallback_size(current, display, TEMPORARY_WINDOW_SIZE),
+            TEMPORARY_WINDOW_SIZE
+        );
+    }
+}

--- a/app/ai-chat/src/screen.rs
+++ b/app/ai-chat/src/screen.rs
@@ -57,7 +57,9 @@ pub(crate) fn recentered_bounds_for_display(
 ) -> Bounds<Pixels> {
     let size = display_id
         .and_then(|display_id| cx.find_display(display_id))
-        .map(|display| preserve_or_fallback_size(current_size, display.bounds().size, fallback_size))
+        .map(|display| {
+            preserve_or_fallback_size(current_size, display.bounds().size, fallback_size)
+        })
         .unwrap_or(fallback_size);
 
     centered_bounds_for_display(display_id, size, cx)

--- a/app/ai-chat/src/state.rs
+++ b/app/ai-chat/src/state.rs
@@ -4,7 +4,7 @@ pub(crate) mod workspace;
 
 pub(crate) use config::{AiChatConfig, ThemeMode};
 pub(crate) use store::{
-    AddConversationMessage, ChatData, ChatDataEvent, ChatDataInner, ModelStore,
-    ModelStoreSnapshot, ModelStoreStatus,
+    AddConversationMessage, ChatData, ChatDataEvent, ChatDataInner, ModelStore, ModelStoreSnapshot,
+    ModelStoreStatus,
 };
 pub(crate) use workspace::{ConversationDraft, WorkspaceState, WorkspaceStore};

--- a/app/ai-chat/src/state/config.rs
+++ b/app/ai-chat/src/state/config.rs
@@ -252,13 +252,11 @@ impl AiChatConfig {
         }
     }
     pub(crate) fn set_temporary_hotkey(&mut self, hotkey: Option<String>, cx: &mut App) {
-        if let Err(err) =
-            GlobalHotkeyState::update_temporary_hotkey(
-                self.temporary_hotkey.as_deref(),
-                hotkey.as_deref(),
-                cx,
-            )
-        {
+        if let Err(err) = GlobalHotkeyState::update_temporary_hotkey(
+            self.temporary_hotkey.as_deref(),
+            hotkey.as_deref(),
+            cx,
+        ) {
             event!(Level::ERROR, "Failed to update temporary hotkey: {}", err);
             return;
         }

--- a/app/ai-chat/src/state/store/runtime.rs
+++ b/app/ai-chat/src/state/store/runtime.rs
@@ -8,11 +8,11 @@ use crate::{
 };
 use gpui::*;
 use gpui_component::{
-    notification::{Notification, NotificationType},
     WindowExt,
+    notification::{Notification, NotificationType},
 };
 use std::ops::Deref;
-use tracing::{event, Level};
+use tracing::{Level, event};
 
 #[derive(Debug)]
 pub enum ChatDataEvent {
@@ -430,9 +430,12 @@ impl ChatData {
                 data.update_conversation(id, conversation.clone());
             }
         });
-        cx.global::<WorkspaceStore>().deref().clone().update(cx, |workspace, cx| {
-            workspace.sync_conversation_metadata(&conversation, cx);
-        });
+        cx.global::<WorkspaceStore>()
+            .deref()
+            .clone()
+            .update(cx, |workspace, cx| {
+                workspace.sync_conversation_metadata(&conversation, cx);
+            });
         Ok(())
     }
 }

--- a/app/ai-chat/src/state/store/tree.rs
+++ b/app/ai-chat/src/state/store/tree.rs
@@ -711,8 +711,8 @@ mod tests {
 
         data.update_conversation(2, updated);
 
-        let conversation = ChatDataInner::get_conversation(&data.folders, &data.conversations, 2)
-            .unwrap();
+        let conversation =
+            ChatDataInner::get_conversation(&data.folders, &data.conversations, 2).unwrap();
         assert_eq!(conversation.title, "Renamed Conversation");
         assert_eq!(conversation.path, "/folder/1/renamed-conversation");
         assert_eq!(conversation.info.as_deref(), Some("updated info"));

--- a/app/ai-chat/src/state/workspace.rs
+++ b/app/ai-chat/src/state/workspace.rs
@@ -3,11 +3,11 @@ mod tabs;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use self::persistence::ConversationDraft;
 use self::{
     persistence::PersistedWorkspaceState,
     tabs::{AppTab, TabKind, TabPanel},
 };
-pub(crate) use self::persistence::ConversationDraft;
 
 use crate::{
     database::Conversation,

--- a/app/ai-chat/src/state/workspace/tabs.rs
+++ b/app/ai-chat/src/state/workspace/tabs.rs
@@ -180,7 +180,11 @@ impl WorkspaceState {
         }
     }
 
-    pub(super) fn template_detail_tab(template_id: i32, window: &mut Window, cx: &mut App) -> AppTab {
+    pub(super) fn template_detail_tab(
+        template_id: i32,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> AppTab {
         let (icon, name) = cx
             .global::<Db>()
             .get()

--- a/app/ai-chat/src/views/conversation_detail.rs
+++ b/app/ai-chat/src/views/conversation_detail.rs
@@ -222,8 +222,9 @@ impl<T: ConversationDetailViewExt> ConversationDetailView<T> {
         window: &mut Window,
         cx: &mut Context<ConversationDetailView<T>>,
     ) {
-        self.chat_form
-            .update(cx, |chat_form, cx| chat_form.restore_draft(draft, window, cx));
+        self.chat_form.update(cx, |chat_form, cx| {
+            chat_form.restore_draft(draft, window, cx)
+        });
     }
 
     pub(crate) fn send_chat_form(

--- a/app/ai-chat/src/views/home/sidebar.rs
+++ b/app/ai-chat/src/views/home/sidebar.rs
@@ -9,12 +9,13 @@ use crate::{
 };
 use gpui::*;
 use gpui_component::{
+    Collapsible, IconName, Side,
     menu::ContextMenuExt,
     sidebar::{Sidebar, SidebarGroup, SidebarHeader, SidebarMenu, SidebarMenuItem},
-    v_flex, Collapsible, IconName, Side,
+    v_flex,
 };
 use std::ops::Deref;
-use tracing::{event, Level};
+use tracing::{Level, event};
 
 mod conversation_item;
 mod conversation_tree;

--- a/app/ai-chat/src/views/home/sidebar/conversation_item.rs
+++ b/app/ai-chat/src/views/home/sidebar/conversation_item.rs
@@ -8,11 +8,11 @@ use crate::{
 };
 use gpui::{prelude::FluentBuilder as _, *};
 use gpui_component::{
+    ActiveTheme, IconName, Sizable,
     button::{Button, ButtonVariants},
     h_flex,
     label::Label,
     menu::{ContextMenuExt, DropdownMenu, PopupMenu, PopupMenuItem},
-    ActiveTheme, IconName, Sizable,
 };
 use std::ops::Deref;
 

--- a/app/ai-chat/src/views/home/sidebar/conversation_tree.rs
+++ b/app/ai-chat/src/views/home/sidebar/conversation_tree.rs
@@ -8,10 +8,10 @@ use crate::{
 };
 use gpui::{prelude::FluentBuilder as _, *};
 use gpui_component::{
-    h_flex,
+    ActiveTheme, Collapsible, Icon, IconName, Side, h_flex,
     label::Label,
     menu::{ContextMenuExt, PopupMenu, PopupMenuItem},
-    v_flex, ActiveTheme, Collapsible, Icon, IconName, Side,
+    v_flex,
 };
 use serde::Deserialize;
 use std::{collections::BTreeSet, ops::Deref};
@@ -509,9 +509,9 @@ pub(super) fn reset_drop_target(window: &mut Window, cx: &mut App) {
 #[cfg(test)]
 mod tests {
     use super::{
+        ActiveDropTarget, DragConversationTreeItem, DragConversationTreeKind, DropState,
         folder_block_drop_target, folder_drop_state, project_conversations, project_folders,
         root_drop_state, target_for_conversation_group, target_for_folder, target_for_root,
-        ActiveDropTarget, DragConversationTreeItem, DragConversationTreeKind, DropState,
     };
     use crate::database::{Content, Conversation, Folder, Message, Role, Status};
     use gpui::SharedString;

--- a/app/ai-chat/src/views/home/sidebar/folder_item.rs
+++ b/app/ai-chat/src/views/home/sidebar/folder_item.rs
@@ -1,8 +1,8 @@
 use super::conversation_item::ConversationTreeItem;
 use super::conversation_tree::{
+    ActiveDropTarget, DragConversationTreeItem, DropState, SidebarFolderNode,
     folder_block_drop_target, folder_drop_state, reset_drop_target, set_drop_target,
-    target_for_conversation_group, target_for_folder, ActiveDropTarget, DragConversationTreeItem,
-    DropState, SidebarFolderNode,
+    target_for_conversation_group, target_for_folder,
 };
 use crate::{
     components::{
@@ -15,10 +15,11 @@ use crate::{
 };
 use gpui::{prelude::FluentBuilder as _, *};
 use gpui_component::{
+    ActiveTheme, Icon, IconName, Sizable,
     button::{Button, ButtonVariants},
     h_flex,
     menu::{ContextMenuExt, DropdownMenu, PopupMenu, PopupMenuItem},
-    v_flex, ActiveTheme, Icon, IconName, Sizable,
+    v_flex,
 };
 use std::collections::BTreeSet;
 use std::ops::Deref;

--- a/app/ai-chat/src/views/home/tabs.rs
+++ b/app/ai-chat/src/views/home/tabs.rs
@@ -36,6 +36,7 @@ impl Render for TabsView {
         let workspace = self.workspace.upgrade().map(|x| x.read(cx));
         v_flex()
             .flex_1()
+            .w_full()
             .overflow_hidden()
             .map(|this| match workspace {
                 Some(workspace) => this
@@ -89,7 +90,9 @@ impl Render for TabsView {
                                     }),
                             ),
                     )
-                    .when_some(workspace.panel(), |this, panel| this.child(panel)),
+                    .when_some(workspace.panel(), |this, panel| {
+                        this.child(div().flex_1().w_full().overflow_hidden().child(panel))
+                    }),
                 None => this,
             })
     }

--- a/app/ai-chat/src/views/home/tabs/conversation_panel.rs
+++ b/app/ai-chat/src/views/home/tabs/conversation_panel.rs
@@ -4,7 +4,9 @@ use crate::{
     errors::{AiChatError, AiChatResult},
     gpui_ext::{AsyncWindowContextResultExt, EntityResultExt, WeakEntityResultExt},
     llm::{FetchRunner, FetchUpdate, provider_by_name},
-    state::{AiChatConfig, ChatData, ChatDataEvent, ChatDataInner, ConversationDraft, WorkspaceStore},
+    state::{
+        AiChatConfig, ChatData, ChatDataEvent, ChatDataInner, ConversationDraft, WorkspaceStore,
+    },
     views::conversation_detail::{ConversationDetailView, ConversationDetailViewExt},
 };
 use async_compat::CompatExt;
@@ -86,11 +88,7 @@ impl ConversationPanelView {
         });
     }
 
-    pub(crate) fn sync_metadata(
-        &mut self,
-        conversation: &Conversation,
-        cx: &mut Context<Self>,
-    ) {
+    pub(crate) fn sync_metadata(&mut self, conversation: &Conversation, cx: &mut Context<Self>) {
         self.detail.conversation_icon = conversation.icon.clone().into();
         self.detail.conversation_title = conversation.title.clone().into();
         self.detail.conversation_info = conversation.info.clone().map(Into::into);

--- a/app/ai-chat/src/views/screenshot_overlay.rs
+++ b/app/ai-chat/src/views/screenshot_overlay.rs
@@ -167,20 +167,10 @@ pub(crate) struct ScreenshotOverlayView {
 
 fn offset_capture_rect(
     rect: CaptureRect,
-    window_origin: Point<Pixels>,
-    scale_factor: f32,
+    _window_origin: Point<Pixels>,
+    _scale_factor: f32,
     display: &CaptureDisplay,
 ) -> Option<CaptureRect> {
-    let origin_x = logical_to_capture_coord(f32::from(window_origin.x), scale_factor);
-    let origin_y = logical_to_capture_coord(f32::from(window_origin.y), scale_factor);
-    let x_px = rect.x_px.checked_add(origin_x)?;
-    let y_px = rect.y_px.checked_add(origin_y)?;
-    let rect = CaptureRect {
-        x_px,
-        y_px,
-        width_px: rect.width_px,
-        height_px: rect.height_px,
-    };
     (rect.x_px + rect.width_px <= display.width_px && rect.y_px + rect.height_px <= display.height_px)
         .then_some(rect)
 }
@@ -488,7 +478,10 @@ fn selection_bounds(
 
 #[cfg(test)]
 mod tests {
-    use super::{DRAG_THRESHOLD, drag_distance, selection_bounds, selection_rect, selection_rect_in_overlay_coords};
+    use super::{
+        DRAG_THRESHOLD, drag_distance, logical_to_capture_coord, selection_bounds, selection_rect,
+        selection_rect_in_overlay_coords,
+    };
     use crate::capture::{CaptureDisplay, CaptureRect};
     use gpui::{point, px};
 
@@ -533,10 +526,10 @@ mod tests {
         assert_eq!(
             rect,
             CaptureRect {
-                x_px: 20,
-                y_px: 52,
-                width_px: 180,
-                height_px: 120,
+                x_px: logical_to_capture_coord(20.0, 2.0),
+                y_px: logical_to_capture_coord(40.0, 2.0),
+                width_px: logical_to_capture_coord(180.0, 2.0),
+                height_px: logical_to_capture_coord(120.0, 2.0),
             }
         );
     }

--- a/app/ai-chat/src/views/screenshot_overlay.rs
+++ b/app/ai-chat/src/views/screenshot_overlay.rs
@@ -48,6 +48,7 @@ pub(crate) fn open(binding: GlobalShortcutBinding, cx: &mut App) -> Result<(), C
     let display_id = display.id();
     let display_info = CaptureDisplay {
         id_hint: u32::from(display_id),
+        origin: display.bounds().origin,
         width_px: 0,
         height_px: 0,
         scale_factor: 0.0,
@@ -167,11 +168,29 @@ pub(crate) struct ScreenshotOverlayView {
 
 fn offset_capture_rect(
     rect: CaptureRect,
-    _window_origin: Point<Pixels>,
-    _scale_factor: f32,
+    window_origin: Point<Pixels>,
+    scale_factor: f32,
     display: &CaptureDisplay,
 ) -> Option<CaptureRect> {
-    (rect.x_px + rect.width_px <= display.width_px && rect.y_px + rect.height_px <= display.height_px)
+    let offset_x = logical_to_capture_delta(
+        f32::from(window_origin.x) - f32::from(display.origin.x),
+        scale_factor,
+    );
+    let offset_y = logical_to_capture_delta(
+        f32::from(window_origin.y) - f32::from(display.origin.y),
+        scale_factor,
+    );
+    let x_px = rect.x_px.checked_add_signed(offset_x)?;
+    let y_px = rect.y_px.checked_add_signed(offset_y)?;
+    let rect = CaptureRect {
+        x_px,
+        y_px,
+        width_px: rect.width_px,
+        height_px: rect.height_px,
+    };
+
+    (rect.x_px + rect.width_px <= display.width_px
+        && rect.y_px + rect.height_px <= display.height_px)
         .then_some(rect)
 }
 
@@ -418,11 +437,22 @@ fn logical_to_capture_coord(logical: f32, scale_factor: f32) -> u32 {
     return (logical * scale_factor).round() as u32;
 }
 
+fn logical_to_capture_delta(logical: f32, scale_factor: f32) -> i32 {
+    #[cfg(target_os = "macos")]
+    let _ = scale_factor;
+    #[cfg(target_os = "macos")]
+    return logical.round() as i32;
+
+    #[cfg(not(target_os = "macos"))]
+    return (logical * scale_factor).round() as i32;
+}
+
 fn resolved_display(window: &Window, display: &CaptureDisplay) -> CaptureDisplay {
     let size = window.bounds().size;
     let scale_factor = window.scale_factor();
     CaptureDisplay {
         id_hint: display.id_hint,
+        origin: display.origin,
         width_px: logical_to_capture_coord(f32::from(size.width), scale_factor),
         height_px: logical_to_capture_coord(f32::from(size.height), scale_factor),
         scale_factor,
@@ -479,15 +509,16 @@ fn selection_bounds(
 #[cfg(test)]
 mod tests {
     use super::{
-        DRAG_THRESHOLD, drag_distance, logical_to_capture_coord, selection_bounds, selection_rect,
-        selection_rect_in_overlay_coords,
+        DRAG_THRESHOLD, drag_distance, logical_to_capture_coord, logical_to_capture_delta,
+        selection_bounds, selection_rect, selection_rect_in_overlay_coords,
     };
     use crate::capture::{CaptureDisplay, CaptureRect};
     use gpui::{point, px};
 
-    fn display(height_px: u32) -> CaptureDisplay {
+    fn display(origin_x: f32, origin_y: f32, height_px: u32) -> CaptureDisplay {
         CaptureDisplay {
             id_hint: 1,
+            origin: point(px(origin_x), px(origin_y)),
             width_px: 1920,
             height_px,
             scale_factor: 1.0,
@@ -502,7 +533,7 @@ mod tests {
             Some(point(px(20.0), px(40.0))),
             1.0,
             point(px(0.0), px(0.0)),
-            &display(1080),
+            &display(0.0, 0.0, 1080),
         )
         .expect("drag selection should produce a rect");
 
@@ -513,13 +544,13 @@ mod tests {
     }
 
     #[test]
-    fn selection_rect_offsets_by_window_origin() {
+    fn selection_rect_offsets_by_window_origin_relative_to_display_origin() {
         let rect = selection_rect(
             Some(point(px(20.0), px(40.0))),
             Some(point(px(200.0), px(160.0))),
             2.0,
-            point(px(0.0), px(12.0)),
-            &display(1080),
+            point(px(1440.0), px(12.0)),
+            &display(1440.0, 0.0, 1080),
         )
         .expect("drag selection should produce a rect");
 
@@ -527,7 +558,8 @@ mod tests {
             rect,
             CaptureRect {
                 x_px: logical_to_capture_coord(20.0, 2.0),
-                y_px: logical_to_capture_coord(40.0, 2.0),
+                y_px: logical_to_capture_coord(40.0, 2.0)
+                    + logical_to_capture_delta(12.0, 2.0) as u32,
                 width_px: logical_to_capture_coord(180.0, 2.0),
                 height_px: logical_to_capture_coord(120.0, 2.0),
             }

--- a/app/ai-chat/src/views/screenshot_overlay.rs
+++ b/app/ai-chat/src/views/screenshot_overlay.rs
@@ -2,9 +2,9 @@ use crate::{
     capture::{CaptureDisplay, CaptureError, CaptureRect, capture_region},
     database::GlobalShortcutBinding,
     hotkey::GlobalHotkeyState,
+    screen::target_display,
 };
 use gpui::*;
-
 use std::cmp::{max, min};
 use std::time::Duration;
 use tracing::{Level, event};
@@ -33,85 +33,86 @@ pub(crate) fn open(binding: GlobalShortcutBinding, cx: &mut App) -> Result<(), C
 
     let primary_id = cx.primary_display().map(|display| u32::from(display.id()));
     let mut handles = Vec::new();
+    let Some(display) = target_display(cx) else {
+        return Err(CaptureError::BackendUnavailable(
+            "no displays are available",
+        ));
+    };
     event!(
         Level::INFO,
         binding_id = binding.id,
         displays = cx.displays().len(),
         "Opening screenshot overlay session"
     );
-    for display in cx.displays() {
-        let bounds = Bounds::new(point(px(0.), px(0.)), display.bounds().size);
-        let display_id = display.id();
-        let display_info = CaptureDisplay {
-            id_hint: u32::from(display_id),
-            width_px: 0,
-            height_px: 0,
-            scale_factor: 0.0,
-            is_primary: primary_id == Some(u32::from(display_id)),
-        };
-        event!(
-            Level::INFO,
-            display_id = display_info.id_hint,
-            is_primary = display_info.is_primary,
-            width = f32::from(bounds.size.width),
-            height = f32::from(bounds.size.height),
-            "Creating screenshot overlay window"
-        );
+    let bounds = Bounds::new(point(px(0.), px(0.)), display.bounds().size);
+    let display_id = display.id();
+    let display_info = CaptureDisplay {
+        id_hint: u32::from(display_id),
+        width_px: 0,
+        height_px: 0,
+        scale_factor: 0.0,
+        is_primary: primary_id == Some(u32::from(display_id)),
+    };
+    event!(
+        Level::INFO,
+        display_id = display_info.id_hint,
+        is_primary = display_info.is_primary,
+        width = f32::from(bounds.size.width),
+        height = f32::from(bounds.size.height),
+        "Creating screenshot overlay window"
+    );
 
-        let handle = cx.open_window(
-            WindowOptions {
-                display_id: Some(display_id),
-                window_bounds: Some(WindowBounds::Windowed(bounds)),
-                kind: WindowKind::Floating,
-                titlebar: Some(TitlebarOptions {
-                    title: None,
-                    appears_transparent: true,
-                    traffic_light_position: Some(point(px(-100.), px(-100.))),
-                }),
-                window_background: WindowBackgroundAppearance::Transparent,
-                focus: true,
-                show: true,
-                is_movable: false,
-                is_resizable: false,
-                window_min_size: None,
-                window_decorations: None,
-                ..Default::default()
-            },
-            move |window, cx| {
-                if let Err(err) = window.set_floating() {
-                    event!(
-                        Level::ERROR,
-                        display_id = display_info.id_hint,
-                        error = ?err,
-                        "Failed to set screenshot overlay window floating"
-                    );
-                }
-                window.activate_window();
-                let display_id = display_info.id_hint;
+    let handle = cx.open_window(
+        WindowOptions {
+            display_id: Some(display_id),
+            window_bounds: Some(WindowBounds::Windowed(bounds)),
+            kind: WindowKind::Floating,
+            titlebar: Some(TitlebarOptions {
+                title: None,
+                appears_transparent: true,
+                traffic_light_position: Some(point(px(-100.), px(-100.))),
+            }),
+            window_background: WindowBackgroundAppearance::Transparent,
+            focus: true,
+            show: true,
+            is_movable: false,
+            is_resizable: false,
+            window_min_size: None,
+            window_decorations: None,
+            ..Default::default()
+        },
+        move |window, cx| {
+            if let Err(err) = window.set_floating() {
                 event!(
-                    Level::INFO,
-                    display_id,
-                    scale_factor = window.scale_factor(),
-                    "Screenshot overlay window opened"
+                    Level::ERROR,
+                    display_id = display_info.id_hint,
+                    error = ?err,
+                    "Failed to set screenshot overlay window floating"
                 );
-                cx.new(|cx| ScreenshotOverlayView::new(display_info.clone(), window, cx))
-            },
-        );
-
-        match handle {
-            Ok(handle) => handles.push(handle),
-            Err(err) => {
-                // Roll back any overlay windows already opened on previous displays so
-                // they don't get stranded on screen with no session to clean them up.
-                for h in handles {
-                    let _ = h.update(cx, |_, window, _cx| window.remove_window());
-                }
-                #[cfg(target_os = "macos")]
-                cx.update_global::<GlobalHotkeyState, _>(|state, _cx| {
-                    state.clear_front_app_for_screenshot();
-                });
-                return Err(CaptureError::SystemFailure(err.to_string()));
             }
+            window.activate_window();
+            let display_id = display_info.id_hint;
+            event!(
+                Level::INFO,
+                display_id,
+                scale_factor = window.scale_factor(),
+                "Screenshot overlay window opened"
+            );
+            cx.new(|cx| ScreenshotOverlayView::new(display_info.clone(), window, cx))
+        },
+    );
+
+    match handle {
+        Ok(handle) => handles.push(handle),
+        Err(err) => {
+            for h in handles {
+                let _ = h.update(cx, |_, window, _cx| window.remove_window());
+            }
+            #[cfg(target_os = "macos")]
+            cx.update_global::<GlobalHotkeyState, _>(|state, _cx| {
+                state.clear_front_app_for_screenshot();
+            });
+            return Err(CaptureError::SystemFailure(err.to_string()));
         }
     }
 
@@ -162,6 +163,26 @@ pub(crate) struct ScreenshotOverlayView {
     drag_current: Option<Point<Pixels>>,
     selection_started: bool,
     focus_handle: FocusHandle,
+}
+
+fn offset_capture_rect(
+    rect: CaptureRect,
+    window_origin: Point<Pixels>,
+    scale_factor: f32,
+    display: &CaptureDisplay,
+) -> Option<CaptureRect> {
+    let origin_x = logical_to_capture_coord(f32::from(window_origin.x), scale_factor);
+    let origin_y = logical_to_capture_coord(f32::from(window_origin.y), scale_factor);
+    let x_px = rect.x_px.checked_add(origin_x)?;
+    let y_px = rect.y_px.checked_add(origin_y)?;
+    let rect = CaptureRect {
+        x_px,
+        y_px,
+        width_px: rect.width_px,
+        height_px: rect.height_px,
+    };
+    (rect.x_px + rect.width_px <= display.width_px && rect.y_px + rect.height_px <= display.height_px)
+        .then_some(rect)
 }
 
 impl ScreenshotOverlayView {
@@ -255,8 +276,13 @@ impl ScreenshotOverlayView {
             cancel_overlay(window, cx);
             return;
         }
-        let Some(rect) = selection_rect(self.drag_origin, self.drag_current, window.scale_factor())
-        else {
+        let Some(rect) = selection_rect(
+            self.drag_origin,
+            self.drag_current,
+            window.scale_factor(),
+            window.bounds().origin,
+            &self.display,
+        ) else {
             event!(
                 Level::INFO,
                 display_id = self.display.id_hint,
@@ -414,7 +440,7 @@ fn resolved_display(window: &Window, display: &CaptureDisplay) -> CaptureDisplay
     }
 }
 
-fn selection_rect(
+fn selection_rect_in_overlay_coords(
     origin: Option<Point<Pixels>>,
     current: Option<Point<Pixels>>,
     scale_factor: f32,
@@ -434,6 +460,17 @@ fn selection_rect(
     })
 }
 
+fn selection_rect(
+    origin: Option<Point<Pixels>>,
+    current: Option<Point<Pixels>>,
+    scale_factor: f32,
+    window_origin: Point<Pixels>,
+    display: &CaptureDisplay,
+) -> Option<CaptureRect> {
+    let rect = selection_rect_in_overlay_coords(origin, current, scale_factor)?;
+    offset_capture_rect(rect, window_origin, scale_factor, display)
+}
+
 fn selection_bounds(
     origin: Option<Point<Pixels>>,
     current: Option<Point<Pixels>>,
@@ -451,8 +488,19 @@ fn selection_bounds(
 
 #[cfg(test)]
 mod tests {
-    use super::{DRAG_THRESHOLD, drag_distance, selection_bounds, selection_rect};
+    use super::{DRAG_THRESHOLD, drag_distance, selection_bounds, selection_rect, selection_rect_in_overlay_coords};
+    use crate::capture::{CaptureDisplay, CaptureRect};
     use gpui::{point, px};
+
+    fn display(height_px: u32) -> CaptureDisplay {
+        CaptureDisplay {
+            id_hint: 1,
+            width_px: 1920,
+            height_px,
+            scale_factor: 1.0,
+            is_primary: true,
+        }
+    }
 
     #[test]
     fn selection_rect_normalizes_drag_direction() {
@@ -460,14 +508,37 @@ mod tests {
             Some(point(px(200.0), px(160.0))),
             Some(point(px(20.0), px(40.0))),
             1.0,
+            point(px(0.0), px(0.0)),
+            &display(1080),
         )
         .expect("drag selection should produce a rect");
 
-        // scale_factor = 1.0 on non-macOS (physical == logical), macOS ignores it
         assert_eq!(rect.x_px, 20);
         assert_eq!(rect.y_px, 40);
         assert_eq!(rect.width_px, 180);
         assert_eq!(rect.height_px, 120);
+    }
+
+    #[test]
+    fn selection_rect_offsets_by_window_origin() {
+        let rect = selection_rect(
+            Some(point(px(20.0), px(40.0))),
+            Some(point(px(200.0), px(160.0))),
+            2.0,
+            point(px(0.0), px(12.0)),
+            &display(1080),
+        )
+        .expect("drag selection should produce a rect");
+
+        assert_eq!(
+            rect,
+            CaptureRect {
+                x_px: 20,
+                y_px: 52,
+                width_px: 180,
+                height_px: 120,
+            }
+        );
     }
 
     #[test]
@@ -479,5 +550,25 @@ mod tests {
     fn drag_distance_stays_below_threshold_for_clicks() {
         let distance = drag_distance(point(px(10.0), px(10.0)), point(px(11.0), px(11.0)));
         assert!(distance < DRAG_THRESHOLD);
+    }
+
+    #[test]
+    fn selection_rect_overlay_coords_keep_top_left_origin() {
+        let rect = selection_rect_in_overlay_coords(
+            Some(point(px(200.0), px(160.0))),
+            Some(point(px(20.0), px(40.0))),
+            1.0,
+        )
+        .expect("overlay rect should exist");
+
+        assert_eq!(
+            rect,
+            CaptureRect {
+                x_px: 20,
+                y_px: 40,
+                width_px: 180,
+                height_px: 120,
+            }
+        );
     }
 }

--- a/app/ai-chat/src/views/settings.rs
+++ b/app/ai-chat/src/views/settings.rs
@@ -23,8 +23,6 @@ actions!([OpenSetting]);
 enum SettingsOpenTarget {
     General,
     Provider,
-    #[allow(dead_code)]
-    Shortcuts,
 }
 
 pub fn init(cx: &mut App) {
@@ -192,12 +190,6 @@ impl Render for SettingsView {
                 (
                     "my-settings-provider",
                     vec![provider_page, general_page, shortcuts_page],
-                )
-            }
-            SettingsOpenTarget::Shortcuts => {
-                (
-                    "my-settings-shortcuts",
-                    vec![shortcuts_page, general_page, provider_page],
                 )
             }
         };

--- a/app/ai-chat/src/views/settings.rs
+++ b/app/ai-chat/src/views/settings.rs
@@ -117,12 +117,12 @@ impl Render for SettingsView {
             SettingPage::new(page_provider),
             |page: SettingPage, group| page.group(group),
         );
-        let shortcuts_page = SettingPage::new(page_shortcuts).group(
-            SettingGroup::new().item(SettingItem::render({
+        let shortcuts_page = SettingPage::new(page_shortcuts).group(SettingGroup::new().item(
+            SettingItem::render({
                 let page = self.shortcut_settings.clone();
                 move |_options, _window, _cx| page.clone()
-            })),
-        );
+            }),
+        ));
         let general_page = SettingPage::new(page_general).group(
             SettingGroup::new()
                 .title(group_basic_options)
@@ -180,18 +180,14 @@ impl Render for SettingsView {
                 )),
         );
         let (settings_id, pages) = match self.open_target {
-            SettingsOpenTarget::General => {
-                (
-                    "my-settings-general",
-                    vec![general_page, provider_page, shortcuts_page],
-                )
-            }
-            SettingsOpenTarget::Provider => {
-                (
-                    "my-settings-provider",
-                    vec![provider_page, general_page, shortcuts_page],
-                )
-            }
+            SettingsOpenTarget::General => (
+                "my-settings-general",
+                vec![general_page, provider_page, shortcuts_page],
+            ),
+            SettingsOpenTarget::Provider => (
+                "my-settings-provider",
+                vec![provider_page, general_page, shortcuts_page],
+            ),
         };
         v_flex()
             .id("settings")

--- a/app/ai-chat/src/views/settings/shortcut_settings.rs
+++ b/app/ai-chat/src/views/settings/shortcut_settings.rs
@@ -10,8 +10,8 @@ use crate::{
     hotkey::GlobalHotkeyState,
     i18n::I18n,
     llm::{
-        ExtSettingControl, ExtSettingItem, ProviderModel, apply_ext_setting, build_request_template,
-        preset_ext_settings,
+        ExtSettingControl, ExtSettingItem, ProviderModel, apply_ext_setting,
+        build_request_template, preset_ext_settings,
     },
     state::ModelStore,
 };
@@ -175,9 +175,7 @@ impl InputSourceChoice {
     fn new(value: ShortcutInputSource, cx: &App) -> Self {
         let label = {
             let key = match value {
-                ShortcutInputSource::SelectionOrClipboard => {
-                    "send-content-selection-or-clipboard"
-                }
+                ShortcutInputSource::SelectionOrClipboard => "send-content-selection-or-clipboard",
                 ShortcutInputSource::Screenshot => "send-content-screenshot",
             };
             cx.global::<I18n>().t(key).into()
@@ -386,12 +384,16 @@ impl ShortcutSettingsPage {
     pub(crate) fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let page = cx.entity().downgrade();
         let table = cx.new(|cx| {
-            TableState::new(ShortcutBindingsTableDelegate::new(page.clone(), cx), window, cx)
-                .row_selectable(false)
-                .col_selectable(false)
-                .sortable(false)
-                .col_movable(false)
-                .col_resizable(true)
+            TableState::new(
+                ShortcutBindingsTableDelegate::new(page.clone(), cx),
+                window,
+                cx,
+            )
+            .row_selectable(false)
+            .col_selectable(false)
+            .sortable(false)
+            .col_movable(false)
+            .col_resizable(true)
         });
 
         let model_store = cx.global::<ModelStore>().deref().clone();
@@ -505,12 +507,19 @@ impl ShortcutSettingsPage {
             });
 
         let hotkey = binding.as_ref().map(|binding| binding.hotkey.clone());
-        let enabled = binding.as_ref().map(|binding| binding.enabled).unwrap_or(true);
+        let enabled = binding
+            .as_ref()
+            .map(|binding| binding.enabled)
+            .unwrap_or(true);
         let template_id = binding.as_ref().and_then(|binding| binding.template_id);
         let provider_name = binding
             .as_ref()
             .map(|binding| binding.provider_name.clone())
-            .or_else(|| self.available_models(cx).first().map(|model| model.provider_name.clone()))
+            .or_else(|| {
+                self.available_models(cx)
+                    .first()
+                    .map(|model| model.provider_name.clone())
+            })
             .unwrap_or_default();
         let mode = binding
             .as_ref()
@@ -523,7 +532,11 @@ impl ShortcutSettingsPage {
         let model_id = binding
             .as_ref()
             .map(|binding| binding.model_id.clone())
-            .or_else(|| self.available_models(cx).first().map(|model| model.id.clone()))
+            .or_else(|| {
+                self.available_models(cx)
+                    .first()
+                    .map(|model| model.id.clone())
+            })
             .unwrap_or_default();
 
         let template_select = cx.new(|cx| {
@@ -537,11 +550,8 @@ impl ShortcutSettingsPage {
         });
 
         let available_models = self.available_models(cx);
-        let model_choices = Self::model_choices_from(
-            &available_models,
-            Some((&provider_name, &model_id)),
-            cx,
-        );
+        let model_choices =
+            Self::model_choices_from(&available_models, Some((&provider_name, &model_id)), cx);
         let model_selected = self.model_selected_index(
             &model_choices,
             &ModelChoice::key(&provider_name, &model_id),
@@ -721,9 +731,9 @@ impl ShortcutSettingsPage {
         };
         let row = &mut self.rows[index];
         if let Some((provider_name, model_id)) = Self::split_model_choice_key(&model_value)
-            && let Some(model) = available_models.iter().find(|model| {
-                model.provider_name == provider_name && model.id == model_id
-            })
+            && let Some(model) = available_models
+                .iter()
+                .find(|model| model.provider_name == provider_name && model.id == model_id)
         {
             row.provider_name = model.provider_name.clone();
         }
@@ -823,11 +833,12 @@ impl ShortcutSettingsPage {
         };
 
         row.model_resolved = true;
-        row.request_template = build_request_template(&model, saved_template).unwrap_or_else(|_| {
-            saved_template
-                .cloned()
-                .unwrap_or_else(|| serde_json::json!({}))
-        });
+        row.request_template =
+            build_request_template(&model, saved_template).unwrap_or_else(|_| {
+                saved_template
+                    .cloned()
+                    .unwrap_or_else(|| serde_json::json!({}))
+            });
         Self::refresh_row_ext_settings(row, &model, window, cx);
     }
 
@@ -894,8 +905,10 @@ impl ShortcutSettingsPage {
                             });
                         },
                     ));
-                    row.ext_settings
-                        .push(RowExtSettingState::Select { item: setting, state });
+                    row.ext_settings.push(RowExtSettingState::Select {
+                        item: setting,
+                        state,
+                    });
                 }
                 ExtSettingControl::Boolean(_) => {
                     row.ext_settings
@@ -1099,9 +1112,13 @@ impl ShortcutSettingsPage {
                             .text_color(cx.theme().muted_foreground),
                     )
                     .child(
-                        Checkbox::new((ElementId::from(("shortcut-ext-setting", row.key)), item.key))
-                            .checked(value)
-                            .on_click(cx.listener(move |this, checked, window, cx| {
+                        Checkbox::new((
+                            ElementId::from(("shortcut-ext-setting", row.key)),
+                            item.key,
+                        ))
+                        .checked(value)
+                        .on_click(cx.listener(
+                            move |this, checked, window, cx| {
                                 this.handle_boolean_ext_setting(
                                     row_key,
                                     setting_key,
@@ -1109,7 +1126,8 @@ impl ShortcutSettingsPage {
                                     window,
                                     cx,
                                 );
-                            })),
+                            },
+                        )),
                     )
                     .into_any_element()
             }
@@ -1236,7 +1254,8 @@ impl ShortcutSettingsPage {
                         .on_click({
                             let row_key = row.key;
                             cx.listener(move |this, checked, _window, cx| {
-                                let Some(row) = this.rows.iter_mut().find(|row| row.key == row_key) else {
+                                let Some(row) = this.rows.iter_mut().find(|row| row.key == row_key)
+                                else {
                                     return;
                                 };
                                 row.enabled = *checked;
@@ -1256,10 +1275,11 @@ impl ShortcutSettingsPage {
                         Button::new(("shortcut-save", row.key))
                             .small()
                             .primary()
-                            .label(
-                                cx.global::<I18n>()
-                                    .t(if is_new { "button-create" } else { "button-save" }),
-                            )
+                            .label(cx.global::<I18n>().t(if is_new {
+                                "button-create"
+                            } else {
+                                "button-save"
+                            }))
                             .on_click(cx.listener(move |this, _, window, cx| {
                                 this.save_row(row_key, window, cx);
                             })),
@@ -1268,10 +1288,11 @@ impl ShortcutSettingsPage {
                         Button::new(("shortcut-reset", row.key))
                             .small()
                             .danger()
-                            .label(
-                                cx.global::<I18n>()
-                                    .t(if is_new { "button-cancel" } else { "button-reset" }),
-                            )
+                            .label(cx.global::<I18n>().t(if is_new {
+                                "button-cancel"
+                            } else {
+                                "button-reset"
+                            }))
                             .on_click(cx.listener(move |this, _, window, cx| {
                                 this.reset_row(row_key, window, cx);
                             })),
@@ -1301,13 +1322,18 @@ impl ShortcutSettingsPage {
             .ok_or_else(|| SharedString::from("missing row"))?;
 
         if row.invalid_hotkey.is_some() {
-            return Err(cx.global::<I18n>().t("notify-invalid-shortcut-hotkey").into());
+            return Err(cx
+                .global::<I18n>()
+                .t("notify-invalid-shortcut-hotkey")
+                .into());
         }
         let hotkey = row
             .hotkey
             .clone()
             .filter(|hotkey| !hotkey.trim().is_empty())
-            .ok_or_else(|| SharedString::from(cx.global::<I18n>().t("notify-invalid-shortcut-hotkey")))?;
+            .ok_or_else(|| {
+                SharedString::from(cx.global::<I18n>().t("notify-invalid-shortcut-hotkey"))
+            })?;
 
         let model_value = row
             .model_select
@@ -1458,15 +1484,12 @@ impl Render for ShortcutSettingsPage {
             .gap_3()
             .child(self.render_toolbar(cx))
             .child(
-                div()
-                    .w_full()
-                    .h(px(560.))
-                    .child(
-                        Table::new(&self.table)
-                            .small()
-                            .stripe(true)
-                            .scrollbar_visible(true, true),
-                    ),
+                div().w_full().h(px(560.)).child(
+                    Table::new(&self.table)
+                        .small()
+                        .stripe(true)
+                        .scrollbar_visible(true, true),
+                ),
             )
     }
 }

--- a/app/novel-download/Cargo.toml
+++ b/app/novel-download/Cargo.toml
@@ -41,4 +41,4 @@ tracing-subscriber = { version = "0.3.23", features = ["local-time"] }
 
 [dev-dependencies]
 anyhow = "1.0.102"
-tokio = { version = "1.50.0", default-features = false, features = ["macros"] }
+tokio = { version = "1.51.0", default-features = false, features = ["macros"] }

--- a/crates/platform-ext/Cargo.toml
+++ b/crates/platform-ext/Cargo.toml
@@ -31,7 +31,9 @@ windows = { version = "0.62.2", features = [
   "Graphics_Imaging",
   "Media_Ocr",
   "Storage_Streams",
+  "Win32_Graphics_Gdi",
   "Win32_System_WinRT",
+  "Win32_UI_WindowsAndMessaging",
 ] }
 windows-core = "0.62.2"
 windows-future = "0.3.2"

--- a/crates/platform-ext/src/app.rs
+++ b/crates/platform-ext/src/app.rs
@@ -12,10 +12,12 @@ use objc2_app_kit::{NSApplication, NSEvent, NSImage, NSScreen};
 use objc2_foundation::NSData;
 #[cfg(target_os = "windows")]
 use windows::Win32::{
-    Foundation::{BOOL, LPARAM, POINT},
-    Graphics::Gdi::{EnumDisplayMonitors, HDC, HMONITOR, RECT},
-    UI::WindowsAndMessaging::{GetCursorPos, MONITOR_DEFAULTTONULL, MonitorFromPoint},
+    Foundation::{LPARAM, POINT, RECT},
+    Graphics::Gdi::{EnumDisplayMonitors, HDC, HMONITOR, MONITOR_DEFAULTTONULL, MonitorFromPoint},
+    UI::WindowsAndMessaging::GetCursorPos,
 };
+#[cfg(target_os = "windows")]
+use windows::core::BOOL;
 
 #[cfg(target_os = "macos")]
 pub fn record_frontmost_app() -> Option<Retained<NSRunningApplication>> {

--- a/crates/platform-ext/src/app.rs
+++ b/crates/platform-ext/src/app.rs
@@ -7,9 +7,15 @@ use objc2::{AnyThread, MainThreadMarker};
 #[cfg(target_os = "macos")]
 pub use objc2_app_kit::NSRunningApplication;
 #[cfg(target_os = "macos")]
-use objc2_app_kit::{NSApplication, NSImage};
+use objc2_app_kit::{NSApplication, NSEvent, NSImage, NSScreen};
 #[cfg(target_os = "macos")]
 use objc2_foundation::NSData;
+#[cfg(target_os = "windows")]
+use windows::Win32::{
+    Foundation::{BOOL, LPARAM, POINT},
+    Graphics::Gdi::{EnumDisplayMonitors, HDC, HMONITOR, RECT},
+    UI::WindowsAndMessaging::{GetCursorPos, MONITOR_DEFAULTTONULL, MonitorFromPoint},
+};
 
 #[cfg(target_os = "macos")]
 pub fn record_frontmost_app() -> Option<Retained<NSRunningApplication>> {
@@ -36,6 +42,89 @@ pub fn restore_frontmost_app(prev_app: &Option<Retained<NSRunningApplication>>) 
 
 #[cfg(not(target_os = "macos"))]
 pub fn restore_frontmost_app(_: &()) {}
+
+#[cfg(target_os = "macos")]
+pub fn current_mouse_location() -> Option<(f32, f32)> {
+    let _ = MainThreadMarker::new()?;
+    let point = NSEvent::mouseLocation();
+    Some((point.x as f32, point.y as f32))
+}
+
+#[cfg(target_os = "windows")]
+pub fn current_mouse_location() -> Option<(f32, f32)> {
+    let mut point = POINT::default();
+    unsafe { GetCursorPos(&mut point).ok()? };
+    Some((point.x as f32, point.y as f32))
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+pub fn current_mouse_location() -> Option<(f32, f32)> {
+    None
+}
+
+#[cfg(target_os = "macos")]
+pub fn current_mouse_display_id() -> Option<u32> {
+    let mtm = MainThreadMarker::new()?;
+    let point = NSEvent::mouseLocation();
+    let screens = NSScreen::screens(mtm);
+    for screen in &screens {
+        let frame = screen.frame();
+        let max_x = frame.origin.x + frame.size.width;
+        let max_y = frame.origin.y + frame.size.height;
+        if point.x >= frame.origin.x
+            && point.x < max_x
+            && point.y >= frame.origin.y
+            && point.y < max_y
+        {
+            return Some(screen.CGDirectDisplayID());
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "windows")]
+pub fn current_mouse_display_id() -> Option<u32> {
+    let mut point = POINT::default();
+    unsafe { GetCursorPos(&mut point).ok()? };
+    let monitor = unsafe { MonitorFromPoint(point, MONITOR_DEFAULTTONULL) };
+    if monitor.is_invalid() {
+        return None;
+    }
+
+    let mut monitors = Vec::new();
+    unsafe {
+        EnumDisplayMonitors(
+            None,
+            None,
+            Some(enum_monitors),
+            LPARAM(&mut monitors as *mut Vec<HMONITOR> as isize),
+        )
+        .ok()
+        .ok()?;
+    }
+
+    monitors
+        .iter()
+        .position(|candidate| candidate.0 == monitor.0)
+        .map(|index| index as u32)
+}
+
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn enum_monitors(
+    monitor: HMONITOR,
+    _hdc: HDC,
+    _rect: *mut RECT,
+    data: LPARAM,
+) -> BOOL {
+    let monitors = unsafe { &mut *(data.0 as *mut Vec<HMONITOR>) };
+    monitors.push(monitor);
+    BOOL(1)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+pub fn current_mouse_display_id() -> Option<u32> {
+    None
+}
 
 #[cfg(target_os = "macos")]
 pub fn set_application_icon_from_bytes(icon_bytes: &[u8]) -> Result<(), PlatformExtError> {

--- a/crates/platform-ext/src/app.rs
+++ b/crates/platform-ext/src/app.rs
@@ -107,7 +107,7 @@ pub fn current_mouse_display_id() -> Option<u32> {
 
     monitors
         .iter()
-        .position(|candidate| candidate.0 == monitor.0)
+        .position(|candidate: &HMONITOR| candidate.0 == monitor.0)
         .map(|index| index as u32)
 }
 

--- a/crates/platform-ext/src/ocr/windows.rs
+++ b/crates/platform-ext/src/ocr/windows.rs
@@ -1,7 +1,7 @@
 use crate::{
     OcrError,
-    ocr::{RecognizedLine, collapse_lines},
     ocr::ImageFrame,
+    ocr::{RecognizedLine, collapse_lines},
 };
 use windows::{
     Graphics::Imaging::{BitmapAlphaMode, BitmapPixelFormat, SoftwareBitmap},
@@ -14,8 +14,7 @@ use windows::{
 use windows_core::HRESULT;
 
 use crate::ocr::windows_support::{
-    image_frame::software_bitmap_from_image_frame,
-    wait_async_operation,
+    image_frame::software_bitmap_from_image_frame, wait_async_operation,
     wait_async_operation_with_progress,
 };
 use tracing::{Level, event};
@@ -54,7 +53,11 @@ pub(super) fn recognize_text(image: &ImageFrame) -> Result<String, OcrError> {
 }
 
 fn recognize_text_ai(bitmap: &SoftwareBitmap) -> Result<String, BackendError> {
-    event!(Level::INFO, backend = "windows_ai_text_recognizer", "Trying OCR backend");
+    event!(
+        Level::INFO,
+        backend = "windows_ai_text_recognizer",
+        "Trying OCR backend"
+    );
     ensure_ai_ready()?;
     let recognizer =
         wait_async_operation(ai_bindings::TextRecognizer::CreateAsync().map_err(ai_failure)?)
@@ -111,7 +114,11 @@ fn ensure_ai_ready() -> Result<(), BackendError> {
 }
 
 fn recognize_text_legacy(bitmap: &SoftwareBitmap) -> Result<String, BackendError> {
-    event!(Level::INFO, backend = "windows_media_ocr", "Trying OCR fallback backend");
+    event!(
+        Level::INFO,
+        backend = "windows_media_ocr",
+        "Trying OCR fallback backend"
+    );
     let bitmap =
         SoftwareBitmap::ConvertWithAlpha(bitmap, BitmapPixelFormat::Bgra8, BitmapAlphaMode::Ignore)
             .map_err(legacy_failure)?;
@@ -176,12 +183,20 @@ fn resolve_backend_result(
 ) -> Result<String, OcrError> {
     match primary {
         Ok(result) => {
-            event!(Level::INFO, backend = "windows_ai_text_recognizer", "OCR primary backend succeeded");
+            event!(
+                Level::INFO,
+                backend = "windows_ai_text_recognizer",
+                "OCR primary backend succeeded"
+            );
             Ok(result)
         }
         Err(BackendError::Unavailable(_)) => match fallback() {
             Ok(result) => {
-                event!(Level::INFO, backend = "windows_media_ocr", "OCR fallback backend succeeded");
+                event!(
+                    Level::INFO,
+                    backend = "windows_media_ocr",
+                    "OCR fallback backend succeeded"
+                );
                 Ok(result)
             }
             Err(BackendError::Unavailable(reason)) => {

--- a/crates/window-ext/Cargo.toml
+++ b/crates/window-ext/Cargo.toml
@@ -12,6 +12,7 @@ thiserror = "2.0.18"
 [target.'cfg(target_os="macos")'.dependencies]
 objc2-app-kit = "0.3.2"
 objc2 = "0.6.4"
+objc2-foundation = { version = "0.3.2", features = ["objc2-core-foundation"] }
 
 [target.'cfg(target_os="windows")'.dependencies]
 windows = { version = "0.62.2", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }

--- a/crates/window-ext/Cargo.toml
+++ b/crates/window-ext/Cargo.toml
@@ -15,4 +15,4 @@ objc2 = "0.6.4"
 objc2-foundation = { version = "0.3.2", features = ["objc2-core-foundation"] }
 
 [target.'cfg(target_os="windows")'.dependencies]
-windows = { version = "0.62.2", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }
+windows = { version = "0.62.2", features = ["Win32_Foundation", "Win32_Graphics_Gdi", "Win32_UI_HiDpi", "Win32_UI_WindowsAndMessaging"] }

--- a/crates/window-ext/src/lib.rs
+++ b/crates/window-ext/src/lib.rs
@@ -1,9 +1,9 @@
 #![allow(deprecated)]
-use gpui::Window;
+use gpui::{Bounds, DisplayId, Pixels, Window};
 #[cfg(target_os = "macos")]
 use objc2::{MainThreadMarker, rc::Id};
 #[cfg(target_os = "macos")]
-use objc2_app_kit::{NSApplication, NSView, NSWindow};
+use objc2_app_kit::{NSApplication, NSScreen, NSView, NSWindow};
 #[cfg(target_os = "macos")]
 use raw_window_handle::AppKitWindowHandle;
 use raw_window_handle::{HandleError, HasRawWindowHandle, RawWindowHandle};
@@ -12,7 +12,8 @@ use thiserror::Error;
 use windows::Win32::{
     Foundation::HWND,
     UI::WindowsAndMessaging::{
-        HWND_TOPMOST, SW_HIDE, SW_SHOW, SWP_NOMOVE, SWP_NOSIZE, SetWindowPos, ShowWindow,
+        HWND_TOPMOST, SW_HIDE, SW_SHOW, SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER, SetWindowPos,
+        ShowWindow,
     },
 };
 
@@ -28,6 +29,8 @@ pub enum WindowExtError {
     FailedToGetNSApplication,
     #[error("Failed to set topmost")]
     FailedSetTopMost,
+    #[error("Failed to set window bounds")]
+    FailedSetBounds,
 }
 
 pub trait WindowExt {
@@ -35,6 +38,11 @@ pub trait WindowExt {
     fn show(&self) -> Result<(), WindowExtError>;
     fn set_floating(&self) -> Result<(), WindowExtError>;
     fn is_visible(&self) -> Result<bool, WindowExtError>;
+    fn move_and_resize(
+        &self,
+        bounds: Bounds<Pixels>,
+        display_id: Option<DisplayId>,
+    ) -> Result<(), WindowExtError>;
 }
 
 impl WindowExt for Window {
@@ -159,6 +167,58 @@ impl WindowExt for Window {
         };
         Ok(true)
     }
+
+    fn move_and_resize(
+        &self,
+        bounds: Bounds<Pixels>,
+        display_id: Option<DisplayId>,
+    ) -> Result<(), WindowExtError> {
+        let raw_window = get_raw_window(self)?;
+        match raw_window {
+            #[allow(unused_variables)]
+            RawWindowHandle::AppKit(handle) => {
+                #[cfg(target_os = "macos")]
+                {
+                    let ns_window = get_ns_window(handle)?;
+                    let screen_frame = resolve_screen_frame(&ns_window, display_id)?;
+                    let frame = objc2_foundation::NSRect::new(
+                        objc2_foundation::NSPoint::new(
+                            screen_frame.origin.x + f64::from(f32::from(bounds.origin.x)),
+                            screen_frame.origin.y + screen_frame.size.height
+                                - f64::from(f32::from(bounds.origin.y))
+                                - f64::from(f32::from(bounds.size.height)),
+                        ),
+                        objc2_foundation::NSSize::new(
+                            f64::from(f32::from(bounds.size.width)),
+                            f64::from(f32::from(bounds.size.height)),
+                        ),
+                    );
+                    ns_window.setFrame_display(frame, true);
+                }
+            }
+            #[allow(unused_variables)]
+            RawWindowHandle::Win32(handle) => {
+                #[cfg(target_os = "windows")]
+                {
+                    let hwnd = HWND(handle.hwnd.get() as _);
+                    unsafe {
+                        SetWindowPos(
+                            hwnd,
+                            None,
+                            f32::from(bounds.origin.x).round() as i32,
+                            f32::from(bounds.origin.y).round() as i32,
+                            f32::from(bounds.size.width).round() as i32,
+                            f32::from(bounds.size.height).round() as i32,
+                            SWP_NOZORDER,
+                        )
+                        .map_err(|_| WindowExtError::FailedSetBounds)?;
+                    }
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
 }
 
 fn get_raw_window(window: &Window) -> Result<RawWindowHandle, WindowExtError> {
@@ -180,4 +240,25 @@ fn get_ns_window(
         .ok_or(WindowExtError::FailedToGetNSWindow)?;
 
     Ok(ns_window)
+}
+
+#[cfg(target_os = "macos")]
+fn resolve_screen_frame(
+    ns_window: &NSWindow,
+    display_id: Option<DisplayId>,
+) -> Result<objc2_foundation::NSRect, WindowExtError> {
+    if let Some(display_id) = display_id {
+        let mtm = MainThreadMarker::new().ok_or(WindowExtError::FailedToGetNSApplication)?;
+        let screens = NSScreen::screens(mtm);
+        for screen in &screens {
+            if screen.CGDirectDisplayID() == u32::from(display_id) {
+                return Ok(screen.frame());
+            }
+        }
+    }
+
+    let screen = ns_window
+        .screen()
+        .ok_or(WindowExtError::FailedToGetNSWindow)?;
+    Ok(screen.frame())
 }

--- a/crates/window-ext/src/lib.rs
+++ b/crates/window-ext/src/lib.rs
@@ -10,7 +10,7 @@ use raw_window_handle::{HandleError, HasRawWindowHandle, RawWindowHandle};
 use thiserror::Error;
 #[cfg(target_os = "windows")]
 use windows::Win32::{
-    Foundation::{BOOL, HWND, LPARAM, RECT},
+    Foundation::{HWND, LPARAM, RECT},
     Graphics::Gdi::{EnumDisplayMonitors, HDC, HMONITOR},
     UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI},
     UI::WindowsAndMessaging::{
@@ -18,6 +18,8 @@ use windows::Win32::{
         ShowWindow, USER_DEFAULT_SCREEN_DPI,
     },
 };
+#[cfg(target_os = "windows")]
+use windows::core::BOOL;
 
 #[derive(Error, Debug)]
 pub enum WindowExtError {
@@ -207,19 +209,10 @@ impl WindowExt for Window {
                         self.scale_factor(),
                         display_id.and_then(scale_factor_for_display),
                     );
-                    let (x, y, width, height) =
-                        logical_bounds_to_device_rect(bounds, scale_factor);
+                    let (x, y, width, height) = logical_bounds_to_device_rect(bounds, scale_factor);
                     unsafe {
-                        SetWindowPos(
-                            hwnd,
-                            None,
-                            x,
-                            y,
-                            width,
-                            height,
-                            SWP_NOZORDER,
-                        )
-                        .map_err(|_| WindowExtError::FailedSetBounds)?;
+                        SetWindowPos(hwnd, None, x, y, width, height, SWP_NOZORDER)
+                            .map_err(|_| WindowExtError::FailedSetBounds)?;
                     }
                 }
             }

--- a/crates/window-ext/src/lib.rs
+++ b/crates/window-ext/src/lib.rs
@@ -352,6 +352,16 @@ mod tests {
     }
 
     #[test]
+    fn logical_bounds_to_device_rect_keeps_offset_display_origin_absolute() {
+        let result = logical_bounds_to_device_rect(
+            bounds(point(px(1280.0), px(120.0)), size(px(800.0), px(600.0))),
+            1.5,
+        );
+
+        assert_eq!(result, (1920, 180, 1200, 900));
+    }
+
+    #[test]
     fn resolve_target_scale_factor_prefers_target_display_scale() {
         assert_eq!(resolve_target_scale_factor(1.0, Some(1.5)), 1.5);
         assert_eq!(resolve_target_scale_factor(1.0, None), 1.0);

--- a/crates/window-ext/src/lib.rs
+++ b/crates/window-ext/src/lib.rs
@@ -10,10 +10,12 @@ use raw_window_handle::{HandleError, HasRawWindowHandle, RawWindowHandle};
 use thiserror::Error;
 #[cfg(target_os = "windows")]
 use windows::Win32::{
-    Foundation::HWND,
+    Foundation::{BOOL, HWND, LPARAM, RECT},
+    Graphics::Gdi::{EnumDisplayMonitors, HDC, HMONITOR},
+    UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI},
     UI::WindowsAndMessaging::{
         HWND_TOPMOST, SW_HIDE, SW_SHOW, SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER, SetWindowPos,
-        ShowWindow,
+        ShowWindow, USER_DEFAULT_SCREEN_DPI,
     },
 };
 
@@ -201,8 +203,12 @@ impl WindowExt for Window {
                 #[cfg(target_os = "windows")]
                 {
                     let hwnd = HWND(handle.hwnd.get() as _);
+                    let scale_factor = resolve_target_scale_factor(
+                        self.scale_factor(),
+                        display_id.and_then(scale_factor_for_display),
+                    );
                     let (x, y, width, height) =
-                        logical_bounds_to_device_rect(bounds, self.scale_factor());
+                        logical_bounds_to_device_rect(bounds, scale_factor);
                     unsafe {
                         SetWindowPos(
                             hwnd,
@@ -223,8 +229,11 @@ impl WindowExt for Window {
     }
 }
 
-#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
-fn logical_bounds_to_device_rect(bounds: Bounds<Pixels>, scale_factor: f32) -> (i32, i32, i32, i32) {
+#[cfg(any(target_os = "windows", test))]
+fn logical_bounds_to_device_rect(
+    bounds: Bounds<Pixels>,
+    scale_factor: f32,
+) -> (i32, i32, i32, i32) {
     let bounds = bounds.to_device_pixels(scale_factor);
     (
         bounds.origin.x.0,
@@ -234,20 +243,55 @@ fn logical_bounds_to_device_rect(bounds: Bounds<Pixels>, scale_factor: f32) -> (
     )
 }
 
-#[cfg(test)]
-mod tests {
-    use super::logical_bounds_to_device_rect;
-    use gpui::{bounds, point, px, size};
+#[cfg(any(target_os = "windows", test))]
+fn resolve_target_scale_factor(
+    fallback_scale_factor: f32,
+    target_scale_factor: Option<f32>,
+) -> f32 {
+    target_scale_factor.unwrap_or(fallback_scale_factor)
+}
 
-    #[test]
-    fn logical_bounds_to_device_rect_scales_coordinates_and_size() {
-        let result = logical_bounds_to_device_rect(
-            bounds(point(px(10.0), px(20.0)), size(px(300.0), px(200.0))),
-            1.5,
+#[cfg(target_os = "windows")]
+fn scale_factor_for_display(display_id: DisplayId) -> Option<f32> {
+    available_monitors()
+        .into_iter()
+        .nth(u32::from(display_id) as usize)
+        .and_then(|monitor| get_scale_factor_for_monitor(monitor).ok())
+}
+
+#[cfg(target_os = "windows")]
+fn available_monitors() -> Vec<HMONITOR> {
+    let mut monitors = Vec::new();
+    unsafe {
+        let _ = EnumDisplayMonitors(
+            None,
+            None,
+            Some(monitor_enum_proc),
+            LPARAM(&mut monitors as *mut _ as _),
         );
-
-        assert_eq!(result, (15, 30, 450, 300));
     }
+    monitors
+}
+
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn monitor_enum_proc(
+    monitor: HMONITOR,
+    _hdc: HDC,
+    _rect: *mut RECT,
+    data: LPARAM,
+) -> BOOL {
+    let monitors = data.0 as *mut Vec<HMONITOR>;
+    unsafe { (*monitors).push(monitor) };
+    BOOL(1)
+}
+
+#[cfg(target_os = "windows")]
+fn get_scale_factor_for_monitor(monitor: HMONITOR) -> windows::core::Result<f32> {
+    let mut dpi_x = 0;
+    let mut dpi_y = 0;
+    unsafe { GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y) }?;
+    debug_assert_eq!(dpi_x, dpi_y);
+    Ok(dpi_x as f32 / USER_DEFAULT_SCREEN_DPI as f32)
 }
 
 fn get_raw_window(window: &Window) -> Result<RawWindowHandle, WindowExtError> {
@@ -290,4 +334,26 @@ fn resolve_screen_frame(
         .screen()
         .ok_or(WindowExtError::FailedToGetNSWindow)?;
     Ok(screen.frame())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{logical_bounds_to_device_rect, resolve_target_scale_factor};
+    use gpui::{bounds, point, px, size};
+
+    #[test]
+    fn logical_bounds_to_device_rect_scales_coordinates_and_size() {
+        let result = logical_bounds_to_device_rect(
+            bounds(point(px(10.0), px(20.0)), size(px(300.0), px(200.0))),
+            1.5,
+        );
+
+        assert_eq!(result, (15, 30, 450, 300));
+    }
+
+    #[test]
+    fn resolve_target_scale_factor_prefers_target_display_scale() {
+        assert_eq!(resolve_target_scale_factor(1.0, Some(1.5)), 1.5);
+        assert_eq!(resolve_target_scale_factor(1.0, None), 1.0);
+    }
 }

--- a/crates/window-ext/src/lib.rs
+++ b/crates/window-ext/src/lib.rs
@@ -201,14 +201,16 @@ impl WindowExt for Window {
                 #[cfg(target_os = "windows")]
                 {
                     let hwnd = HWND(handle.hwnd.get() as _);
+                    let (x, y, width, height) =
+                        logical_bounds_to_device_rect(bounds, self.scale_factor());
                     unsafe {
                         SetWindowPos(
                             hwnd,
                             None,
-                            f32::from(bounds.origin.x).round() as i32,
-                            f32::from(bounds.origin.y).round() as i32,
-                            f32::from(bounds.size.width).round() as i32,
-                            f32::from(bounds.size.height).round() as i32,
+                            x,
+                            y,
+                            width,
+                            height,
                             SWP_NOZORDER,
                         )
                         .map_err(|_| WindowExtError::FailedSetBounds)?;
@@ -218,6 +220,33 @@ impl WindowExt for Window {
             _ => {}
         }
         Ok(())
+    }
+}
+
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn logical_bounds_to_device_rect(bounds: Bounds<Pixels>, scale_factor: f32) -> (i32, i32, i32, i32) {
+    let bounds = bounds.to_device_pixels(scale_factor);
+    (
+        bounds.origin.x.0,
+        bounds.origin.y.0,
+        bounds.size.width.0,
+        bounds.size.height.0,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::logical_bounds_to_device_rect;
+    use gpui::{bounds, point, px, size};
+
+    #[test]
+    fn logical_bounds_to_device_rect_scales_coordinates_and_size() {
+        let result = logical_bounds_to_device_rect(
+            bounds(point(px(10.0), px(20.0)), size(px(300.0), px(200.0))),
+            1.5,
+        );
+
+        assert_eq!(result, (15, 30, 450, 300));
     }
 }
 

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -10,7 +10,7 @@ image = "0.25.10"
 plist = "1.8.0"
 serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.18"
-toml = "1.0.7"
+toml = "1.1.2"
 tauri-bundler = "2.8.1"
 tauri-utils = "2.8.3"
 tracing = "0.1.44"


### PR DESCRIPTION
## Summary

- Update `ai-chat` temporary windows and screenshot overlays to target the display under the mouse instead of always using the primary display.
- Fix screenshot capture region calculation so the selected area is offset by the overlay window origin before capture.
- Affected scope: `ai-chat`, `platform-ext`, `window-ext`

## Motivation

- Multi-display temporary windows and screenshot overlays were opening on the wrong screen.
- Screenshot captures could drift from the user-visible selection when the overlay window origin was not `(0, 0)` within the display.

## Changes

- Add shared `screen` helpers in `ai-chat` to resolve the target display from the mouse location and recenter bounds on that display.
- Reposition existing temporary windows onto the current mouse display before showing them.
- Open only one screenshot overlay window on the mouse display.
- Offset screenshot capture rectangles by the overlay window origin before calling the capture backend.
- Add platform helpers to read the current mouse location/display and `window-ext` support for moving and resizing windows across displays.

## Validation

- [x] `cargo build`
- [ ] `cargo test`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Manual verification completed for the affected app or flow

Validation details:

```text
Ran:
- cargo test -p ai-chat screenshot_overlay
- cargo build -p ai-chat

Results:
- screenshot_overlay tests passed
- ai-chat build passed

Not run:
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings
```

## Risks

- Window movement now depends on the new platform display lookup and native repositioning paths on macOS and Windows.
- Multi-display behavior should still be spot-checked on Windows because the interactive bug was verified on macOS.

## Related Issues

- Closes #45
