### PR TITLE
[bug] ai-chat: fix sidebar context menu scope

### DIFF
--- a/app/ai-chat/src/views/home/sidebar.rs
+++ b/app/ai-chat/src/views/home/sidebar.rs
@@ -8,7 +8,6 @@ use crate::{
 use gpui::*;
 use gpui_component::{
     Collapsible, Side,
-    menu::ContextMenuExt,
     sidebar::{Sidebar, SidebarGroup, SidebarHeader, SidebarItem, SidebarMenu, SidebarMenuItem},
     v_flex,
 };
@@ -98,7 +97,6 @@ impl Render for SidebarView {
             template_list_label,
             add_conversation_label,
             add_folder_label,
-            root_label,
         ) = {
             let i18n = cx.global::<I18n>();
             (
@@ -110,9 +108,9 @@ impl Render for SidebarView {
                 i18n.t("sidebar-template-list"),
                 i18n.t("sidebar-add-conversation"),
                 i18n.t("sidebar-add-folder"),
-                i18n.t("sidebar-root"),
             )
         };
+        let root_label = cx.global::<I18n>().t("sidebar-root");
         v_flex()
             .key_context(CONTEXT)
             .track_focus(&self.focus_handle)
@@ -204,17 +202,5 @@ impl Render for SidebarView {
                         ),
                     )),
             )
-            .context_menu(move |this, _window, _cx| {
-                let add_conversation_label = add_conversation_label.clone();
-                let add_folder_label = add_folder_label.clone();
-                this.check_side(Side::Left)
-                    .external_link_icon(false)
-                    .menu_with_icon(
-                        add_conversation_label,
-                        IconName::Plus,
-                        Box::new(AddConversation),
-                    )
-                    .menu_with_icon(add_folder_label, IconName::Plus, Box::new(AddFolder))
-            })
     }
 }

--- a/app/ai-chat/src/views/home/sidebar/conversation_tree.rs
+++ b/app/ai-chat/src/views/home/sidebar/conversation_tree.rs
@@ -5,6 +5,7 @@ use crate::{
         add_conversation::open_add_conversation_dialog, add_folder::open_add_folder_dialog,
     },
     database::{Conversation, Folder},
+    i18n::I18n,
     state::{ChatData, ChatDataEvent, ChatDataInner},
 };
 use gpui::{prelude::FluentBuilder as _, *};
@@ -253,7 +254,8 @@ impl SidebarItem for ConversationTree {
                             .justify_center()
                             .text_sm()
                             .text_color(cx.theme().muted_foreground)
-                            .child(root_label),
+                            .child(root_label)
+                            .context_menu(root_context_menu),
                     )
                     .on_drag_move::<DragConversationTreeItem>({
                         move |event, window, cx| {
@@ -275,10 +277,8 @@ impl SidebarItem for ConversationTree {
                             return;
                         }
                         drag.move_to_root(cx);
-                    })
-                    .context_menu(root_context_menu),
+                    }),
             )
-            .context_menu(root_context_menu)
     }
 }
 
@@ -486,16 +486,17 @@ impl Render for DragConversationTreeItem {
 fn root_context_menu(
     menu: PopupMenu,
     _window: &mut Window,
-    _cx: &mut Context<PopupMenu>,
+    cx: &mut Context<PopupMenu>,
 ) -> PopupMenu {
+    let i18n = cx.global::<I18n>();
     menu.check_side(Side::Left)
         .item(
-            PopupMenuItem::new("Add Conversation")
+            PopupMenuItem::new(i18n.t("sidebar-add-conversation"))
                 .icon(IconName::Plus)
                 .on_click(|_, window, cx| open_add_conversation_dialog(None, None, window, cx)),
         )
         .item(
-            PopupMenuItem::new("Add Folder")
+            PopupMenuItem::new(i18n.t("sidebar-add-folder"))
                 .icon(IconName::Plus)
                 .on_click(|_, window, cx| open_add_folder_dialog(None, window, cx)),
         )


### PR DESCRIPTION
## Summary

- Fixed duplicate context menus when right-clicking `ai-chat` sidebar folders and conversations.
- Affected app: `ai-chat`.

## Motivation

- Addresses issue #70, where nested `ContextMenuExt` handlers could all respond to the same right-click event because the GPUI component context menu opens during bubble phase without stopping propagation.
- Also fixes the root sidebar context menu labels so they use existing localization keys.

## Changes

- Removed the sidebar-wide context menu from `SidebarView`.
- Removed the root context menu from ancestor `ConversationTree` containers.
- Kept the root add menu only on the root/drop placeholder row.
- Kept folder and conversation row context menus unchanged.
- Localized the root menu labels with `sidebar-add-conversation` and `sidebar-add-folder`.

## Validation

- [x] `cargo build`
- [ ] `cargo test`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
cargo fmt
passed

cargo test -p ai-chat conversation_tree
passed; 14 passed, 193 filtered out

cargo test -p ai-chat sidebar
passed; 15 passed, 192 filtered out

cargo build -p ai-chat
passed

Full cargo test, clippy, and final manual UI verification were not run in this step.
```

## Risks

- The root add menu is intentionally limited to the root/drop placeholder row, so right-clicking unrelated sidebar action items no longer opens the add menu.
- Right-click menu uniqueness still needs manual UI verification because there is no stable lightweight unit test for rendered context-menu count.

## Related Issues

- Closes #70
- Related to #66
