### PR TITLE
fix(ai-chat): harden Ollama compatibility and error reporting

### DIFF
--- a/.agents/skills/ollama-api/references/chat-and-show-reference.md
+++ b/.agents/skills/ollama-api/references/chat-and-show-reference.md
@@ -262,6 +262,11 @@ Implementation note:
 | `parameter_size` | `string` |
 | `quantization_level` | `string` |
 
+Implementation note:
+
+- `api/types.go` models `families` as `[]string`, but actual JSON may still serialize it as `null` when the Go slice is nil.
+- Provider implementations should treat `null` the same as an empty array.
+
 ### `tensors` item shape
 
 | Field | Type |

--- a/app/ai-chat/src/llm/provider/ollama.rs
+++ b/app/ai-chat/src/llm/provider/ollama.rs
@@ -14,7 +14,7 @@ use gpui::*;
 use gpui_component::setting::{SettingField, SettingGroup, SettingItem};
 use reqwest::Client;
 use reqwest::Url;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::json;
 use std::net::IpAddr;
 use toml::Value;
@@ -90,6 +90,14 @@ fn should_bypass_proxy(base_url: &str) -> bool {
     let host = host.trim_matches(['[', ']']);
     host.eq_ignore_ascii_case("localhost")
         || host.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
+}
+
+fn deserialize_null_default_vec<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Ok(Option::<Vec<T>>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -242,7 +250,7 @@ struct OllamaTagModel {
 struct OllamaShowResponse {
     #[serde(default)]
     details: OllamaModelDetails,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_default_vec")]
     capabilities: Vec<String>,
 }
 
@@ -250,7 +258,7 @@ struct OllamaShowResponse {
 struct OllamaModelDetails {
     #[serde(default)]
     family: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_default_vec")]
     families: Vec<String>,
 }
 
@@ -776,7 +784,13 @@ impl Provider for OllamaProvider {
                     .await?
                     .error_for_status()?
                     .json::<OllamaShowResponse>()
-                    .await?;
+                    .await
+                    .map_err(|err| {
+                        AiChatError::StreamError(format!(
+                            "decode Ollama show response failed for model {}: {}",
+                            model.name, err
+                        ))
+                    })?;
                 if !show
                     .capabilities
                     .iter()
@@ -1094,5 +1108,20 @@ mod tests {
         );
         assert_eq!(content.text, "final answer");
         assert_eq!(content.reasoning_summary.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn show_response_treats_null_slices_as_empty_vectors() -> anyhow::Result<()> {
+        let response = serde_json::from_value::<super::OllamaShowResponse>(json!({
+            "details": {
+                "family": "qwen3_5",
+                "families": null
+            },
+            "capabilities": null
+        }))?;
+        assert_eq!(response.details.family, "qwen3_5");
+        assert!(response.details.families.is_empty());
+        assert!(response.capabilities.is_empty());
+        Ok(())
     }
 }

--- a/app/ai-chat/src/llm/provider/ollama.rs
+++ b/app/ai-chat/src/llm/provider/ollama.rs
@@ -13,6 +13,7 @@ use futures::{FutureExt, StreamExt, future::BoxFuture, stream::BoxStream};
 use gpui::*;
 use gpui_component::setting::{SettingField, SettingGroup, SettingItem};
 use reqwest::Client;
+use reqwest::StatusCode;
 use reqwest::Url;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::json;
@@ -98,6 +99,47 @@ where
     T: Deserialize<'de>,
 {
     Ok(Option::<Vec<T>>::deserialize(deserializer)?.unwrap_or_default())
+}
+
+fn format_ollama_error_message(operation: &str, status: StatusCode, body: &str) -> String {
+    #[derive(Deserialize)]
+    struct OllamaErrorResponse {
+        #[serde(default)]
+        error: String,
+    }
+
+    let status_text = status
+        .canonical_reason()
+        .map(|reason| format!("{} {}", status.as_u16(), reason))
+        .unwrap_or_else(|| status.as_u16().to_string());
+    let detail = serde_json::from_str::<OllamaErrorResponse>(body)
+        .ok()
+        .map(|response| response.error)
+        .filter(|error| !error.trim().is_empty())
+        .or_else(|| {
+            let trimmed = body.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        });
+
+    match detail {
+        Some(detail) => format!("Ollama {operation} failed ({status_text}): {detail}"),
+        None => format!("Ollama {operation} failed ({status_text})"),
+    }
+}
+
+async fn error_for_status_with_ollama_message(
+    response: reqwest::Response,
+    operation: &str,
+) -> AiChatResult<reqwest::Response> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+
+    let body = response.text().await.unwrap_or_default();
+    Err(AiChatError::StreamError(format_ollama_error_message(
+        operation, status, &body,
+    )))
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -504,7 +546,8 @@ impl OllamaProvider {
                     }))
                     .send()
                     .await?;
-                let response = response.error_for_status()?;
+                let response =
+                    error_for_status_with_ollama_message(response, "web_search request").await?;
                 let result = response.json::<WebSearchResponse>().await?;
                 let citations = result
                     .results
@@ -541,7 +584,8 @@ impl OllamaProvider {
                     .json(&json!({ "url": url }))
                     .send()
                     .await?;
-                let response = response.error_for_status()?;
+                let response =
+                    error_for_status_with_ollama_message(response, "web_fetch request").await?;
                 let result = response.json::<WebFetchResponse>().await?;
                 let citations = vec![UrlCitation {
                     title: (!result.title.trim().is_empty()).then(|| result.title.clone()),
@@ -667,7 +711,7 @@ impl Provider for OllamaProvider {
                     .json(&chat_request)
                     .send()
                     .await?;
-                let response = response.error_for_status()?;
+                let response = error_for_status_with_ollama_message(response, "chat request").await?;
 
                 let round = if !chat_request.stream {
                     let response = response.json::<OllamaChatResponse>().await?;
@@ -768,11 +812,9 @@ impl Provider for OllamaProvider {
             let settings: OllamaSettings = settings.try_into()?;
             let settings = settings.normalized();
             let client = Self::client(&config, &settings.base_url)?;
-            let response = client
-                .get(tags_url(&settings.base_url))
-                .send()
+            let response = client.get(tags_url(&settings.base_url)).send().await?;
+            let response = error_for_status_with_ollama_message(response, "tags request")
                 .await?
-                .error_for_status()?
                 .json::<OllamaTagsResponse>()
                 .await?;
             let mut models = Vec::new();
@@ -781,8 +823,9 @@ impl Provider for OllamaProvider {
                     .post(show_url(&settings.base_url))
                     .json(&json!({ "model": model.model }))
                     .send()
+                    .await?;
+                let show = error_for_status_with_ollama_message(show, "show request")
                     .await?
-                    .error_for_status()?
                     .json::<OllamaShowResponse>()
                     .await
                     .map_err(|err| {
@@ -1123,5 +1166,31 @@ mod tests {
         assert!(response.details.families.is_empty());
         assert!(response.capabilities.is_empty());
         Ok(())
+    }
+
+    #[test]
+    fn format_ollama_error_message_uses_json_error_field() {
+        let message = super::format_ollama_error_message(
+            "chat request",
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            r#"{"error":"mlx runner failed"}"#,
+        );
+        assert_eq!(
+            message,
+            "Ollama chat request failed (500 Internal Server Error): mlx runner failed"
+        );
+    }
+
+    #[test]
+    fn format_ollama_error_message_falls_back_to_plain_text_body() {
+        let message = super::format_ollama_error_message(
+            "show request",
+            reqwest::StatusCode::BAD_GATEWAY,
+            "upstream gateway failure",
+        );
+        assert_eq!(
+            message,
+            "Ollama show request failed (502 Bad Gateway): upstream gateway failure"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Harden `ai-chat` Ollama integration against nullable slice fields in `/api/show`, including `details.families: null`
- Surface Ollama server-side error bodies for failed chat/model/tool requests so runtime failures are diagnosable in the UI and logs
- Update the local `ollama-api` skill reference to note that `families` may serialize as `null`

## Motivation

- `ai-chat` failed to load some Ollama models because it assumed `details.families` was always an array
- When Ollama returned runtime failures such as `mlx runner failed`, the app only showed a generic HTTP 500 and hid the useful server error text

## Changes

- Normalize nullable Ollama vector fields to empty arrays during `/api/show` deserialization
- Add model-context decode errors for `/api/show` failures
- Parse non-2xx Ollama response bodies and propagate their `error` messages through the existing UI error path
- Add tests covering nullable slice decoding and Ollama error-message formatting
- Document the nullable `families` behavior in `.agents/skills/ollama-api/references/chat-and-show-reference.md`

## Validation

- [ ] `cargo build`
- [x] `cargo test`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Manual verification completed for the affected app or flow

Validation details:

```text
Ran:
- cargo test -p ai-chat llm::provider::ollama -- --nocapture

Result:
- 11 Ollama provider tests passed

Manual verification:
- Reproduced the original Homebrew Ollama 0.20.5 failure for qwen3.5:9b-nvfp4 (`MLX not available`)
- Replaced the Homebrew install with the official Ollama.app 0.20.7
- Verified local /api/tags succeeds and qwen3.5:9b-nvfp4 /api/chat succeeds under the official app install

Not run:
- cargo build
- cargo clippy --all-targets --all-features -- -D warnings
```

## Risks

- Ollama HTTP failures will now present more specific server-provided text, which changes user-visible error strings
- The new error path assumes Ollama error bodies are either JSON with `error` or plain text; unexpected formats still fall back to status-only messaging

## Related Issues

- Closes #47
- Related to #47
