### PR TITLE
[bug] ai-chat: fix template detail scrolling

### DIFF
--- a/app/ai-chat/src/views/home/tabs/template_detail.rs
+++ b/app/ai-chat/src/views/home/tabs/template_detail.rs
@@ -17,7 +17,6 @@ use gpui_component::{
     h_flex,
     label::Label,
     notification::{Notification, NotificationType},
-    scroll::ScrollableElement,
     text::TextView,
     v_flex,
 };
@@ -192,8 +191,10 @@ impl Render for TemplateDetailView {
         let reload_label = cx.global::<I18n>().t("button-reload");
         v_flex()
             .size_full()
+            .overflow_hidden()
             .child(
                 h_flex()
+                    .flex_initial()
                     .items_center()
                     .justify_end()
                     .gap_2()
@@ -232,7 +233,8 @@ impl Render for TemplateDetailView {
             .child(match &self.template {
                 Ok(template) => render_template_detail(template, window, cx),
                 Err(err) => v_flex()
-                    .size_full()
+                    .flex_1()
+                    .min_h_0()
                     .items_center()
                     .justify_center()
                     .child(Label::new(format!("{load_template_failed}: {err}")).text_sm())
@@ -257,11 +259,13 @@ fn render_template_detail(
             .span(3),
     ];
 
-    div()
+    v_flex()
         .id(template.id)
         .flex_1()
+        .min_h_0()
         .gap_3()
         .px_4()
+        .py_3()
         .child(Label::new(i18n.t("section-information")).text_lg())
         .child(
             div().child(
@@ -272,21 +276,13 @@ fn render_template_detail(
             ),
         )
         .child(Label::new(i18n.t("field-prompts")).text_lg())
-        .child(
-            div().id("template-prompts").children(
-                template
-                    .prompts
-                    .iter()
-                    .enumerate()
-                    .map(|(index, prompt)| {
-                        render_prompt_message(template.id, index, prompt, window, cx)
-                    })
-                    .collect::<Vec<_>>(),
-            ),
-        )
-        .child(div().h_4())
-        .overflow_hidden()
-        .overflow_y_scrollbar()
+        .child(v_flex().id("template-prompts").children(
+            template.prompts.iter().enumerate().map(|(index, prompt)| {
+                render_prompt_message(template.id, index, prompt, window, cx)
+            }),
+        ))
+        .overflow_x_hidden()
+        .overflow_y_scroll()
         .into_any_element()
 }
 


### PR DESCRIPTION
## Summary

- Fixed the `ai-chat` template detail tab so long template content scrolls instead of being clipped.
- Affected app: `ai-chat`.

## Motivation

- Addresses issue #69, where templates with long descriptions or many prompt messages could extend past the tab body and become inaccessible because the detail content did not establish a reliable scroll container.

## Changes

- Constrained `TemplateDetailView` with an overflow-hidden root and fixed-height toolbar behavior.
- Changed the template detail body to a bounded `v_flex` scroll region with `flex_1` and `min_h_0`.
- Switched the detail content to GPUI native vertical scrolling so the content keeps its natural height and can produce a real scroll range.
- Converted the prompt list to a vertical flex container and removed the trailing spacer used to compensate for clipping.

## Validation

- [x] `cargo build`
- [ ] `cargo test`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
cargo fmt
passed

cargo test -p ai-chat template_detail
passed; 0 tests matched, 207 filtered out

cargo test -p ai-chat home
passed; 29 passed, 178 filtered out

cargo build -p ai-chat
passed

Full cargo test, clippy, and final manual UI verification were not run in this step.
```

## Risks

- Uses GPUI native `overflow_y_scroll()` rather than the gpui-component scrollbar wrapper for this view because the wrapper can force the content element into `flex_1`, preventing long natural content from producing a usable scroll range.
- Visual verification is still needed with a long template detail page in the current branch build.

## Related Issues

- Closes #69
- Related to #66
