### PR TITLE
fix(ai-chat): make sidebar resize affect visual width

### DIFF
--- a/app/ai-chat/src/state/workspace.rs
+++ b/app/ai-chat/src/state/workspace.rs
@@ -18,6 +18,10 @@ use gpui::*;
 use std::{collections::BTreeSet, ops::Deref};
 use tracing::{Level, event};
 
+pub(crate) const SIDEBAR_MIN_WIDTH: Pixels = px(180.);
+pub(crate) const SIDEBAR_DEFAULT_WIDTH: Pixels = px(300.);
+pub(crate) const SIDEBAR_MAX_WIDTH: Pixels = px(420.);
+
 pub(crate) struct WorkspaceState {
     persisted: PersistedWorkspaceState,
     tabs: Vec<AppTab>,
@@ -39,11 +43,11 @@ impl WorkspaceState {
     }
 
     pub(crate) fn sidebar_width(&self) -> Pixels {
-        px(self.persisted.sidebar_width.max(100.))
+        clamp_sidebar_width(px(self.persisted.sidebar_width))
     }
 
     pub(crate) fn set_sidebar_width(&mut self, width: Pixels, cx: &mut Context<Self>) {
-        self.persisted.sidebar_width = f32::from(width.max(px(100.)));
+        self.persisted.sidebar_width = f32::from(clamp_sidebar_width(width));
         self.schedule_save(cx);
         cx.notify();
     }
@@ -345,6 +349,10 @@ impl WorkspaceState {
     pub(crate) fn open_folder_ids(&self) -> BTreeSet<i32> {
         self.persisted.open_folder_ids.clone()
     }
+}
+
+fn clamp_sidebar_width(width: Pixels) -> Pixels {
+    width.max(SIDEBAR_MIN_WIDTH).min(SIDEBAR_MAX_WIDTH)
 }
 
 pub(crate) struct WorkspaceStore {

--- a/app/ai-chat/src/state/workspace/persistence.rs
+++ b/app/ai-chat/src/state/workspace/persistence.rs
@@ -1,4 +1,4 @@
-use super::{TabKind, WorkspaceState};
+use super::{SIDEBAR_DEFAULT_WIDTH, TabKind, WorkspaceState};
 use crate::{
     app::APP_NAME,
     database::Mode,
@@ -11,7 +11,6 @@ use tracing::{Level, event};
 
 const STATE_FILE_NAME: &str = "state.toml";
 const STATE_VERSION: u32 = 1;
-const DEFAULT_SIDEBAR_WIDTH: f32 = 300.;
 const SAVE_DEBOUNCE: Duration = Duration::from_millis(300);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -115,7 +114,7 @@ impl Default for PersistedWorkspaceState {
     fn default() -> Self {
         Self {
             version: STATE_VERSION,
-            sidebar_width: DEFAULT_SIDEBAR_WIDTH,
+            sidebar_width: default_sidebar_width(),
             open_folder_ids: Default::default(),
             tabs: Vec::new(),
             active_tab: None,
@@ -286,7 +285,7 @@ fn default_state_version() -> u32 {
 }
 
 fn default_sidebar_width() -> f32 {
-    DEFAULT_SIDEBAR_WIDTH
+    f32::from(SIDEBAR_DEFAULT_WIDTH)
 }
 
 fn serialize_request_template<S>(

--- a/app/ai-chat/src/state/workspace/tests.rs
+++ b/app/ai-chat/src/state/workspace/tests.rs
@@ -1,4 +1,7 @@
-use super::{ConversationDraft, PersistedWorkspaceState, WorkspaceState, persistence::*};
+use super::{
+    ConversationDraft, PersistedWorkspaceState, SIDEBAR_DEFAULT_WIDTH, SIDEBAR_MAX_WIDTH,
+    SIDEBAR_MIN_WIDTH, WorkspaceState, persistence::*,
+};
 use crate::database::Mode;
 
 fn sample_request_template() -> serde_json::Value {
@@ -126,6 +129,41 @@ sidebar_width = 300.0
     .unwrap();
 
     assert_eq!(state.latest_model_preset, None);
+}
+
+#[test]
+fn sidebar_width_clamps_persisted_values() {
+    let below_min = WorkspaceState {
+        persisted: PersistedWorkspaceState {
+            sidebar_width: f32::from(SIDEBAR_MIN_WIDTH) - 1.,
+            ..PersistedWorkspaceState::default()
+        },
+        tabs: Vec::new(),
+        active_tab: None,
+        save_task: None,
+    };
+    let above_max = WorkspaceState {
+        persisted: PersistedWorkspaceState {
+            sidebar_width: f32::from(SIDEBAR_MAX_WIDTH) + 1.,
+            ..PersistedWorkspaceState::default()
+        },
+        tabs: Vec::new(),
+        active_tab: None,
+        save_task: None,
+    };
+    let normal = WorkspaceState {
+        persisted: PersistedWorkspaceState {
+            sidebar_width: f32::from(SIDEBAR_DEFAULT_WIDTH),
+            ..PersistedWorkspaceState::default()
+        },
+        tabs: Vec::new(),
+        active_tab: None,
+        save_task: None,
+    };
+
+    assert_eq!(below_min.sidebar_width(), SIDEBAR_MIN_WIDTH);
+    assert_eq!(above_max.sidebar_width(), SIDEBAR_MAX_WIDTH);
+    assert_eq!(normal.sidebar_width(), SIDEBAR_DEFAULT_WIDTH);
 }
 
 #[test]

--- a/app/ai-chat/src/views/home.rs
+++ b/app/ai-chat/src/views/home.rs
@@ -186,6 +186,10 @@ impl Render for HomeView {
                                 .child(
                                     resizable_panel()
                                         .size(sidebar_width)
+                                        .size_range(
+                                            state::workspace::SIDEBAR_MIN_WIDTH
+                                                ..state::workspace::SIDEBAR_MAX_WIDTH,
+                                        )
                                         .child(self.sidebar.clone()),
                                 )
                                 .child(self.tabs.clone().into_any_element()),

--- a/app/ai-chat/src/views/home/sidebar.rs
+++ b/app/ai-chat/src/views/home/sidebar.rs
@@ -121,6 +121,8 @@ impl Render for SidebarView {
                 Sidebar::new("sidebar")
                     .side(Side::Left)
                     .w_full()
+                    .collapsible(false)
+                    .collapsed(false)
                     .header(SidebarHeader::new().child(app_title))
                     .child(SidebarSection::Tree(
                         SidebarGroup::new(conversation_tree_title).child(


### PR DESCRIPTION
## Summary

- Affected app: `ai-chat`.
- Fix sidebar resize so dragging the divider changes the visual sidebar width instead of only shrinking/growing the main content area.
- Clamp persisted sidebar widths to a shared min/default/max range.

## Motivation

- Fixes #68.
- Related to #66.
- The outer `ResizablePanel` width was changing, but `gpui_component::Sidebar` kept its internal collapsible transition wrapper at the default width because ai-chat passed `.w_full()` rather than an absolute pixel width.

## Changes

- Disabled the unused `Sidebar` collapsible wrapper for the ai-chat home sidebar.
- Added a sidebar panel size range of `180px..420px`.
- Centralized sidebar width constants and clamped persisted width reads/writes.
- Added a focused test for persisted sidebar width clamping.

## Validation

- [x] `cargo build`
- [x] `cargo test`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
cargo fmt: passed
cargo test -p ai-chat sidebar_width: passed
cargo test -p ai-chat home: passed
cargo build -p ai-chat: passed
git diff --check: passed

Manual verification note: not completed in this pass because existing old AI Chat instances can cause Computer Use to attach to `/Applications/AI Chat.app` instead of the current branch binary. The resize behavior should be manually rechecked after closing or isolating old instances.
```

## Risks

- The sidebar can now resize only within `180px..420px`; values outside that range are clamped on restore/save.
- Disabling the internal `Sidebar` collapsible wrapper is expected to be safe because ai-chat does not expose a sidebar collapse/expand UI.

## Related Issues

- Closes #68
- Related to #66