### PR TITLE
[bug] ai-chat: persist main and settings window bounds

### DIFF
--- a/app/ai-chat/src/app.rs
+++ b/app/ai-chat/src/app.rs
@@ -11,6 +11,7 @@ use tracing_subscriber::{Layer, fmt, layer::SubscriberExt, util::SubscriberInitE
 use window_ext::WindowExt;
 
 pub(crate) static APP_NAME: &str = "top.sushao.ai-chat";
+const MAIN_WINDOW_FALLBACK_SIZE: Size<Pixels> = size(px(1536.), px(864.));
 
 #[cfg(feature = "dhat-heap")]
 mod profiling {
@@ -170,8 +171,15 @@ fn reveal_main_window(root: &mut Root, window: &mut Window, cx: &mut Context<Roo
 
 pub(crate) fn open_main_window(cx: &mut App) -> Result<WindowHandle<Root>, anyhow::Error> {
     let title = cx.global::<I18n>().t("app-title");
+    let placement = state::workspace::restored_window_placement(
+        state::workspace::WindowPlacementKind::Main,
+        MAIN_WINDOW_FALLBACK_SIZE,
+        cx,
+    );
     cx.open_window(
         WindowOptions {
+            window_bounds: Some(placement.window_bounds),
+            display_id: placement.display_id,
             titlebar: Some(TitlebarOptions {
                 title: Some(title.into()),
                 ..TitleBar::title_bar_options()

--- a/app/ai-chat/src/state.rs
+++ b/app/ai-chat/src/state.rs
@@ -8,4 +8,6 @@ pub(crate) use chat::{
     ModelStore, ModelStoreSnapshot, ModelStoreStatus,
 };
 pub(crate) use config::{AiChatConfig, Language, ThemeMode};
-pub(crate) use workspace::{ConversationDraft, WorkspaceState, WorkspaceStore};
+pub(crate) use workspace::{
+    ConversationDraft, WindowPlacementKind, WorkspaceState, WorkspaceStore,
+};

--- a/app/ai-chat/src/state/workspace.rs
+++ b/app/ai-chat/src/state/workspace.rs
@@ -5,7 +5,10 @@ mod tests;
 
 pub(crate) use self::persistence::ConversationDraft;
 use self::{
-    persistence::PersistedWorkspaceState,
+    persistence::{
+        PersistedWindowBounds, PersistedWorkspaceState, WindowDisplaySnapshot,
+        fallback_display_id_for_persisted_window, resolve_persisted_window_bounds,
+    },
     tabs::{AppTab, TabKind, TabPanel},
 };
 
@@ -21,6 +24,18 @@ use tracing::{Level, event};
 pub(crate) const SIDEBAR_MIN_WIDTH: Pixels = px(180.);
 pub(crate) const SIDEBAR_DEFAULT_WIDTH: Pixels = px(300.);
 pub(crate) const SIDEBAR_MAX_WIDTH: Pixels = px(420.);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WindowPlacementKind {
+    Main,
+    Settings,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct WindowPlacement {
+    pub(crate) window_bounds: WindowBounds,
+    pub(crate) display_id: Option<DisplayId>,
+}
 
 pub(crate) struct WorkspaceState {
     persisted: PersistedWorkspaceState,
@@ -50,6 +65,38 @@ impl WorkspaceState {
         self.persisted.sidebar_width = f32::from(clamp_sidebar_width(width));
         self.schedule_save(cx);
         cx.notify();
+    }
+
+    pub(crate) fn set_window_bounds(
+        &mut self,
+        kind: WindowPlacementKind,
+        window_bounds: WindowBounds,
+        display_id: Option<DisplayId>,
+        cx: &mut Context<Self>,
+    ) {
+        let next = PersistedWindowBounds::from_window_bounds(window_bounds, display_id);
+        if self.update_persisted_window_bounds(kind, next) {
+            self.schedule_save(cx);
+        }
+    }
+
+    fn update_persisted_window_bounds(
+        &mut self,
+        kind: WindowPlacementKind,
+        next: PersistedWindowBounds,
+    ) -> bool {
+        let next = Some(next);
+        let current = match kind {
+            WindowPlacementKind::Main => &mut self.persisted.main_window_bounds,
+            WindowPlacementKind::Settings => &mut self.persisted.settings_window_bounds,
+        };
+
+        if *current == next {
+            return false;
+        }
+
+        *current = next;
+        true
     }
 
     pub(crate) fn toggle_folder_open(&mut self, folder_id: i32, cx: &mut Context<Self>) {
@@ -368,6 +415,72 @@ impl Deref for WorkspaceStore {
 }
 
 impl Global for WorkspaceStore {}
+
+pub(crate) fn restored_window_placement(
+    kind: WindowPlacementKind,
+    fallback_size: Size<Pixels>,
+    cx: &App,
+) -> WindowPlacement {
+    let persisted = if cx.has_global::<WorkspaceStore>() {
+        cx.global::<WorkspaceStore>().read(cx).persisted.clone()
+    } else {
+        WorkspaceState::load_persisted().unwrap_or_default()
+    };
+    restored_window_placement_from_state(&persisted, kind, fallback_size, cx)
+}
+
+fn restored_window_placement_from_state(
+    persisted: &PersistedWorkspaceState,
+    kind: WindowPlacementKind,
+    fallback_size: Size<Pixels>,
+    cx: &App,
+) -> WindowPlacement {
+    let displays = window_display_snapshots(cx);
+    let persisted_bounds = persisted_window_bounds(persisted, kind);
+
+    if let Some(resolved) = resolve_persisted_window_bounds(persisted_bounds, &displays) {
+        return WindowPlacement {
+            window_bounds: resolved.window_bounds,
+            display_id: display_id_from_raw(cx, resolved.display_id),
+        };
+    }
+
+    let display_id = fallback_display_id_for_persisted_window(persisted_bounds, &displays)
+        .and_then(|display_id| display_id_from_raw(cx, display_id));
+    WindowPlacement {
+        window_bounds: WindowBounds::Windowed(Bounds::centered(display_id, fallback_size, cx)),
+        display_id,
+    }
+}
+
+fn persisted_window_bounds(
+    persisted: &PersistedWorkspaceState,
+    kind: WindowPlacementKind,
+) -> Option<PersistedWindowBounds> {
+    match kind {
+        WindowPlacementKind::Main => persisted.main_window_bounds,
+        WindowPlacementKind::Settings => persisted.settings_window_bounds,
+    }
+}
+
+fn window_display_snapshots(cx: &App) -> Vec<WindowDisplaySnapshot> {
+    let primary_id = cx.primary_display().map(|display| u32::from(display.id()));
+    cx.displays()
+        .into_iter()
+        .map(|display| WindowDisplaySnapshot {
+            id: u32::from(display.id()),
+            bounds: display.bounds(),
+            is_primary: primary_id == Some(u32::from(display.id())),
+        })
+        .collect()
+}
+
+fn display_id_from_raw(cx: &App, raw_id: u32) -> Option<DisplayId> {
+    cx.displays()
+        .into_iter()
+        .find(|display| u32::from(display.id()) == raw_id)
+        .map(|display| display.id())
+}
 
 pub(crate) fn init(window: &mut Window, cx: &mut Context<crate::views::home::HomeView>) {
     let data = cx.new(|cx| WorkspaceState::new(window, cx));

--- a/app/ai-chat/src/state/workspace/persistence.rs
+++ b/app/ai-chat/src/state/workspace/persistence.rs
@@ -69,6 +69,139 @@ pub(super) enum PersistedTab {
     },
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum PersistedWindowMode {
+    Windowed,
+    Maximized,
+    Fullscreen,
+}
+
+impl Default for PersistedWindowMode {
+    fn default() -> Self {
+        Self::Windowed
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub(super) struct PersistedWindowBounds {
+    #[serde(default)]
+    pub(super) mode: PersistedWindowMode,
+    #[serde(default)]
+    pub(super) x: f32,
+    #[serde(default)]
+    pub(super) y: f32,
+    #[serde(default)]
+    pub(super) width: f32,
+    #[serde(default)]
+    pub(super) height: f32,
+    #[serde(default)]
+    pub(super) display_id: Option<u32>,
+}
+
+impl PersistedWindowBounds {
+    pub(super) fn from_window_bounds(
+        window_bounds: WindowBounds,
+        display_id: Option<DisplayId>,
+    ) -> Self {
+        let (mode, bounds) = match window_bounds {
+            WindowBounds::Windowed(bounds) => (PersistedWindowMode::Windowed, bounds),
+            WindowBounds::Maximized(bounds) => (PersistedWindowMode::Maximized, bounds),
+            WindowBounds::Fullscreen(bounds) => (PersistedWindowMode::Fullscreen, bounds),
+        };
+
+        Self {
+            mode,
+            x: f32::from(bounds.origin.x),
+            y: f32::from(bounds.origin.y),
+            width: f32::from(bounds.size.width),
+            height: f32::from(bounds.size.height),
+            display_id: display_id.map(u32::from),
+        }
+    }
+
+    pub(super) fn window_bounds(self) -> WindowBounds {
+        let bounds = self.bounds();
+        match self.mode {
+            PersistedWindowMode::Windowed => WindowBounds::Windowed(bounds),
+            PersistedWindowMode::Maximized => WindowBounds::Maximized(bounds),
+            PersistedWindowMode::Fullscreen => WindowBounds::Fullscreen(bounds),
+        }
+    }
+
+    pub(super) fn bounds(self) -> Bounds<Pixels> {
+        Bounds::new(
+            point(px(self.x), px(self.y)),
+            size(px(self.width), px(self.height)),
+        )
+    }
+
+    fn has_valid_size(self) -> bool {
+        self.width > 0. && self.height > 0.
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct WindowDisplaySnapshot {
+    pub(super) id: u32,
+    pub(super) bounds: Bounds<Pixels>,
+    pub(super) is_primary: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct ResolvedWindowBounds {
+    pub(super) window_bounds: WindowBounds,
+    pub(super) display_id: u32,
+}
+
+pub(super) fn resolve_persisted_window_bounds(
+    persisted: Option<PersistedWindowBounds>,
+    displays: &[WindowDisplaySnapshot],
+) -> Option<ResolvedWindowBounds> {
+    let persisted = persisted?;
+    if !persisted.has_valid_size() {
+        return None;
+    }
+
+    let bounds = persisted.bounds();
+    let display = match persisted.display_id {
+        Some(display_id) => displays.iter().find(|display| display.id == display_id)?,
+        None => displays
+            .iter()
+            .find(|display| bounds.intersects(&display.bounds))?,
+    };
+
+    if !bounds.intersects(&display.bounds) {
+        return None;
+    }
+
+    Some(ResolvedWindowBounds {
+        window_bounds: persisted.window_bounds(),
+        display_id: display.id,
+    })
+}
+
+pub(super) fn fallback_display_id_for_persisted_window(
+    persisted: Option<PersistedWindowBounds>,
+    displays: &[WindowDisplaySnapshot],
+) -> Option<u32> {
+    persisted
+        .and_then(|persisted| persisted.display_id)
+        .and_then(|display_id| {
+            displays
+                .iter()
+                .any(|display| display.id == display_id)
+                .then_some(display_id)
+        })
+        .or_else(|| {
+            displays
+                .iter()
+                .find(|display| display.is_primary)
+                .map(|display| display.id)
+        })
+        .or_else(|| displays.first().map(|display| display.id))
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(super) struct PersistedWorkspaceState {
     #[serde(default = "default_state_version")]
@@ -83,6 +216,10 @@ pub(super) struct PersistedWorkspaceState {
     pub(super) active_tab: Option<PersistedTabKey>,
     #[serde(default)]
     pub(super) latest_model_preset: Option<LatestModelPreset>,
+    #[serde(default)]
+    pub(super) main_window_bounds: Option<PersistedWindowBounds>,
+    #[serde(default)]
+    pub(super) settings_window_bounds: Option<PersistedWindowBounds>,
 }
 
 impl ConversationDraft {
@@ -119,6 +256,8 @@ impl Default for PersistedWorkspaceState {
             tabs: Vec::new(),
             active_tab: None,
             latest_model_preset: None,
+            main_window_bounds: None,
+            settings_window_bounds: None,
         }
     }
 }

--- a/app/ai-chat/src/state/workspace/tests.rs
+++ b/app/ai-chat/src/state/workspace/tests.rs
@@ -1,8 +1,9 @@
 use super::{
     ConversationDraft, PersistedWorkspaceState, SIDEBAR_DEFAULT_WIDTH, SIDEBAR_MAX_WIDTH,
-    SIDEBAR_MIN_WIDTH, WorkspaceState, persistence::*,
+    SIDEBAR_MIN_WIDTH, WindowPlacementKind, WorkspaceState, persistence::*,
 };
 use crate::database::Mode;
+use gpui::{Bounds, WindowBounds, point, px, size};
 
 fn sample_request_template() -> serde_json::Value {
     serde_json::json!({
@@ -129,6 +130,141 @@ sidebar_width = 300.0
     .unwrap();
 
     assert_eq!(state.latest_model_preset, None);
+    assert_eq!(state.main_window_bounds, None);
+    assert_eq!(state.settings_window_bounds, None);
+}
+
+fn window_bounds(x: f32, y: f32, width: f32, height: f32) -> PersistedWindowBounds {
+    PersistedWindowBounds {
+        mode: PersistedWindowMode::Windowed,
+        x,
+        y,
+        width,
+        height,
+        display_id: Some(1),
+    }
+}
+
+fn display(
+    id: u32,
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+    is_primary: bool,
+) -> WindowDisplaySnapshot {
+    WindowDisplaySnapshot {
+        id,
+        bounds: Bounds::new(point(px(x), px(y)), size(px(width), px(height))),
+        is_primary,
+    }
+}
+
+#[test]
+fn persisted_workspace_state_roundtrips_window_bounds_per_window_type() {
+    let main_window_bounds = window_bounds(10., 20., 1200., 800.);
+    let settings_window_bounds = PersistedWindowBounds {
+        mode: PersistedWindowMode::Maximized,
+        x: 50.,
+        y: 60.,
+        width: 960.,
+        height: 720.,
+        display_id: Some(2),
+    };
+    let state = PersistedWorkspaceState {
+        main_window_bounds: Some(main_window_bounds),
+        settings_window_bounds: Some(settings_window_bounds),
+        ..PersistedWorkspaceState::default()
+    };
+
+    let text = toml::to_string_pretty(&state).unwrap();
+    let parsed: PersistedWorkspaceState = toml::from_str(&text).unwrap();
+
+    assert_eq!(parsed.main_window_bounds, Some(main_window_bounds));
+    assert_eq!(parsed.settings_window_bounds, Some(settings_window_bounds));
+}
+
+#[test]
+fn persisted_window_bounds_resolve_only_when_visible_on_current_display() {
+    let displays = vec![display(1, 0., 0., 1440., 900., true)];
+    let valid = window_bounds(10., 20., 1200., 800.);
+
+    let resolved = resolve_persisted_window_bounds(Some(valid), &displays).unwrap();
+
+    assert_eq!(resolved.display_id, 1);
+    assert_eq!(
+        resolved.window_bounds,
+        WindowBounds::Windowed(Bounds::new(
+            point(px(10.), px(20.)),
+            size(px(1200.), px(800.)),
+        ))
+    );
+    assert_eq!(
+        resolve_persisted_window_bounds(Some(window_bounds(10., 20., 0., 800.)), &displays),
+        None
+    );
+    assert_eq!(
+        resolve_persisted_window_bounds(Some(window_bounds(2000., 20., 1200., 800.)), &displays),
+        None
+    );
+    assert_eq!(
+        resolve_persisted_window_bounds(
+            Some(PersistedWindowBounds {
+                display_id: Some(99),
+                ..valid
+            }),
+            &displays,
+        ),
+        None
+    );
+}
+
+#[test]
+fn fallback_display_prefers_saved_display_then_primary() {
+    let displays = vec![
+        display(1, 0., 0., 1440., 900., true),
+        display(2, 1440., 0., 1920., 1080., false),
+    ];
+
+    assert_eq!(
+        fallback_display_id_for_persisted_window(
+            Some(PersistedWindowBounds {
+                display_id: Some(2),
+                ..window_bounds(3000., 3000., 1200., 800.)
+            }),
+            &displays,
+        ),
+        Some(2)
+    );
+    assert_eq!(
+        fallback_display_id_for_persisted_window(
+            Some(PersistedWindowBounds {
+                display_id: Some(99),
+                ..window_bounds(3000., 3000., 1200., 800.)
+            }),
+            &displays,
+        ),
+        Some(1)
+    );
+}
+
+#[test]
+fn window_bounds_updates_are_separated_by_window_type() {
+    let main = window_bounds(10., 20., 1200., 800.);
+    let settings = window_bounds(30., 40., 960., 720.);
+    let mut state = WorkspaceState {
+        persisted: PersistedWorkspaceState::default(),
+        tabs: Vec::new(),
+        active_tab: None,
+        save_task: None,
+    };
+
+    assert!(state.update_persisted_window_bounds(WindowPlacementKind::Main, main));
+    assert!(!state.update_persisted_window_bounds(WindowPlacementKind::Main, main));
+    assert!(state.update_persisted_window_bounds(WindowPlacementKind::Settings, settings));
+
+    assert_eq!(state.persisted.main_window_bounds, Some(main));
+    assert_eq!(state.persisted.settings_window_bounds, Some(settings));
 }
 
 #[test]

--- a/app/ai-chat/src/views/home.rs
+++ b/app/ai-chat/src/views/home.rs
@@ -4,7 +4,7 @@ use crate::{
         add_conversation::open_add_conversation_dialog, add_folder::open_add_folder_dialog,
     },
     i18n::I18n,
-    state::{self, AiChatConfig, WorkspaceStore},
+    state::{self, AiChatConfig, WindowPlacementKind, WorkspaceStore},
     views::home::{sidebar::SidebarView, tabs::TabsView},
 };
 use gpui::{prelude::FluentBuilder, *};
@@ -72,6 +72,21 @@ impl HomeView {
             _subscriptions: vec![
                 cx.observe(&workspace, |_state, _workspace, cx| {
                     cx.notify();
+                }),
+                cx.observe_window_bounds(window, |_state, window, cx| {
+                    let window_bounds = window.window_bounds();
+                    let display_id = window.display(cx).map(|display| display.id());
+                    cx.global::<WorkspaceStore>()
+                        .deref()
+                        .clone()
+                        .update(cx, |workspace, cx| {
+                            workspace.set_window_bounds(
+                                WindowPlacementKind::Main,
+                                window_bounds,
+                                display_id,
+                                cx,
+                            );
+                        });
                 }),
                 cx.observe_window_appearance(window, |_state, window, cx| {
                     let theme_registry = ThemeRegistry::global(cx);

--- a/app/ai-chat/src/views/settings.rs
+++ b/app/ai-chat/src/views/settings.rs
@@ -4,7 +4,7 @@ use crate::{
     components::hotkey_input::{HotkeyEvent, HotkeyInput, string_to_keystroke},
     i18n::{self, I18n},
     llm::provider_setting_groups,
-    state::{AiChatConfig, Language},
+    state::{AiChatConfig, Language, WindowPlacementKind, WorkspaceStore},
     tray,
 };
 use gpui::*;
@@ -17,7 +17,7 @@ use gpui_component::{
     setting::{SettingField, SettingGroup, SettingItem, SettingPage, Settings},
     v_flex,
 };
-use std::any::TypeId;
+use std::{any::TypeId, ops::Deref};
 use tracing::{Level, event};
 
 pub(super) mod appearance_settings;
@@ -33,6 +33,8 @@ enum SettingsOpenTarget {
     General,
     Provider,
 }
+
+const SETTINGS_WINDOW_FALLBACK_SIZE: Size<Pixels> = size(px(960.), px(720.));
 
 pub fn init(cx: &mut App) {
     cx.bind_keys([KeyBinding::new(
@@ -67,7 +69,28 @@ impl SettingsView {
         });
         let appearance_settings = cx.new(|cx| AppearanceSettingsPage::new(window, cx));
         let shortcut_settings = cx.new(|cx| ShortcutSettingsPage::new(window, cx));
-        let _subscriptions = vec![cx.subscribe(&hotkey_input, Self::subscribe_hotkey_changes)];
+        let _subscriptions = vec![
+            cx.subscribe(&hotkey_input, Self::subscribe_hotkey_changes),
+            cx.observe_window_bounds(window, |_settings, window, cx| {
+                if !cx.has_global::<WorkspaceStore>() {
+                    return;
+                }
+
+                let window_bounds = window.window_bounds();
+                let display_id = window.display(cx).map(|display| display.id());
+                cx.global::<WorkspaceStore>()
+                    .deref()
+                    .clone()
+                    .update(cx, |workspace, cx| {
+                        workspace.set_window_bounds(
+                            WindowPlacementKind::Settings,
+                            window_bounds,
+                            display_id,
+                            cx,
+                        );
+                    });
+            }),
+        ];
         Self {
             focus_handle,
             hotkey_input,
@@ -328,8 +351,15 @@ fn open_settings_window_to(target: SettingsOpenTarget, toggle_if_active: bool, c
 
 fn inner_open_settings_window(target: SettingsOpenTarget, cx: &mut App) {
     let title = cx.global::<I18n>().t("settings-title");
+    let placement = crate::state::workspace::restored_window_placement(
+        WindowPlacementKind::Settings,
+        SETTINGS_WINDOW_FALLBACK_SIZE,
+        cx,
+    );
     match cx.open_window(
         WindowOptions {
+            window_bounds: Some(placement.window_bounds),
+            display_id: placement.display_id,
             titlebar: Some(settings_titlebar_options(title)),
             window_background: WindowBackgroundAppearance::Blurred,
             ..Default::default()


### PR DESCRIPTION
## Summary

- Persist `ai-chat` main window and settings window bounds separately in workspace state.
- Restore the correct saved bounds when opening each window, with display visibility validation and default fallback sizes.
- Affected app: `ai-chat`.

## Motivation

Fixes #71. The main window and settings window were opened with default `WindowOptions`, so they reopened at fixed centered sizes and did not keep independent position/size state.

## Changes

- Added optional `main_window_bounds` and `settings_window_bounds` fields to workspace persistence with serde defaults for old `state.toml` compatibility.
- Added window placement restore/save helpers keyed by `WindowPlacementKind::{Main, Settings}`.
- Saved bounds through `observe_window_bounds` in `HomeView` and `SettingsView`.
- Applied restored bounds to `open_main_window` and `inner_open_settings_window`, using `1536x864` and `960x720` fallback sizes respectively.
- Added display validation so invalid zero-size or offscreen saved bounds fall back to a visible centered placement.
- Added tests for old state compatibility, per-window roundtrip, offscreen validation, display fallback, and idempotent per-window updates.

## Validation

- [x] `cargo build`
- [ ] `cargo test`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual UI verification

Executed:

```text
cargo fmt
passed

cargo test -p ai-chat window_bounds
passed; 3 passed, 208 filtered out

cargo test -p ai-chat workspace
passed; 13 passed, 198 filtered out

cargo test -p ai-chat settings
passed; 15 passed, 196 filtered out

cargo build -p ai-chat
passed
```

Full workspace tests, clippy, and final manual UI verification were not run in this step.

## Risks

- Real window-manager behavior still needs manual verification, especially maximized/fullscreen restore and display removal/offscreen fallback.
- The persistence fields are optional and should not require migration for existing users.

## Related Issues

- Closes #71
- Related to #66
