### PR TITLE
[codex] fix ai-chat screenshot overlay crosshair cursor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,10 +46,11 @@
 
 ## 4. 提权与 GitHub 规则
 
-- 任何需要联网、安装依赖、修改 `Cargo.lock`、执行 `cargo add` / `cargo install`、运行 `gh` 写操作，或其他超出沙盒权限的命令，都必须先申请权限。
-- 如果命令因网络、权限或沙盒限制失败，应直接对原命令申请权限，不要改用绕过限制的替代方案。
+- 任何需要联网、安装依赖、修改 `Cargo.lock`、执行 `cargo add` / `cargo install`、运行 `gh`、或其他超出沙盒权限的命令，都必须先申请权限。不要先在沙盒内试跑 `gh` 或联网命令。
+- `gh` 的认证、查询和写操作都必须提权运行，包括 `gh auth status`、`gh pr view`、`gh pr create`、`gh pr ready`、`gh workflow run` 等。沙盒内 `gh` 失败、token 无效或无法访问 keyring，不代表真实环境不可用，禁止据此切换到其他方案。
+- 如果命令因网络、权限或沙盒限制失败，应直接对原命令申请权限重跑，不要改用绕过限制的替代方案。
 - 删除文件、覆盖生成产物、批量改写文件或改写 lockfile 前，也要先说明并申请权限。
-- GitHub 相关操作优先使用 `gh`，不要手写推测性结果。
+- GitHub 相关操作必须优先使用提权后的 `gh`，不要手写推测性结果。只有在提权后的 `gh` 明确不可用时，才允许使用 GitHub App / MCP 作为降级方案，并必须在汇报中说明原因。
 - 编写 issue、PR、release note、评论前，先检查 `.github/` 下的模板和 workflow。
 - issue 默认使用：
   - `.github/ISSUE_TEMPLATE/bug_report.yml`
@@ -57,6 +58,7 @@
   - `.github/ISSUE_TEMPLATE/tech_request.yml`
 - PR 默认使用 `.github/pull_request_template.md`。
 - 编写 PR 内容时，必须基于“当前分支相对远程最新 `main`”的整体差异进行总结，不要只根据最后一次提交或本次会话中的改动来写。
+- 用户要求“提交 PR / 开 PR / 提 PR”时，默认创建可直接 review 的普通 PR；只有用户明确说“draft PR / 草稿 PR”时才创建 draft。
 - issue / PR 标题和描述要明确对应应用或 crate，例如 `ai-chat`、`feiwen`、`http-client`、`novel-download`、`window-ext`、`xtask`。
 
 ## 5. 验证与 CI

--- a/app/ai-chat/src/hotkey/shortcut_flow.rs
+++ b/app/ai-chat/src/hotkey/shortcut_flow.rs
@@ -139,6 +139,16 @@ impl GlobalHotkeyState {
         text: String,
         cx: &mut App,
     ) {
+        self.trigger_shortcut_with_input_before_showing_window(binding, text, cx, |_, _| {});
+    }
+
+    fn trigger_shortcut_with_input_before_showing_window(
+        &mut self,
+        binding: GlobalShortcutBinding,
+        text: String,
+        cx: &mut App,
+        before_showing_window: impl FnOnce(&mut Self, &mut App),
+    ) {
         let models = cx.global::<ModelStore>().read(cx).snapshot().models;
         let model_available = models.iter().any(|model| {
             model.provider_name == binding.provider_name && model.id == binding.model_id
@@ -148,6 +158,7 @@ impl GlobalHotkeyState {
             return;
         }
 
+        before_showing_window(self, cx);
         let Some(window) = self.ensure_temporary_window_visible(cx) else {
             return;
         };
@@ -297,11 +308,15 @@ impl GlobalHotkeyState {
                         "Screenshot OCR completed"
                     );
                     match normalized_text(Some(text)) {
-                        Some(text) => {
-                            #[cfg(target_os = "macos")]
-                            hotkeys.transfer_front_app_from_screenshot_to_temporary_window(cx);
-                            hotkeys.trigger_shortcut_with_input(binding, text, cx);
-                        }
+                        Some(text) => hotkeys.trigger_shortcut_with_input_before_showing_window(
+                            binding,
+                            text,
+                            cx,
+                            |hotkeys, cx| {
+                                #[cfg(target_os = "macos")]
+                                hotkeys.transfer_front_app_from_screenshot_to_temporary_window(cx);
+                            },
+                        ),
                         None => hotkeys.handle_empty_shortcut_input(cx),
                     }
                 }

--- a/app/ai-chat/src/hotkey/shortcut_flow.rs
+++ b/app/ai-chat/src/hotkey/shortcut_flow.rs
@@ -139,15 +139,15 @@ impl GlobalHotkeyState {
         text: String,
         cx: &mut App,
     ) {
-        self.trigger_shortcut_with_input_before_showing_window(binding, text, cx, |_, _| {});
+        self.trigger_shortcut_with_input_after_showing_window(binding, text, cx, |_, _| {});
     }
 
-    fn trigger_shortcut_with_input_before_showing_window(
+    fn trigger_shortcut_with_input_after_showing_window(
         &mut self,
         binding: GlobalShortcutBinding,
         text: String,
         cx: &mut App,
-        before_showing_window: impl FnOnce(&mut Self, &mut App),
+        after_showing_window: impl FnOnce(&mut Self, &mut App),
     ) {
         let models = cx.global::<ModelStore>().read(cx).snapshot().models;
         let model_available = models.iter().any(|model| {
@@ -158,10 +158,10 @@ impl GlobalHotkeyState {
             return;
         }
 
-        before_showing_window(self, cx);
         let Some(window) = self.ensure_temporary_window_visible(cx) else {
             return;
         };
+        after_showing_window(self, cx);
         let draft = ConversationDraft {
             text,
             provider_name: binding.provider_name.clone(),
@@ -308,7 +308,7 @@ impl GlobalHotkeyState {
                         "Screenshot OCR completed"
                     );
                     match normalized_text(Some(text)) {
-                        Some(text) => hotkeys.trigger_shortcut_with_input_before_showing_window(
+                        Some(text) => hotkeys.trigger_shortcut_with_input_after_showing_window(
                             binding,
                             text,
                             cx,

--- a/app/ai-chat/src/hotkey/shortcut_flow.rs
+++ b/app/ai-chat/src/hotkey/shortcut_flow.rs
@@ -297,7 +297,11 @@ impl GlobalHotkeyState {
                         "Screenshot OCR completed"
                     );
                     match normalized_text(Some(text)) {
-                        Some(text) => hotkeys.trigger_shortcut_with_input(binding, text, cx),
+                        Some(text) => {
+                            #[cfg(target_os = "macos")]
+                            hotkeys.transfer_front_app_from_screenshot_to_temporary_window(cx);
+                            hotkeys.trigger_shortcut_with_input(binding, text, cx);
+                        }
                         None => hotkeys.handle_empty_shortcut_input(cx),
                     }
                 }

--- a/app/ai-chat/src/hotkey/shortcut_flow.rs
+++ b/app/ai-chat/src/hotkey/shortcut_flow.rs
@@ -139,29 +139,36 @@ impl GlobalHotkeyState {
         text: String,
         cx: &mut App,
     ) {
-        self.trigger_shortcut_with_input_after_showing_window(binding, text, cx, |_, _| {});
+        self.trigger_shortcut_with_input_with_restore_target(
+            binding,
+            text,
+            cx,
+            super::temporary_window::FocusRestoreTarget::ExistingOrRecordCurrent,
+        );
     }
 
-    fn trigger_shortcut_with_input_after_showing_window(
+    fn trigger_shortcut_with_input_with_restore_target(
         &mut self,
         binding: GlobalShortcutBinding,
         text: String,
         cx: &mut App,
-        after_showing_window: impl FnOnce(&mut Self, &mut App),
+        restore_target: super::temporary_window::FocusRestoreTarget,
     ) {
         let models = cx.global::<ModelStore>().read(cx).snapshot().models;
         let model_available = models.iter().any(|model| {
             model.provider_name == binding.provider_name && model.id == binding.model_id
         });
         if !model_available {
+            restore_target.restore_if_override();
             self.handle_unavailable_model(&binding, cx);
             return;
         }
 
-        let Some(window) = self.ensure_temporary_window_visible(cx) else {
+        let Some(window) =
+            self.ensure_temporary_window_visible_with_restore_target(cx, restore_target)
+        else {
             return;
         };
-        after_showing_window(self, cx);
         let draft = ConversationDraft {
             text,
             provider_name: binding.provider_name.clone(),
@@ -308,15 +315,24 @@ impl GlobalHotkeyState {
                         "Screenshot OCR completed"
                     );
                     match normalized_text(Some(text)) {
-                        Some(text) => hotkeys.trigger_shortcut_with_input_after_showing_window(
-                            binding,
-                            text,
-                            cx,
-                            |hotkeys, cx| {
-                                #[cfg(target_os = "macos")]
-                                hotkeys.transfer_front_app_from_screenshot_to_temporary_window(cx);
-                            },
-                        ),
+                        Some(text) => {
+                            #[cfg(target_os = "macos")]
+                            {
+                                let front_app = hotkeys.take_front_app_for_screenshot();
+                                hotkeys.trigger_shortcut_with_input_with_restore_target(
+                                    binding,
+                                    text,
+                                    cx,
+                                    super::temporary_window::FocusRestoreTarget::Override(
+                                        front_app,
+                                    ),
+                                );
+                            }
+                            #[cfg(not(target_os = "macos"))]
+                            {
+                                hotkeys.trigger_shortcut_with_input(binding, text, cx);
+                            }
+                        }
                         None => hotkeys.handle_empty_shortcut_input(cx),
                     }
                 }

--- a/app/ai-chat/src/hotkey/temporary_window.rs
+++ b/app/ai-chat/src/hotkey/temporary_window.rs
@@ -109,6 +109,9 @@ impl TemporaryWindowState {
         if let Err(err) = window.move_and_resize(target_bounds, target_display_id) {
             event!(Level::ERROR, error = ?err, "Failed to reposition temporary window");
         }
+        if let Err(err) = window.show_without_activation() {
+            event!(Level::ERROR, error = ?err, "Failed to show temporary window");
+        }
         window.activate_window();
     }
 

--- a/app/ai-chat/src/hotkey/temporary_window.rs
+++ b/app/ai-chat/src/hotkey/temporary_window.rs
@@ -9,6 +9,21 @@ pub(crate) struct TemporaryWindowState {
 
 impl Global for TemporaryWindowState {}
 
+pub(super) enum FocusRestoreTarget {
+    ExistingOrRecordCurrent,
+    #[cfg(target_os = "macos")]
+    Override(Option<Retained<NSRunningApplication>>),
+}
+
+impl FocusRestoreTarget {
+    pub(super) fn restore_if_override(self) {
+        #[cfg(target_os = "macos")]
+        if let Self::Override(front_app) = self {
+            restore_frontmost_app(&front_app);
+        }
+    }
+}
+
 pub(crate) fn init_temporary_window_state(cx: &mut App) {
     if cx.has_global::<TemporaryWindowState>() {
         return;
@@ -72,9 +87,12 @@ impl TemporaryWindowState {
     }
 
     #[cfg(target_os = "macos")]
-    fn adopt_front_app(&mut self, front_app: Option<Retained<NSRunningApplication>>) {
-        if self.front_app.is_none() {
-            self.front_app = front_app;
+    fn prepare_front_app_for_visible_session(&mut self, restore_target: FocusRestoreTarget) {
+        match restore_target {
+            FocusRestoreTarget::ExistingOrRecordCurrent => self.record_front_app(),
+            FocusRestoreTarget::Override(front_app) => {
+                self.front_app = front_app;
+            }
         }
     }
 
@@ -95,10 +113,15 @@ impl TemporaryWindowState {
         }
     }
 
-    fn show_temporary_window_on_mouse_display(&mut self, window: &mut Window, cx: &App) {
+    fn show_temporary_window_on_mouse_display(
+        &mut self,
+        window: &mut Window,
+        cx: &App,
+        restore_target: FocusRestoreTarget,
+    ) -> bool {
         self.delay_close = None;
-        #[cfg(target_os = "macos")]
-        self.record_front_app();
+        #[cfg(not(target_os = "macos"))]
+        let _ = &restore_target;
         let target_display_id = target_display_id(cx);
         let target_bounds = recentered_bounds_for_display(
             target_display_id,
@@ -111,13 +134,16 @@ impl TemporaryWindowState {
         }
         if let Err(err) = window.show_without_activation() {
             event!(Level::ERROR, error = ?err, "Failed to show temporary window");
+            restore_target.restore_if_override();
+            return false;
         }
         window.activate_window();
+        #[cfg(target_os = "macos")]
+        self.prepare_front_app_for_visible_session(restore_target);
+        true
     }
 
     fn create_temporary_window(&mut self, cx: &mut App) -> Option<WindowHandle<Root>> {
-        #[cfg(target_os = "macos")]
-        self.record_front_app();
         let target_display_id = target_display_id(cx);
         match cx.open_window(
             WindowOptions {
@@ -153,13 +179,40 @@ impl TemporaryWindowState {
         &mut self,
         cx: &mut App,
     ) -> Option<WindowHandle<Root>> {
+        self.ensure_temporary_window_visible_with_restore_target(
+            cx,
+            FocusRestoreTarget::ExistingOrRecordCurrent,
+        )
+    }
+
+    pub(super) fn ensure_temporary_window_visible_with_restore_target(
+        &mut self,
+        cx: &mut App,
+        restore_target: FocusRestoreTarget,
+    ) -> Option<WindowHandle<Root>> {
         let window =
             Self::find_temporary_window(cx).or_else(|| self.create_temporary_window(cx))?;
-        let _ = window.update(cx, |root, window, cx| {
-            self.show_temporary_window_on_mouse_display(window, cx);
+        let mut restore_target = Some(restore_target);
+        match window.update(cx, |root, window, cx| {
+            let restore_target = restore_target
+                .take()
+                .expect("restore target should be consumed by temporary window update");
+            if !self.show_temporary_window_on_mouse_display(window, cx, restore_target) {
+                return false;
+            }
             focus_temporary_window_chat_form(root, window, cx);
-        });
-        Some(window)
+            true
+        }) {
+            Ok(true) => Some(window),
+            Ok(false) => None,
+            Err(err) => {
+                if let Some(restore_target) = restore_target.take() {
+                    restore_target.restore_if_override();
+                }
+                event!(Level::ERROR, "Failed to update temporary window: {:?}", err);
+                None
+            }
+        }
     }
 
     pub(super) fn toggle_temporary_window(&mut self, cx: &mut App) {
@@ -169,7 +222,11 @@ impl TemporaryWindowState {
                     if window.is_visible().unwrap_or(false) {
                         self.delay_or_hide_temporary_window(window, cx);
                     } else {
-                        self.show_temporary_window_on_mouse_display(window, cx);
+                        self.show_temporary_window_on_mouse_display(
+                            window,
+                            cx,
+                            FocusRestoreTarget::ExistingOrRecordCurrent,
+                        );
                     }
                 }) {
                     event!(Level::ERROR, "Failed to update temporary window: {:?}", err);
@@ -216,23 +273,21 @@ impl GlobalHotkeyState {
     }
 
     #[cfg(target_os = "macos")]
-    pub(crate) fn transfer_front_app_from_screenshot_to_temporary_window(&mut self, cx: &mut App) {
-        let front_app = self.front_app.take();
-        if front_app.is_none() {
-            return;
-        }
-
-        let _ = with_temporary_window_state(cx, |state, _cx| {
-            state.adopt_front_app(front_app);
-        });
+    pub(crate) fn take_front_app_for_screenshot(
+        &mut self,
+    ) -> Option<Retained<NSRunningApplication>> {
+        self.front_app.take()
     }
 
-    pub(super) fn ensure_temporary_window_visible(
+    pub(super) fn ensure_temporary_window_visible_with_restore_target(
         &mut self,
         cx: &mut App,
+        restore_target: FocusRestoreTarget,
     ) -> Option<WindowHandle<Root>> {
-        with_temporary_window_state(cx, |state, cx| state.ensure_temporary_window_visible(cx))
-            .flatten()
+        with_temporary_window_state(cx, |state, cx| {
+            state.ensure_temporary_window_visible_with_restore_target(cx, restore_target)
+        })
+        .flatten()
     }
 
     pub(super) fn toggle_temporary_window(&mut self, cx: &mut App) {

--- a/app/ai-chat/src/hotkey/temporary_window.rs
+++ b/app/ai-chat/src/hotkey/temporary_window.rs
@@ -137,9 +137,9 @@ impl TemporaryWindowState {
             restore_target.restore_if_override();
             return false;
         }
-        window.activate_window();
         #[cfg(target_os = "macos")]
         self.prepare_front_app_for_visible_session(restore_target);
+        window.activate_window();
         true
     }
 

--- a/app/ai-chat/src/hotkey/temporary_window.rs
+++ b/app/ai-chat/src/hotkey/temporary_window.rs
@@ -71,6 +71,13 @@ impl TemporaryWindowState {
         }
     }
 
+    #[cfg(target_os = "macos")]
+    fn adopt_front_app(&mut self, front_app: Option<Retained<NSRunningApplication>>) {
+        if self.front_app.is_none() {
+            self.front_app = front_app;
+        }
+    }
+
     pub fn request_hide_with_delay(window: &mut Window, cx: &mut App) {
         let _ = with_temporary_window_state(cx, |hotkeys, cx| {
             hotkeys.delay_or_hide_temporary_window(window, cx);
@@ -211,6 +218,18 @@ impl GlobalHotkeyState {
     pub(crate) fn restore_and_clear_front_app_for_screenshot(&mut self) {
         restore_frontmost_app(&self.front_app);
         self.front_app = None;
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(crate) fn transfer_front_app_from_screenshot_to_temporary_window(&mut self, cx: &mut App) {
+        let front_app = self.front_app.take();
+        if front_app.is_none() {
+            return;
+        }
+
+        let _ = with_temporary_window_state(cx, |state, _cx| {
+            state.adopt_front_app(front_app);
+        });
     }
 
     pub(super) fn ensure_temporary_window_visible(

--- a/app/ai-chat/src/hotkey/temporary_window.rs
+++ b/app/ai-chat/src/hotkey/temporary_window.rs
@@ -109,10 +109,6 @@ impl TemporaryWindowState {
         if let Err(err) = window.move_and_resize(target_bounds, target_display_id) {
             event!(Level::ERROR, error = ?err, "Failed to reposition temporary window");
         }
-        if let Err(err) = window.show() {
-            window.activate_window();
-            event!(Level::ERROR, "Failed to show temporary window: {:?}", err);
-        };
         window.activate_window();
     }
 
@@ -122,7 +118,7 @@ impl TemporaryWindowState {
         let target_display_id = target_display_id(cx);
         match cx.open_window(
             WindowOptions {
-                kind: WindowKind::Floating,
+                kind: WindowKind::PopUp,
                 titlebar: Some(TitlebarOptions {
                     title: None,
                     appears_transparent: true,
@@ -138,10 +134,6 @@ impl TemporaryWindowState {
                 ..Default::default()
             },
             |window, cx| {
-                window.activate_window();
-                if let Err(err) = window.set_floating() {
-                    event!(Level::ERROR, error = ?err, "Failed to set floating");
-                }
                 let view = cx.new(|cx| TemporaryView::new(window, cx));
                 cx.new(|cx| Root::new(view, window, cx))
             },

--- a/app/ai-chat/src/views/screenshot/overlay.rs
+++ b/app/ai-chat/src/views/screenshot/overlay.rs
@@ -1,15 +1,16 @@
 use crate::{
+    database::GlobalShortcutBinding,
+    hotkey::GlobalHotkeyState,
     platform::{
         capture::{CaptureDisplay, CaptureError, CaptureRect, capture_region},
         display::target_display,
     },
-    database::GlobalShortcutBinding,
-    hotkey::GlobalHotkeyState,
 };
 use gpui::*;
 use std::cmp::{max, min};
 use std::time::Duration;
 use tracing::{Level, event};
+use window_ext::WindowExt;
 
 actions!(screenshot_overlay, [CancelScreenshotSelection]);
 
@@ -68,7 +69,7 @@ pub(crate) fn open(binding: GlobalShortcutBinding, cx: &mut App) -> Result<(), C
         WindowOptions {
             display_id: Some(display_id),
             window_bounds: Some(WindowBounds::Windowed(bounds)),
-            kind: WindowKind::PopUp,
+            kind: WindowKind::Floating,
             titlebar: Some(TitlebarOptions {
                 title: None,
                 appears_transparent: true,
@@ -84,6 +85,15 @@ pub(crate) fn open(binding: GlobalShortcutBinding, cx: &mut App) -> Result<(), C
             ..Default::default()
         },
         move |window, cx| {
+            if let Err(err) = window.set_floating() {
+                event!(
+                    Level::ERROR,
+                    display_id = display_info.id_hint,
+                    error = ?err,
+                    "Failed to set screenshot overlay window floating"
+                );
+            }
+            window.activate_window();
             let display_id = display_info.id_hint;
             event!(
                 Level::INFO,
@@ -156,6 +166,7 @@ pub(crate) struct ScreenshotOverlayView {
     drag_current: Option<Point<Pixels>>,
     selection_started: bool,
     focus_handle: FocusHandle,
+    _subscriptions: Vec<Subscription>,
 }
 
 fn offset_capture_rect(
@@ -190,12 +201,35 @@ impl ScreenshotOverlayView {
     fn new(display: CaptureDisplay, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let focus_handle = cx.focus_handle();
         focus_handle.focus(window, cx);
+        let subscriptions = vec![cx.observe_window_activation(window, |this, window, _cx| {
+            if !window.is_window_active() {
+                return;
+            }
+            if let Err(err) = window.set_crosshair_cursor_rect() {
+                event!(
+                    Level::ERROR,
+                    display_id = this.display.id_hint,
+                    error = ?err,
+                    "Failed to set screenshot overlay cursor rect"
+                );
+            }
+        })];
+        if let Err(err) = window.set_crosshair_cursor_rect() {
+            let display_id = display.id_hint;
+            event!(
+                Level::ERROR,
+                display_id,
+                error = ?err,
+                "Failed to set screenshot overlay cursor rect"
+            );
+        }
         Self {
             display,
             drag_origin: None,
             drag_current: None,
             selection_started: false,
             focus_handle,
+            _subscriptions: subscriptions,
         }
     }
 
@@ -323,6 +357,15 @@ impl ScreenshotOverlayView {
             return;
         };
 
+        if let Err(err) = window.clear_cursor_rects() {
+            event!(
+                Level::ERROR,
+                display_id = self.display.id_hint,
+                error = ?err,
+                "Failed to clear screenshot overlay cursor rect"
+            );
+        }
+
         // Remove the current overlay window directly — this is the only safe way to do it
         // from within the window's own event handler.
         window.remove_window();
@@ -394,6 +437,13 @@ impl Render for ScreenshotOverlayView {
 }
 
 fn cancel_overlay(window: &mut Window, cx: &mut Context<ScreenshotOverlayView>) {
+    if let Err(err) = window.clear_cursor_rects() {
+        event!(
+            Level::ERROR,
+            error = ?err,
+            "Failed to clear screenshot overlay cursor rect"
+        );
+    }
     cx.update_global::<ScreenshotOverlayState, _>(|state, cx| {
         if let Some(session) = state.session.take() {
             session.close_all(cx);

--- a/app/ai-chat/src/views/screenshot/overlay.rs
+++ b/app/ai-chat/src/views/screenshot/overlay.rs
@@ -10,7 +10,6 @@ use gpui::*;
 use std::cmp::{max, min};
 use std::time::Duration;
 use tracing::{Level, event};
-use window_ext::WindowExt;
 
 actions!(screenshot_overlay, [CancelScreenshotSelection]);
 
@@ -69,7 +68,7 @@ pub(crate) fn open(binding: GlobalShortcutBinding, cx: &mut App) -> Result<(), C
         WindowOptions {
             display_id: Some(display_id),
             window_bounds: Some(WindowBounds::Windowed(bounds)),
-            kind: WindowKind::Floating,
+            kind: WindowKind::PopUp,
             titlebar: Some(TitlebarOptions {
                 title: None,
                 appears_transparent: true,
@@ -85,15 +84,6 @@ pub(crate) fn open(binding: GlobalShortcutBinding, cx: &mut App) -> Result<(), C
             ..Default::default()
         },
         move |window, cx| {
-            if let Err(err) = window.set_floating() {
-                event!(
-                    Level::ERROR,
-                    display_id = display_info.id_hint,
-                    error = ?err,
-                    "Failed to set screenshot overlay window floating"
-                );
-            }
-            window.activate_window();
             let display_id = display_info.id_hint;
             event!(
                 Level::INFO,
@@ -200,15 +190,6 @@ impl ScreenshotOverlayView {
     fn new(display: CaptureDisplay, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let focus_handle = cx.focus_handle();
         focus_handle.focus(window, cx);
-        if let Err(err) = window.set_crosshair_cursor_rect() {
-            let display_id = display.id_hint;
-            event!(
-                Level::ERROR,
-                display_id,
-                error = ?err,
-                "Failed to set screenshot overlay cursor rect"
-            );
-        }
         Self {
             display,
             drag_origin: None,
@@ -342,15 +323,6 @@ impl ScreenshotOverlayView {
             return;
         };
 
-        if let Err(err) = window.clear_cursor_rects() {
-            event!(
-                Level::ERROR,
-                display_id = self.display.id_hint,
-                error = ?err,
-                "Failed to clear screenshot overlay cursor rect"
-            );
-        }
-
         // Remove the current overlay window directly — this is the only safe way to do it
         // from within the window's own event handler.
         window.remove_window();
@@ -422,13 +394,6 @@ impl Render for ScreenshotOverlayView {
 }
 
 fn cancel_overlay(window: &mut Window, cx: &mut Context<ScreenshotOverlayView>) {
-    if let Err(err) = window.clear_cursor_rects() {
-        event!(
-            Level::ERROR,
-            error = ?err,
-            "Failed to clear screenshot overlay cursor rect"
-        );
-    }
     cx.update_global::<ScreenshotOverlayState, _>(|state, cx| {
         if let Some(session) = state.session.take() {
             session.close_all(cx);

--- a/app/ai-chat/src/views/screenshot/overlay.rs
+++ b/app/ai-chat/src/views/screenshot/overlay.rs
@@ -200,6 +200,15 @@ impl ScreenshotOverlayView {
     fn new(display: CaptureDisplay, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let focus_handle = cx.focus_handle();
         focus_handle.focus(window, cx);
+        if let Err(err) = window.set_crosshair_cursor_rect() {
+            let display_id = display.id_hint;
+            event!(
+                Level::ERROR,
+                display_id,
+                error = ?err,
+                "Failed to set screenshot overlay cursor rect"
+            );
+        }
         Self {
             display,
             drag_origin: None,
@@ -333,6 +342,15 @@ impl ScreenshotOverlayView {
             return;
         };
 
+        if let Err(err) = window.clear_cursor_rects() {
+            event!(
+                Level::ERROR,
+                display_id = self.display.id_hint,
+                error = ?err,
+                "Failed to clear screenshot overlay cursor rect"
+            );
+        }
+
         // Remove the current overlay window directly — this is the only safe way to do it
         // from within the window's own event handler.
         window.remove_window();
@@ -404,6 +422,13 @@ impl Render for ScreenshotOverlayView {
 }
 
 fn cancel_overlay(window: &mut Window, cx: &mut Context<ScreenshotOverlayView>) {
+    if let Err(err) = window.clear_cursor_rects() {
+        event!(
+            Level::ERROR,
+            error = ?err,
+            "Failed to clear screenshot overlay cursor rect"
+        );
+    }
     cx.update_global::<ScreenshotOverlayState, _>(|state, cx| {
         if let Some(session) = state.session.take() {
             session.close_all(cx);

--- a/crates/window-ext/src/lib.rs
+++ b/crates/window-ext/src/lib.rs
@@ -175,10 +175,10 @@ impl WindowExt for Window {
     }
 
     fn set_crosshair_cursor_rect(&self) -> Result<(), WindowExtError> {
-        let raw_window = get_raw_window(self)?;
-        if let RawWindowHandle::AppKit(handle) = raw_window {
-            #[cfg(target_os = "macos")]
-            {
+        #[cfg(target_os = "macos")]
+        {
+            let raw_window = get_raw_window(self)?;
+            if let RawWindowHandle::AppKit(handle) = raw_window {
                 let ns_view = get_ns_view(handle)?;
                 let cursor = NSCursor::crosshairCursor();
                 ns_view.discardCursorRects();
@@ -190,10 +190,10 @@ impl WindowExt for Window {
     }
 
     fn clear_cursor_rects(&self) -> Result<(), WindowExtError> {
-        let raw_window = get_raw_window(self)?;
-        if let RawWindowHandle::AppKit(handle) = raw_window {
-            #[cfg(target_os = "macos")]
-            {
+        #[cfg(target_os = "macos")]
+        {
+            let raw_window = get_raw_window(self)?;
+            if let RawWindowHandle::AppKit(handle) = raw_window {
                 let ns_view = get_ns_view(handle)?;
                 ns_view.discardCursorRects();
                 NSCursor::arrowCursor().set();

--- a/crates/window-ext/src/lib.rs
+++ b/crates/window-ext/src/lib.rs
@@ -40,6 +40,7 @@ pub enum WindowExtError {
 pub trait WindowExt {
     fn hide(&self) -> Result<(), WindowExtError>;
     fn show(&self) -> Result<(), WindowExtError>;
+    fn show_without_activation(&self) -> Result<(), WindowExtError>;
     fn set_floating(&self) -> Result<(), WindowExtError>;
     fn set_crosshair_cursor_rect(&self) -> Result<(), WindowExtError>;
     fn clear_cursor_rects(&self) -> Result<(), WindowExtError>;
@@ -91,6 +92,32 @@ impl WindowExt for Window {
                         MainThreadMarker::new().ok_or(WindowExtError::FailedToGetNSApplication)?,
                     );
                     ns_app.activate();
+                }
+            }
+            #[allow(unused_variables)]
+            RawWindowHandle::Win32(handle) => {
+                #[cfg(target_os = "windows")]
+                {
+                    let hwnd = HWND(handle.hwnd.get() as _);
+                    unsafe {
+                        let _ = ShowWindow(hwnd, SW_SHOW);
+                    };
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn show_without_activation(&self) -> Result<(), WindowExtError> {
+        let raw_window = get_raw_window(self)?;
+        match raw_window {
+            #[allow(unused_variables)]
+            RawWindowHandle::AppKit(handle) => {
+                #[cfg(target_os = "macos")]
+                {
+                    let ns_window = get_ns_window(handle)?;
+                    ns_window.orderFront(None);
                 }
             }
             #[allow(unused_variables)]

--- a/crates/window-ext/src/lib.rs
+++ b/crates/window-ext/src/lib.rs
@@ -3,7 +3,7 @@ use gpui::{Bounds, DisplayId, Pixels, Window};
 #[cfg(target_os = "macos")]
 use objc2::{MainThreadMarker, rc::Id};
 #[cfg(target_os = "macos")]
-use objc2_app_kit::{NSApplication, NSCursor, NSScreen, NSView, NSWindow};
+use objc2_app_kit::{NSApplication, NSScreen, NSView, NSWindow};
 #[cfg(target_os = "macos")]
 use raw_window_handle::AppKitWindowHandle;
 use raw_window_handle::{HandleError, HasRawWindowHandle, RawWindowHandle};
@@ -14,8 +14,7 @@ use windows::Win32::{
     Graphics::Gdi::{EnumDisplayMonitors, HDC, HMONITOR},
     UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI},
     UI::WindowsAndMessaging::{
-        HWND_TOPMOST, SW_HIDE, SW_SHOW, SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER, SetWindowPos,
-        ShowWindow, USER_DEFAULT_SCREEN_DPI,
+        SW_HIDE, SW_SHOW, SWP_NOZORDER, SetWindowPos, ShowWindow, USER_DEFAULT_SCREEN_DPI,
     },
 };
 #[cfg(target_os = "windows")]
@@ -31,8 +30,6 @@ pub enum WindowExtError {
     FailedToGetNSWindow,
     #[error("Failed to get NSApplication")]
     FailedToGetNSApplication,
-    #[error("Failed to set topmost")]
-    FailedSetTopMost,
     #[error("Failed to set window bounds")]
     FailedSetBounds,
 }
@@ -40,9 +37,6 @@ pub enum WindowExtError {
 pub trait WindowExt {
     fn hide(&self) -> Result<(), WindowExtError>;
     fn show(&self) -> Result<(), WindowExtError>;
-    fn set_floating(&self) -> Result<(), WindowExtError>;
-    fn set_crosshair_cursor_rect(&self) -> Result<(), WindowExtError>;
-    fn clear_cursor_rects(&self) -> Result<(), WindowExtError>;
     fn is_visible(&self) -> Result<bool, WindowExtError>;
     fn move_and_resize(
         &self,
@@ -107,73 +101,6 @@ impl WindowExt for Window {
         }
         Ok(())
     }
-    fn set_floating(&self) -> Result<(), WindowExtError> {
-        let raw_window = get_raw_window(self)?;
-        match raw_window {
-            #[allow(unused_variables)]
-            RawWindowHandle::AppKit(handle) => {
-                #[cfg(target_os = "macos")]
-                {
-                    let ns_window = get_ns_window(handle)?;
-                    ns_window.setLevel(5 as _);
-                    let ns_app = NSApplication::sharedApplication(
-                        MainThreadMarker::new().ok_or(WindowExtError::FailedToGetNSApplication)?,
-                    );
-                    ns_app.activate();
-                }
-            }
-            #[allow(unused_variables)]
-            RawWindowHandle::Win32(handle) => {
-                #[cfg(target_os = "windows")]
-                {
-                    let hwnd = HWND(handle.hwnd.get() as _);
-                    unsafe {
-                        SetWindowPos(
-                            hwnd,
-                            Some(HWND_TOPMOST),
-                            0,
-                            0,
-                            0,
-                            0,
-                            SWP_NOSIZE | SWP_NOMOVE,
-                        )
-                        .map_err(|_| WindowExtError::FailedSetTopMost)?;
-                    }
-                }
-            }
-            _ => (),
-        }
-        Ok(())
-    }
-
-    fn set_crosshair_cursor_rect(&self) -> Result<(), WindowExtError> {
-        let raw_window = get_raw_window(self)?;
-        if let RawWindowHandle::AppKit(handle) = raw_window {
-            #[cfg(target_os = "macos")]
-            {
-                let ns_view = get_ns_view(handle)?;
-                let cursor = NSCursor::crosshairCursor();
-                ns_view.discardCursorRects();
-                ns_view.addCursorRect_cursor(ns_view.bounds(), &cursor);
-                cursor.set();
-            }
-        }
-        Ok(())
-    }
-
-    fn clear_cursor_rects(&self) -> Result<(), WindowExtError> {
-        let raw_window = get_raw_window(self)?;
-        if let RawWindowHandle::AppKit(handle) = raw_window {
-            #[cfg(target_os = "macos")]
-            {
-                let ns_view = get_ns_view(handle)?;
-                ns_view.discardCursorRects();
-                NSCursor::arrowCursor().set();
-            }
-        }
-        Ok(())
-    }
-
     fn is_visible(&self) -> Result<bool, WindowExtError> {
         let raw_window = get_raw_window(self)?;
         match raw_window {

--- a/crates/window-ext/src/lib.rs
+++ b/crates/window-ext/src/lib.rs
@@ -3,7 +3,7 @@ use gpui::{Bounds, DisplayId, Pixels, Window};
 #[cfg(target_os = "macos")]
 use objc2::{MainThreadMarker, rc::Id};
 #[cfg(target_os = "macos")]
-use objc2_app_kit::{NSApplication, NSScreen, NSView, NSWindow};
+use objc2_app_kit::{NSApplication, NSCursor, NSScreen, NSView, NSWindow};
 #[cfg(target_os = "macos")]
 use raw_window_handle::AppKitWindowHandle;
 use raw_window_handle::{HandleError, HasRawWindowHandle, RawWindowHandle};
@@ -14,7 +14,8 @@ use windows::Win32::{
     Graphics::Gdi::{EnumDisplayMonitors, HDC, HMONITOR},
     UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI},
     UI::WindowsAndMessaging::{
-        SW_HIDE, SW_SHOW, SWP_NOZORDER, SetWindowPos, ShowWindow, USER_DEFAULT_SCREEN_DPI,
+        HWND_TOPMOST, SW_HIDE, SW_SHOW, SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER, SetWindowPos,
+        ShowWindow, USER_DEFAULT_SCREEN_DPI,
     },
 };
 #[cfg(target_os = "windows")]
@@ -30,6 +31,8 @@ pub enum WindowExtError {
     FailedToGetNSWindow,
     #[error("Failed to get NSApplication")]
     FailedToGetNSApplication,
+    #[error("Failed to set topmost")]
+    FailedSetTopMost,
     #[error("Failed to set window bounds")]
     FailedSetBounds,
 }
@@ -37,6 +40,9 @@ pub enum WindowExtError {
 pub trait WindowExt {
     fn hide(&self) -> Result<(), WindowExtError>;
     fn show(&self) -> Result<(), WindowExtError>;
+    fn set_floating(&self) -> Result<(), WindowExtError>;
+    fn set_crosshair_cursor_rect(&self) -> Result<(), WindowExtError>;
+    fn clear_cursor_rects(&self) -> Result<(), WindowExtError>;
     fn is_visible(&self) -> Result<bool, WindowExtError>;
     fn move_and_resize(
         &self,
@@ -101,6 +107,74 @@ impl WindowExt for Window {
         }
         Ok(())
     }
+
+    fn set_floating(&self) -> Result<(), WindowExtError> {
+        let raw_window = get_raw_window(self)?;
+        match raw_window {
+            #[allow(unused_variables)]
+            RawWindowHandle::AppKit(handle) => {
+                #[cfg(target_os = "macos")]
+                {
+                    let ns_window = get_ns_window(handle)?;
+                    ns_window.setLevel(5 as _);
+                    let ns_app = NSApplication::sharedApplication(
+                        MainThreadMarker::new().ok_or(WindowExtError::FailedToGetNSApplication)?,
+                    );
+                    ns_app.activate();
+                }
+            }
+            #[allow(unused_variables)]
+            RawWindowHandle::Win32(handle) => {
+                #[cfg(target_os = "windows")]
+                {
+                    let hwnd = HWND(handle.hwnd.get() as _);
+                    unsafe {
+                        SetWindowPos(
+                            hwnd,
+                            Some(HWND_TOPMOST),
+                            0,
+                            0,
+                            0,
+                            0,
+                            SWP_NOSIZE | SWP_NOMOVE,
+                        )
+                        .map_err(|_| WindowExtError::FailedSetTopMost)?;
+                    }
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn set_crosshair_cursor_rect(&self) -> Result<(), WindowExtError> {
+        let raw_window = get_raw_window(self)?;
+        if let RawWindowHandle::AppKit(handle) = raw_window {
+            #[cfg(target_os = "macos")]
+            {
+                let ns_view = get_ns_view(handle)?;
+                let cursor = NSCursor::crosshairCursor();
+                ns_view.discardCursorRects();
+                ns_view.addCursorRect_cursor(ns_view.bounds(), &cursor);
+                cursor.set();
+            }
+        }
+        Ok(())
+    }
+
+    fn clear_cursor_rects(&self) -> Result<(), WindowExtError> {
+        let raw_window = get_raw_window(self)?;
+        if let RawWindowHandle::AppKit(handle) = raw_window {
+            #[cfg(target_os = "macos")]
+            {
+                let ns_view = get_ns_view(handle)?;
+                ns_view.discardCursorRects();
+                NSCursor::arrowCursor().set();
+            }
+        }
+        Ok(())
+    }
+
     fn is_visible(&self) -> Result<bool, WindowExtError> {
         let raw_window = get_raw_window(self)?;
         match raw_window {

--- a/crates/window-ext/src/lib.rs
+++ b/crates/window-ext/src/lib.rs
@@ -3,7 +3,7 @@ use gpui::{Bounds, DisplayId, Pixels, Window};
 #[cfg(target_os = "macos")]
 use objc2::{MainThreadMarker, rc::Id};
 #[cfg(target_os = "macos")]
-use objc2_app_kit::{NSApplication, NSScreen, NSView, NSWindow};
+use objc2_app_kit::{NSApplication, NSCursor, NSScreen, NSView, NSWindow};
 #[cfg(target_os = "macos")]
 use raw_window_handle::AppKitWindowHandle;
 use raw_window_handle::{HandleError, HasRawWindowHandle, RawWindowHandle};
@@ -41,6 +41,8 @@ pub trait WindowExt {
     fn hide(&self) -> Result<(), WindowExtError>;
     fn show(&self) -> Result<(), WindowExtError>;
     fn set_floating(&self) -> Result<(), WindowExtError>;
+    fn set_crosshair_cursor_rect(&self) -> Result<(), WindowExtError>;
+    fn clear_cursor_rects(&self) -> Result<(), WindowExtError>;
     fn is_visible(&self) -> Result<bool, WindowExtError>;
     fn move_and_resize(
         &self,
@@ -140,6 +142,34 @@ impl WindowExt for Window {
                 }
             }
             _ => (),
+        }
+        Ok(())
+    }
+
+    fn set_crosshair_cursor_rect(&self) -> Result<(), WindowExtError> {
+        let raw_window = get_raw_window(self)?;
+        if let RawWindowHandle::AppKit(handle) = raw_window {
+            #[cfg(target_os = "macos")]
+            {
+                let ns_view = get_ns_view(handle)?;
+                let cursor = NSCursor::crosshairCursor();
+                ns_view.discardCursorRects();
+                ns_view.addCursorRect_cursor(ns_view.bounds(), &cursor);
+                cursor.set();
+            }
+        }
+        Ok(())
+    }
+
+    fn clear_cursor_rects(&self) -> Result<(), WindowExtError> {
+        let raw_window = get_raw_window(self)?;
+        if let RawWindowHandle::AppKit(handle) = raw_window {
+            #[cfg(target_os = "macos")]
+            {
+                let ns_view = get_ns_view(handle)?;
+                ns_view.discardCursorRects();
+                NSCursor::arrowCursor().set();
+            }
         }
         Ok(())
     }
@@ -298,14 +328,20 @@ fn get_raw_window(window: &Window) -> Result<RawWindowHandle, WindowExtError> {
 fn get_ns_window(
     window: AppKitWindowHandle,
 ) -> Result<objc2::rc::Retained<NSWindow>, WindowExtError> {
-    let ns_view = window.ns_view.as_ptr();
-    let ns_view: Id<NSView> =
-        unsafe { Id::retain(ns_view.cast()) }.ok_or(WindowExtError::FailedToGetNSView)?;
+    let ns_view = get_ns_view(window)?;
     let ns_window = ns_view
         .window()
         .ok_or(WindowExtError::FailedToGetNSWindow)?;
 
     Ok(ns_window)
+}
+
+#[cfg(target_os = "macos")]
+fn get_ns_view(window: AppKitWindowHandle) -> Result<objc2::rc::Retained<NSView>, WindowExtError> {
+    let ns_view = window.ns_view.as_ptr();
+    let ns_view: Id<NSView> =
+        unsafe { Id::retain(ns_view.cast()) }.ok_or(WindowExtError::FailedToGetNSView)?;
+    Ok(ns_view)
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

- Restores the `ai-chat` screenshot overlay to an activating floating window so macOS can reliably apply the crosshair cursor.
- Keeps temporary shortcut windows on non-activating popup panels so they do not steal app/menu focus.
- Affected app/crate: `ai-chat`, `window-ext`.

## Motivation

The screenshot overlay cursor could remain or revert to the normal arrow when invoked by global shortcut. The root cause is that macOS non-activating panels do not reliably honor AppKit cursor updates for a full-window crosshair overlay. Screenshot capture needs an active floating overlay, while temporary chat windows can remain non-activating because their text cursor is driven by normal GPUI hover hitboxes.

## Changes

- Reopens the screenshot overlay as `WindowKind::Floating` and explicitly activates it when shown.
- Restores `WindowExt::set_floating()` so the screenshot overlay can stay above normal windows and activate the app on macOS.
- Registers and reapplies crosshair cursor rects for the overlay window, and clears them on cancel or capture.
- Preserves front-app restoration after screenshot capture and keeps temporary windows as popup/non-activating panels.

## Validation

- [ ] `cargo build`
- [ ] `cargo test`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
cargo test -p ai-chat views::screenshot::overlay
Result: passed, 5 tests.

cargo build -p ai-chat --profile release-fast
Result: passed.

cargo clippy -p ai-chat --all-targets -- -D warnings
Result: passed.

git diff --check
Result: passed.

Full workspace build/test/clippy and manual GUI verification were not run in this session.
```

## Risks

- Screenshot overlay activation may briefly make `ai-chat` the active app during selection; the existing front-app restoration flow handles returning focus afterward.
- `WindowExt::set_floating()` restores Windows topmost behavior as part of the shared extension method, but the current bug was validated on macOS.

## Related Issues

- Closes #55
