### PR TITLE
[tech] ai-chat: stability hardening for known UI and provider bugs

### DIFF
--- a/app/ai-chat/src/app.rs
+++ b/app/ai-chat/src/app.rs
@@ -11,6 +11,7 @@ use tracing_subscriber::{Layer, fmt, layer::SubscriberExt, util::SubscriberInitE
 use window_ext::WindowExt;
 
 pub(crate) static APP_NAME: &str = "top.sushao.ai-chat";
+const MAIN_WINDOW_FALLBACK_SIZE: Size<Pixels> = size(px(1536.), px(864.));
 
 #[cfg(feature = "dhat-heap")]
 mod profiling {
@@ -170,8 +171,15 @@ fn reveal_main_window(root: &mut Root, window: &mut Window, cx: &mut Context<Roo
 
 pub(crate) fn open_main_window(cx: &mut App) -> Result<WindowHandle<Root>, anyhow::Error> {
     let title = cx.global::<I18n>().t("app-title");
+    let placement = state::workspace::restored_window_placement(
+        state::workspace::WindowPlacementKind::Main,
+        MAIN_WINDOW_FALLBACK_SIZE,
+        cx,
+    );
     cx.open_window(
         WindowOptions {
+            window_bounds: Some(placement.window_bounds),
+            display_id: placement.display_id,
             titlebar: Some(TitlebarOptions {
                 title: Some(title.into()),
                 ..TitleBar::title_bar_options()

--- a/app/ai-chat/src/components/chat_form/model_select.rs
+++ b/app/ai-chat/src/components/chat_form/model_select.rs
@@ -33,6 +33,7 @@ pub(crate) struct ModelSelect {
     selected_model: Option<ProviderModel>,
     model_picker: Entity<ListState<PickerListDelegate<ModelOption>>>,
     model_picker_bounds: Bounds<Pixels>,
+    model_picker_loading: bool,
     model_picker_open: bool,
     _subscriptions: Vec<Subscription>,
 }
@@ -74,12 +75,13 @@ impl ModelSelect {
             selected_model: None,
             model_picker,
             model_picker_bounds: Bounds::default(),
+            model_picker_loading: false,
             model_picker_open: false,
             _subscriptions: Vec::new(),
         };
         this.bind_store_events(window, cx);
         this.ensure_models_loaded(window, cx);
-        this.sync_models_from_store(window, cx);
+        this.sync_models_from_store(window, cx, false);
         this
     }
 
@@ -115,13 +117,13 @@ impl ModelSelect {
             &cx.global::<ModelStore>().deref().clone(),
             window,
             |this, _, window, cx| {
-                this.sync_models_from_store(window, cx);
+                this.sync_models_from_store(window, cx, false);
             },
         );
         let config_subscription =
             cx.observe_global_in::<AiChatConfig>(window, |this, window, cx| {
-                this.sync_selection_with_config(cx);
-                this.sync_models_from_store(window, cx);
+                let selection_changed = this.sync_selection_with_config(cx);
+                this.sync_models_from_store(window, cx, selection_changed);
             });
         self._subscriptions.push(store_subscription);
         self._subscriptions.push(config_subscription);
@@ -141,46 +143,71 @@ impl ModelSelect {
         cx.global::<ModelStore>().read(cx).snapshot()
     }
 
-    fn sync_models_from_store(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let snapshot = self.model_store_snapshot(cx);
-        self.models = snapshot.models.clone();
+    fn sync_models_from_store(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+        force_selection_sync: bool,
+    ) {
+        let ModelStoreSnapshot { models, status } = self.model_store_snapshot(cx);
+        let models_changed = self.models != models;
+        if models_changed {
+            self.models = models;
+        }
 
         let keep_selected = self.selected_model.as_ref().is_some_and(|selected| {
             self.models.iter().any(|model| {
                 model.provider_name == selected.provider_name && model.id == selected.id
             })
         });
+        let mut selection_changed = force_selection_sync;
         if !keep_selected && self.selected_model.take().is_some() {
+            selection_changed = true;
             cx.emit(ModelSelectEvent::Change(None));
         }
 
-        let sections = model_sections(&self.models);
-        let selected_ix =
-            PickerListDelegate::selected_index_for(&sections, self.selected_model.as_ref());
-        let is_loading = matches!(
-            snapshot.status,
-            Some(ModelStoreStatus::InitialLoading | ModelStoreStatus::Refreshing)
-        );
-        self.model_picker.update(cx, |picker, cx| {
-            picker.delegate_mut().set_sections(sections);
-            picker.delegate_mut().set_loading(is_loading);
-            picker.set_selected_index(selected_ix, window, cx);
+        let next_loading = model_store_is_loading(status);
+        let loading_changed = self.model_picker_loading != next_loading;
+        if loading_changed {
+            self.model_picker_loading = next_loading;
+        }
+
+        let picker_selection = (models_changed || selection_changed).then(|| {
+            let sections = model_sections(&self.models);
+            let selected_ix =
+                PickerListDelegate::selected_index_for(&sections, self.selected_model.as_ref());
+            (sections, selected_ix)
         });
-        cx.emit(ModelSelectEvent::ModelsChanged);
-        cx.notify();
+
+        if picker_selection.is_some() || loading_changed {
+            self.model_picker.update(cx, |picker, cx| {
+                if let Some((sections, selected_ix)) = picker_selection {
+                    picker.delegate_mut().set_sections(sections);
+                    picker.set_selected_index(selected_ix, window, cx);
+                }
+                if loading_changed {
+                    picker.delegate_mut().set_loading(next_loading);
+                }
+            });
+            if models_changed {
+                cx.emit(ModelSelectEvent::ModelsChanged);
+            }
+            cx.notify();
+        }
     }
 
-    fn sync_selection_with_config(&mut self, cx: &mut Context<Self>) {
+    fn sync_selection_with_config(&mut self, cx: &mut Context<Self>) -> bool {
         let Some(selected_model) = self.selected_model.as_ref() else {
-            return;
+            return false;
         };
         let configured =
             provider_is_configured(cx.global::<AiChatConfig>(), &selected_model.provider_name)
                 .unwrap_or(false);
         if !configured && self.selected_model.take().is_some() {
             cx.emit(ModelSelectEvent::Change(None));
-            cx.notify();
+            return true;
         }
+        false
     }
 
     fn open_model_picker(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -221,7 +248,7 @@ impl ModelSelect {
         let search_label = cx.global::<I18n>().t("field-search-models");
         let reload_tooltip = cx.global::<I18n>().t("button-reload");
         let configure_label = cx.global::<I18n>().t("button-configure");
-        let snapshot = self.model_store_snapshot(cx);
+        let is_loading = self.model_picker_loading;
         let on_mouse_down_out = cx.listener(|select, ev: &MouseDownEvent, window, cx| {
             if select.model_picker_bounds.contains(&ev.position) {
                 return;
@@ -262,13 +289,7 @@ impl ModelSelect {
                                 .ghost()
                                 .small()
                                 .tooltip(reload_tooltip)
-                                .disabled(matches!(
-                                    snapshot.status,
-                                    Some(
-                                        ModelStoreStatus::InitialLoading
-                                            | ModelStoreStatus::Refreshing
-                                    )
-                                ))
+                                .disabled(is_loading)
                                 .on_click(cx.listener(|select, _event, window, cx| {
                                     cx.stop_propagation();
                                     select.reload_models(window, cx);
@@ -308,8 +329,11 @@ impl Render for ModelSelect {
                     {
                         let state = cx.entity();
                         move |bounds, cx| {
-                            state.update(cx, |select, _| {
-                                select.model_picker_bounds = bounds;
+                            state.update(cx, |select, cx| {
+                                if select.model_picker_bounds != bounds {
+                                    select.model_picker_bounds = bounds;
+                                    cx.notify();
+                                }
                             })
                         }
                     },
@@ -320,5 +344,28 @@ impl Render for ModelSelect {
             .when(self.model_picker_open, |this| {
                 this.child(self.render_model_picker(window, cx))
             })
+    }
+}
+
+fn model_store_is_loading(status: Option<ModelStoreStatus>) -> bool {
+    matches!(
+        status,
+        Some(ModelStoreStatus::InitialLoading | ModelStoreStatus::Refreshing)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::model_store_is_loading;
+    use crate::state::ModelStoreStatus;
+
+    #[test]
+    fn model_store_loading_status_matches_refresh_states() {
+        assert!(model_store_is_loading(Some(
+            ModelStoreStatus::InitialLoading
+        )));
+        assert!(model_store_is_loading(Some(ModelStoreStatus::Refreshing)));
+        assert!(!model_store_is_loading(Some(ModelStoreStatus::Idle)));
+        assert!(!model_store_is_loading(None));
     }
 }

--- a/app/ai-chat/src/components/chat_form/picker.rs
+++ b/app/ai-chat/src/components/chat_form/picker.rs
@@ -84,27 +84,20 @@ where
             .w_full()
             .relative()
             .gap_x_1()
+            .min_h(px(28.))
             .px_3()
             .py_1()
+            .rounded(cx.theme().radius)
             .text_base()
             .text_color(cx.theme().foreground)
             .items_center()
             .justify_between()
-            .child(
-                div()
-                    .absolute()
-                    .top(px(1.))
-                    .right(px(2.))
-                    .bottom(px(1.))
-                    .left(px(2.))
-                    .rounded(cx.theme().radius)
-                    .when(self.is_selected, |this| {
-                        this.bg(cx.theme().secondary_active)
-                    })
-                    .when(!self.is_selected, |this| {
-                        this.hover(|this| this.bg(cx.theme().secondary_hover))
-                    }),
-            )
+            .when(self.is_selected, |this| {
+                this.bg(cx.theme().secondary_active)
+            })
+            .when(!self.is_selected, |this| {
+                this.hover(|this| this.bg(cx.theme().secondary_hover))
+            })
             .child(
                 h_flex()
                     .relative()

--- a/app/ai-chat/src/llm/preset.rs
+++ b/app/ai-chat/src/llm/preset.rs
@@ -86,6 +86,26 @@ mod tests {
     }
 
     #[test]
+    fn build_request_template_defaults_ollama_boolean_thinking_to_false() -> anyhow::Result<()> {
+        let model = ProviderModel::new("Ollama", "qwen3", ProviderModelCapability::Streaming)
+            .with_metadata(json!({
+                "capabilities": ["completion", "thinking"],
+                "family": "qwen3",
+                "families": ["qwen3"]
+            }));
+        let template = build_request_template(
+            &model,
+            Some(&json!({
+                "model": "qwen3",
+                "stream": true
+            })),
+        )?;
+
+        assert_eq!(template["think"], false);
+        Ok(())
+    }
+
+    #[test]
     fn build_request_template_skips_invalid_saved_ext_settings() -> anyhow::Result<()> {
         let model = ProviderModel::new("OpenAI", "gpt-5.2-pro", ProviderModelCapability::Streaming);
         let template = build_request_template(

--- a/app/ai-chat/src/llm/provider/ollama.rs
+++ b/app/ai-chat/src/llm/provider/ollama.rs
@@ -389,6 +389,11 @@ impl OllamaProvider {
             .any(|family| matches!(family.as_str(), "gptoss" | "gpt-oss"))
     }
 
+    fn default_think_for_model(model: &ProviderModel) -> Option<OllamaThinkValue> {
+        (Self::supports_thinking(model) && !Self::uses_thinking_levels(model))
+            .then_some(OllamaThinkValue::Boolean(false))
+    }
+
     fn thinking_value_from_template(
         model: &ProviderModel,
         template: &serde_json::Value,
@@ -660,7 +665,7 @@ impl Provider for OllamaProvider {
         Ok(serde_json::to_value(OllamaRequestTemplate {
             model: model.id.clone(),
             stream: model.capability.stream_flag(),
-            think: None,
+            think: Self::default_think_for_model(model),
             web_search: false,
         })?)
     }
@@ -1028,6 +1033,47 @@ mod tests {
         assert_eq!(settings[1].key, WEB_SEARCH_KEY);
         assert_eq!(settings[1].tooltip, Some(WEB_SEARCH_TOOLTIP_KEY));
         assert_eq!(settings[1].control, ExtSettingControl::Boolean(true));
+        Ok(())
+    }
+
+    #[test]
+    fn default_template_disables_standard_thinking_models() -> anyhow::Result<()> {
+        let model = model_with_metadata("qwen3", &["completion", "thinking"], "qwen3", &["qwen3"]);
+        let template = OllamaProvider.default_template_for_model(&model)?;
+        assert_eq!(template["think"], false);
+        Ok(())
+    }
+
+    #[test]
+    fn default_template_omits_think_for_non_thinking_models() -> anyhow::Result<()> {
+        let model = model_with_metadata("llama3.2", &["completion"], "llama", &["llama"]);
+        let template = OllamaProvider.default_template_for_model(&model)?;
+        assert!(template.get("think").is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn default_template_keeps_gptoss_level_thinking_default() -> anyhow::Result<()> {
+        let model = model_with_metadata(
+            "gpt-oss:20b",
+            &["completion", "thinking"],
+            "gptoss",
+            &["gptoss"],
+        );
+        let template = OllamaProvider.default_template_for_model(&model)?;
+        assert!(template.get("think").is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn request_body_preserves_default_false_think() -> anyhow::Result<()> {
+        let model = model_with_metadata("qwen3", &["completion", "thinking"], "qwen3", &["qwen3"]);
+        let template = OllamaProvider.default_template_for_model(&model)?;
+        let request = OllamaProvider.request_body(
+            &template,
+            vec![crate::llm::Message::new(Role::User, "hello".to_string())],
+        )?;
+        assert_eq!(request["think"], false);
         Ok(())
     }
 

--- a/app/ai-chat/src/state.rs
+++ b/app/ai-chat/src/state.rs
@@ -8,4 +8,6 @@ pub(crate) use chat::{
     ModelStore, ModelStoreSnapshot, ModelStoreStatus,
 };
 pub(crate) use config::{AiChatConfig, Language, ThemeMode};
-pub(crate) use workspace::{ConversationDraft, WorkspaceState, WorkspaceStore};
+pub(crate) use workspace::{
+    ConversationDraft, WindowPlacementKind, WorkspaceState, WorkspaceStore,
+};

--- a/app/ai-chat/src/state/workspace.rs
+++ b/app/ai-chat/src/state/workspace.rs
@@ -445,12 +445,38 @@ fn restored_window_placement_from_state(
         };
     }
 
-    let display_id = fallback_display_id_for_persisted_window(persisted_bounds, &displays)
-        .and_then(|display_id| display_id_from_raw(cx, display_id));
+    let fallback_display_id = fallback_display_id_for_persisted_window(persisted_bounds, &displays);
+    let fallback_display_bounds = fallback_display_id.and_then(|display_id| {
+        displays
+            .iter()
+            .find(|display| display.id == display_id)
+            .map(|display| display.bounds)
+    });
+    let fallback_size = clamp_fallback_window_size(fallback_size, fallback_display_bounds);
+    let display_id = fallback_display_id.and_then(|display_id| display_id_from_raw(cx, display_id));
     WindowPlacement {
         window_bounds: WindowBounds::Windowed(Bounds::centered(display_id, fallback_size, cx)),
         display_id,
     }
+}
+
+fn clamp_fallback_window_size(
+    fallback_size: Size<Pixels>,
+    display_bounds: Option<Bounds<Pixels>>,
+) -> Size<Pixels> {
+    let Some(display_bounds) = display_bounds else {
+        return fallback_size;
+    };
+    let display_width = f32::from(display_bounds.size.width);
+    let display_height = f32::from(display_bounds.size.height);
+    if display_width <= 0. || display_height <= 0. {
+        return fallback_size;
+    }
+
+    size(
+        px(f32::from(fallback_size.width).min(display_width)),
+        px(f32::from(fallback_size.height).min(display_height)),
+    )
 }
 
 fn persisted_window_bounds(

--- a/app/ai-chat/src/state/workspace.rs
+++ b/app/ai-chat/src/state/workspace.rs
@@ -18,6 +18,10 @@ use gpui::*;
 use std::{collections::BTreeSet, ops::Deref};
 use tracing::{Level, event};
 
+pub(crate) const SIDEBAR_MIN_WIDTH: Pixels = px(180.);
+pub(crate) const SIDEBAR_DEFAULT_WIDTH: Pixels = px(300.);
+pub(crate) const SIDEBAR_MAX_WIDTH: Pixels = px(420.);
+
 pub(crate) struct WorkspaceState {
     persisted: PersistedWorkspaceState,
     tabs: Vec<AppTab>,
@@ -39,11 +43,11 @@ impl WorkspaceState {
     }
 
     pub(crate) fn sidebar_width(&self) -> Pixels {
-        px(self.persisted.sidebar_width.max(100.))
+        clamp_sidebar_width(px(self.persisted.sidebar_width))
     }
 
     pub(crate) fn set_sidebar_width(&mut self, width: Pixels, cx: &mut Context<Self>) {
-        self.persisted.sidebar_width = f32::from(width.max(px(100.)));
+        self.persisted.sidebar_width = f32::from(clamp_sidebar_width(width));
         self.schedule_save(cx);
         cx.notify();
     }
@@ -345,6 +349,10 @@ impl WorkspaceState {
     pub(crate) fn open_folder_ids(&self) -> BTreeSet<i32> {
         self.persisted.open_folder_ids.clone()
     }
+}
+
+fn clamp_sidebar_width(width: Pixels) -> Pixels {
+    width.max(SIDEBAR_MIN_WIDTH).min(SIDEBAR_MAX_WIDTH)
 }
 
 pub(crate) struct WorkspaceStore {

--- a/app/ai-chat/src/state/workspace.rs
+++ b/app/ai-chat/src/state/workspace.rs
@@ -5,7 +5,10 @@ mod tests;
 
 pub(crate) use self::persistence::ConversationDraft;
 use self::{
-    persistence::PersistedWorkspaceState,
+    persistence::{
+        PersistedWindowBounds, PersistedWorkspaceState, WindowDisplaySnapshot,
+        fallback_display_id_for_persisted_window, resolve_persisted_window_bounds,
+    },
     tabs::{AppTab, TabKind, TabPanel},
 };
 
@@ -21,6 +24,18 @@ use tracing::{Level, event};
 pub(crate) const SIDEBAR_MIN_WIDTH: Pixels = px(180.);
 pub(crate) const SIDEBAR_DEFAULT_WIDTH: Pixels = px(300.);
 pub(crate) const SIDEBAR_MAX_WIDTH: Pixels = px(420.);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum WindowPlacementKind {
+    Main,
+    Settings,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct WindowPlacement {
+    pub(crate) window_bounds: WindowBounds,
+    pub(crate) display_id: Option<DisplayId>,
+}
 
 pub(crate) struct WorkspaceState {
     persisted: PersistedWorkspaceState,
@@ -50,6 +65,38 @@ impl WorkspaceState {
         self.persisted.sidebar_width = f32::from(clamp_sidebar_width(width));
         self.schedule_save(cx);
         cx.notify();
+    }
+
+    pub(crate) fn set_window_bounds(
+        &mut self,
+        kind: WindowPlacementKind,
+        window_bounds: WindowBounds,
+        display_id: Option<DisplayId>,
+        cx: &mut Context<Self>,
+    ) {
+        let next = PersistedWindowBounds::from_window_bounds(window_bounds, display_id);
+        if self.update_persisted_window_bounds(kind, next) {
+            self.schedule_save(cx);
+        }
+    }
+
+    fn update_persisted_window_bounds(
+        &mut self,
+        kind: WindowPlacementKind,
+        next: PersistedWindowBounds,
+    ) -> bool {
+        let next = Some(next);
+        let current = match kind {
+            WindowPlacementKind::Main => &mut self.persisted.main_window_bounds,
+            WindowPlacementKind::Settings => &mut self.persisted.settings_window_bounds,
+        };
+
+        if *current == next {
+            return false;
+        }
+
+        *current = next;
+        true
     }
 
     pub(crate) fn toggle_folder_open(&mut self, folder_id: i32, cx: &mut Context<Self>) {
@@ -368,6 +415,72 @@ impl Deref for WorkspaceStore {
 }
 
 impl Global for WorkspaceStore {}
+
+pub(crate) fn restored_window_placement(
+    kind: WindowPlacementKind,
+    fallback_size: Size<Pixels>,
+    cx: &App,
+) -> WindowPlacement {
+    let persisted = if cx.has_global::<WorkspaceStore>() {
+        cx.global::<WorkspaceStore>().read(cx).persisted.clone()
+    } else {
+        WorkspaceState::load_persisted().unwrap_or_default()
+    };
+    restored_window_placement_from_state(&persisted, kind, fallback_size, cx)
+}
+
+fn restored_window_placement_from_state(
+    persisted: &PersistedWorkspaceState,
+    kind: WindowPlacementKind,
+    fallback_size: Size<Pixels>,
+    cx: &App,
+) -> WindowPlacement {
+    let displays = window_display_snapshots(cx);
+    let persisted_bounds = persisted_window_bounds(persisted, kind);
+
+    if let Some(resolved) = resolve_persisted_window_bounds(persisted_bounds, &displays) {
+        return WindowPlacement {
+            window_bounds: resolved.window_bounds,
+            display_id: display_id_from_raw(cx, resolved.display_id),
+        };
+    }
+
+    let display_id = fallback_display_id_for_persisted_window(persisted_bounds, &displays)
+        .and_then(|display_id| display_id_from_raw(cx, display_id));
+    WindowPlacement {
+        window_bounds: WindowBounds::Windowed(Bounds::centered(display_id, fallback_size, cx)),
+        display_id,
+    }
+}
+
+fn persisted_window_bounds(
+    persisted: &PersistedWorkspaceState,
+    kind: WindowPlacementKind,
+) -> Option<PersistedWindowBounds> {
+    match kind {
+        WindowPlacementKind::Main => persisted.main_window_bounds,
+        WindowPlacementKind::Settings => persisted.settings_window_bounds,
+    }
+}
+
+fn window_display_snapshots(cx: &App) -> Vec<WindowDisplaySnapshot> {
+    let primary_id = cx.primary_display().map(|display| u32::from(display.id()));
+    cx.displays()
+        .into_iter()
+        .map(|display| WindowDisplaySnapshot {
+            id: u32::from(display.id()),
+            bounds: display.bounds(),
+            is_primary: primary_id == Some(u32::from(display.id())),
+        })
+        .collect()
+}
+
+fn display_id_from_raw(cx: &App, raw_id: u32) -> Option<DisplayId> {
+    cx.displays()
+        .into_iter()
+        .find(|display| u32::from(display.id()) == raw_id)
+        .map(|display| display.id())
+}
 
 pub(crate) fn init(window: &mut Window, cx: &mut Context<crate::views::home::HomeView>) {
     let data = cx.new(|cx| WorkspaceState::new(window, cx));

--- a/app/ai-chat/src/state/workspace/persistence.rs
+++ b/app/ai-chat/src/state/workspace/persistence.rs
@@ -1,4 +1,4 @@
-use super::{TabKind, WorkspaceState};
+use super::{SIDEBAR_DEFAULT_WIDTH, TabKind, WorkspaceState};
 use crate::{
     app::APP_NAME,
     database::Mode,
@@ -11,7 +11,6 @@ use tracing::{Level, event};
 
 const STATE_FILE_NAME: &str = "state.toml";
 const STATE_VERSION: u32 = 1;
-const DEFAULT_SIDEBAR_WIDTH: f32 = 300.;
 const SAVE_DEBOUNCE: Duration = Duration::from_millis(300);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -115,7 +114,7 @@ impl Default for PersistedWorkspaceState {
     fn default() -> Self {
         Self {
             version: STATE_VERSION,
-            sidebar_width: DEFAULT_SIDEBAR_WIDTH,
+            sidebar_width: default_sidebar_width(),
             open_folder_ids: Default::default(),
             tabs: Vec::new(),
             active_tab: None,
@@ -286,7 +285,7 @@ fn default_state_version() -> u32 {
 }
 
 fn default_sidebar_width() -> f32 {
-    DEFAULT_SIDEBAR_WIDTH
+    f32::from(SIDEBAR_DEFAULT_WIDTH)
 }
 
 fn serialize_request_template<S>(

--- a/app/ai-chat/src/state/workspace/persistence.rs
+++ b/app/ai-chat/src/state/workspace/persistence.rs
@@ -69,6 +69,139 @@ pub(super) enum PersistedTab {
     },
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum PersistedWindowMode {
+    Windowed,
+    Maximized,
+    Fullscreen,
+}
+
+impl Default for PersistedWindowMode {
+    fn default() -> Self {
+        Self::Windowed
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub(super) struct PersistedWindowBounds {
+    #[serde(default)]
+    pub(super) mode: PersistedWindowMode,
+    #[serde(default)]
+    pub(super) x: f32,
+    #[serde(default)]
+    pub(super) y: f32,
+    #[serde(default)]
+    pub(super) width: f32,
+    #[serde(default)]
+    pub(super) height: f32,
+    #[serde(default)]
+    pub(super) display_id: Option<u32>,
+}
+
+impl PersistedWindowBounds {
+    pub(super) fn from_window_bounds(
+        window_bounds: WindowBounds,
+        display_id: Option<DisplayId>,
+    ) -> Self {
+        let (mode, bounds) = match window_bounds {
+            WindowBounds::Windowed(bounds) => (PersistedWindowMode::Windowed, bounds),
+            WindowBounds::Maximized(bounds) => (PersistedWindowMode::Maximized, bounds),
+            WindowBounds::Fullscreen(bounds) => (PersistedWindowMode::Fullscreen, bounds),
+        };
+
+        Self {
+            mode,
+            x: f32::from(bounds.origin.x),
+            y: f32::from(bounds.origin.y),
+            width: f32::from(bounds.size.width),
+            height: f32::from(bounds.size.height),
+            display_id: display_id.map(u32::from),
+        }
+    }
+
+    pub(super) fn window_bounds(self) -> WindowBounds {
+        let bounds = self.bounds();
+        match self.mode {
+            PersistedWindowMode::Windowed => WindowBounds::Windowed(bounds),
+            PersistedWindowMode::Maximized => WindowBounds::Maximized(bounds),
+            PersistedWindowMode::Fullscreen => WindowBounds::Fullscreen(bounds),
+        }
+    }
+
+    pub(super) fn bounds(self) -> Bounds<Pixels> {
+        Bounds::new(
+            point(px(self.x), px(self.y)),
+            size(px(self.width), px(self.height)),
+        )
+    }
+
+    fn has_valid_size(self) -> bool {
+        self.width > 0. && self.height > 0.
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct WindowDisplaySnapshot {
+    pub(super) id: u32,
+    pub(super) bounds: Bounds<Pixels>,
+    pub(super) is_primary: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct ResolvedWindowBounds {
+    pub(super) window_bounds: WindowBounds,
+    pub(super) display_id: u32,
+}
+
+pub(super) fn resolve_persisted_window_bounds(
+    persisted: Option<PersistedWindowBounds>,
+    displays: &[WindowDisplaySnapshot],
+) -> Option<ResolvedWindowBounds> {
+    let persisted = persisted?;
+    if !persisted.has_valid_size() {
+        return None;
+    }
+
+    let bounds = persisted.bounds();
+    let display = match persisted.display_id {
+        Some(display_id) => displays.iter().find(|display| display.id == display_id)?,
+        None => displays
+            .iter()
+            .find(|display| bounds.intersects(&display.bounds))?,
+    };
+
+    if !bounds.intersects(&display.bounds) {
+        return None;
+    }
+
+    Some(ResolvedWindowBounds {
+        window_bounds: persisted.window_bounds(),
+        display_id: display.id,
+    })
+}
+
+pub(super) fn fallback_display_id_for_persisted_window(
+    persisted: Option<PersistedWindowBounds>,
+    displays: &[WindowDisplaySnapshot],
+) -> Option<u32> {
+    persisted
+        .and_then(|persisted| persisted.display_id)
+        .and_then(|display_id| {
+            displays
+                .iter()
+                .any(|display| display.id == display_id)
+                .then_some(display_id)
+        })
+        .or_else(|| {
+            displays
+                .iter()
+                .find(|display| display.is_primary)
+                .map(|display| display.id)
+        })
+        .or_else(|| displays.first().map(|display| display.id))
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(super) struct PersistedWorkspaceState {
     #[serde(default = "default_state_version")]
@@ -83,6 +216,10 @@ pub(super) struct PersistedWorkspaceState {
     pub(super) active_tab: Option<PersistedTabKey>,
     #[serde(default)]
     pub(super) latest_model_preset: Option<LatestModelPreset>,
+    #[serde(default)]
+    pub(super) main_window_bounds: Option<PersistedWindowBounds>,
+    #[serde(default)]
+    pub(super) settings_window_bounds: Option<PersistedWindowBounds>,
 }
 
 impl ConversationDraft {
@@ -119,6 +256,8 @@ impl Default for PersistedWorkspaceState {
             tabs: Vec::new(),
             active_tab: None,
             latest_model_preset: None,
+            main_window_bounds: None,
+            settings_window_bounds: None,
         }
     }
 }

--- a/app/ai-chat/src/state/workspace/persistence.rs
+++ b/app/ai-chat/src/state/workspace/persistence.rs
@@ -69,18 +69,16 @@ pub(super) enum PersistedTab {
     },
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+const MIN_RESTORED_WINDOW_VISIBLE_WIDTH: f32 = 160.;
+const MIN_RESTORED_WINDOW_VISIBLE_HEIGHT: f32 = 120.;
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub(super) enum PersistedWindowMode {
+    #[default]
     Windowed,
     Maximized,
     Fullscreen,
-}
-
-impl Default for PersistedWindowMode {
-    fn default() -> Self {
-        Self::Windowed
-    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
@@ -154,6 +152,28 @@ pub(super) struct ResolvedWindowBounds {
     pub(super) display_id: u32,
 }
 
+fn has_meaningful_visible_area(
+    window_bounds: Bounds<Pixels>,
+    display_bounds: Bounds<Pixels>,
+) -> bool {
+    let window_left = f32::from(window_bounds.origin.x);
+    let window_top = f32::from(window_bounds.origin.y);
+    let window_right = window_left + f32::from(window_bounds.size.width);
+    let window_bottom = window_top + f32::from(window_bounds.size.height);
+    let display_left = f32::from(display_bounds.origin.x);
+    let display_top = f32::from(display_bounds.origin.y);
+    let display_right = display_left + f32::from(display_bounds.size.width);
+    let display_bottom = display_top + f32::from(display_bounds.size.height);
+
+    let visible_width = window_right.min(display_right) - window_left.max(display_left);
+    let visible_height = window_bottom.min(display_bottom) - window_top.max(display_top);
+    let required_width = f32::from(window_bounds.size.width).min(MIN_RESTORED_WINDOW_VISIBLE_WIDTH);
+    let required_height =
+        f32::from(window_bounds.size.height).min(MIN_RESTORED_WINDOW_VISIBLE_HEIGHT);
+
+    visible_width >= required_width && visible_height >= required_height
+}
+
 pub(super) fn resolve_persisted_window_bounds(
     persisted: Option<PersistedWindowBounds>,
     displays: &[WindowDisplaySnapshot],
@@ -168,10 +188,10 @@ pub(super) fn resolve_persisted_window_bounds(
         Some(display_id) => displays.iter().find(|display| display.id == display_id)?,
         None => displays
             .iter()
-            .find(|display| bounds.intersects(&display.bounds))?,
+            .find(|display| has_meaningful_visible_area(bounds, display.bounds))?,
     };
 
-    if !bounds.intersects(&display.bounds) {
+    if !has_meaningful_visible_area(bounds, display.bounds) {
         return None;
     }
 

--- a/app/ai-chat/src/state/workspace/tests.rs
+++ b/app/ai-chat/src/state/workspace/tests.rs
@@ -1,6 +1,7 @@
 use super::{
     ConversationDraft, PersistedWorkspaceState, SIDEBAR_DEFAULT_WIDTH, SIDEBAR_MAX_WIDTH,
-    SIDEBAR_MIN_WIDTH, WindowPlacementKind, WorkspaceState, persistence::*,
+    SIDEBAR_MIN_WIDTH, WindowPlacementKind, WorkspaceState, clamp_fallback_window_size,
+    persistence::*,
 };
 use crate::database::Mode;
 use gpui::{Bounds, WindowBounds, point, px, size};
@@ -249,6 +250,24 @@ fn fallback_display_prefers_saved_display_then_primary() {
             &displays,
         ),
         Some(1)
+    );
+}
+
+#[test]
+fn fallback_window_size_clamps_to_display_bounds() {
+    let small_display = display(1, 0., 0., 1366., 768., true);
+
+    assert_eq!(
+        clamp_fallback_window_size(size(px(1536.), px(864.)), Some(small_display.bounds)),
+        size(px(1366.), px(768.))
+    );
+    assert_eq!(
+        clamp_fallback_window_size(size(px(960.), px(720.)), Some(small_display.bounds)),
+        size(px(960.), px(720.))
+    );
+    assert_eq!(
+        clamp_fallback_window_size(size(px(1536.), px(864.)), None),
+        size(px(1536.), px(864.))
     );
 }
 

--- a/app/ai-chat/src/state/workspace/tests.rs
+++ b/app/ai-chat/src/state/workspace/tests.rs
@@ -1,4 +1,7 @@
-use super::{ConversationDraft, PersistedWorkspaceState, WorkspaceState, persistence::*};
+use super::{
+    ConversationDraft, PersistedWorkspaceState, SIDEBAR_DEFAULT_WIDTH, SIDEBAR_MAX_WIDTH,
+    SIDEBAR_MIN_WIDTH, WorkspaceState, persistence::*,
+};
 use crate::database::Mode;
 
 fn sample_request_template() -> serde_json::Value {
@@ -126,6 +129,41 @@ sidebar_width = 300.0
     .unwrap();
 
     assert_eq!(state.latest_model_preset, None);
+}
+
+#[test]
+fn sidebar_width_clamps_persisted_values() {
+    let below_min = WorkspaceState {
+        persisted: PersistedWorkspaceState {
+            sidebar_width: f32::from(SIDEBAR_MIN_WIDTH) - 1.,
+            ..PersistedWorkspaceState::default()
+        },
+        tabs: Vec::new(),
+        active_tab: None,
+        save_task: None,
+    };
+    let above_max = WorkspaceState {
+        persisted: PersistedWorkspaceState {
+            sidebar_width: f32::from(SIDEBAR_MAX_WIDTH) + 1.,
+            ..PersistedWorkspaceState::default()
+        },
+        tabs: Vec::new(),
+        active_tab: None,
+        save_task: None,
+    };
+    let normal = WorkspaceState {
+        persisted: PersistedWorkspaceState {
+            sidebar_width: f32::from(SIDEBAR_DEFAULT_WIDTH),
+            ..PersistedWorkspaceState::default()
+        },
+        tabs: Vec::new(),
+        active_tab: None,
+        save_task: None,
+    };
+
+    assert_eq!(below_min.sidebar_width(), SIDEBAR_MIN_WIDTH);
+    assert_eq!(above_max.sidebar_width(), SIDEBAR_MAX_WIDTH);
+    assert_eq!(normal.sidebar_width(), SIDEBAR_DEFAULT_WIDTH);
 }
 
 #[test]

--- a/app/ai-chat/src/state/workspace/tests.rs
+++ b/app/ai-chat/src/state/workspace/tests.rs
@@ -208,6 +208,10 @@ fn persisted_window_bounds_resolve_only_when_visible_on_current_display() {
         None
     );
     assert_eq!(
+        resolve_persisted_window_bounds(Some(window_bounds(-1100., 20., 1200., 800.)), &displays),
+        None
+    );
+    assert_eq!(
         resolve_persisted_window_bounds(
             Some(PersistedWindowBounds {
                 display_id: Some(99),

--- a/app/ai-chat/src/state/workspace/tests.rs
+++ b/app/ai-chat/src/state/workspace/tests.rs
@@ -1,8 +1,9 @@
 use super::{
     ConversationDraft, PersistedWorkspaceState, SIDEBAR_DEFAULT_WIDTH, SIDEBAR_MAX_WIDTH,
-    SIDEBAR_MIN_WIDTH, WorkspaceState, persistence::*,
+    SIDEBAR_MIN_WIDTH, WindowPlacementKind, WorkspaceState, persistence::*,
 };
 use crate::database::Mode;
+use gpui::{Bounds, WindowBounds, point, px, size};
 
 fn sample_request_template() -> serde_json::Value {
     serde_json::json!({
@@ -129,6 +130,141 @@ sidebar_width = 300.0
     .unwrap();
 
     assert_eq!(state.latest_model_preset, None);
+    assert_eq!(state.main_window_bounds, None);
+    assert_eq!(state.settings_window_bounds, None);
+}
+
+fn window_bounds(x: f32, y: f32, width: f32, height: f32) -> PersistedWindowBounds {
+    PersistedWindowBounds {
+        mode: PersistedWindowMode::Windowed,
+        x,
+        y,
+        width,
+        height,
+        display_id: Some(1),
+    }
+}
+
+fn display(
+    id: u32,
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+    is_primary: bool,
+) -> WindowDisplaySnapshot {
+    WindowDisplaySnapshot {
+        id,
+        bounds: Bounds::new(point(px(x), px(y)), size(px(width), px(height))),
+        is_primary,
+    }
+}
+
+#[test]
+fn persisted_workspace_state_roundtrips_window_bounds_per_window_type() {
+    let main_window_bounds = window_bounds(10., 20., 1200., 800.);
+    let settings_window_bounds = PersistedWindowBounds {
+        mode: PersistedWindowMode::Maximized,
+        x: 50.,
+        y: 60.,
+        width: 960.,
+        height: 720.,
+        display_id: Some(2),
+    };
+    let state = PersistedWorkspaceState {
+        main_window_bounds: Some(main_window_bounds),
+        settings_window_bounds: Some(settings_window_bounds),
+        ..PersistedWorkspaceState::default()
+    };
+
+    let text = toml::to_string_pretty(&state).unwrap();
+    let parsed: PersistedWorkspaceState = toml::from_str(&text).unwrap();
+
+    assert_eq!(parsed.main_window_bounds, Some(main_window_bounds));
+    assert_eq!(parsed.settings_window_bounds, Some(settings_window_bounds));
+}
+
+#[test]
+fn persisted_window_bounds_resolve_only_when_visible_on_current_display() {
+    let displays = vec![display(1, 0., 0., 1440., 900., true)];
+    let valid = window_bounds(10., 20., 1200., 800.);
+
+    let resolved = resolve_persisted_window_bounds(Some(valid), &displays).unwrap();
+
+    assert_eq!(resolved.display_id, 1);
+    assert_eq!(
+        resolved.window_bounds,
+        WindowBounds::Windowed(Bounds::new(
+            point(px(10.), px(20.)),
+            size(px(1200.), px(800.)),
+        ))
+    );
+    assert_eq!(
+        resolve_persisted_window_bounds(Some(window_bounds(10., 20., 0., 800.)), &displays),
+        None
+    );
+    assert_eq!(
+        resolve_persisted_window_bounds(Some(window_bounds(2000., 20., 1200., 800.)), &displays),
+        None
+    );
+    assert_eq!(
+        resolve_persisted_window_bounds(
+            Some(PersistedWindowBounds {
+                display_id: Some(99),
+                ..valid
+            }),
+            &displays,
+        ),
+        None
+    );
+}
+
+#[test]
+fn fallback_display_prefers_saved_display_then_primary() {
+    let displays = vec![
+        display(1, 0., 0., 1440., 900., true),
+        display(2, 1440., 0., 1920., 1080., false),
+    ];
+
+    assert_eq!(
+        fallback_display_id_for_persisted_window(
+            Some(PersistedWindowBounds {
+                display_id: Some(2),
+                ..window_bounds(3000., 3000., 1200., 800.)
+            }),
+            &displays,
+        ),
+        Some(2)
+    );
+    assert_eq!(
+        fallback_display_id_for_persisted_window(
+            Some(PersistedWindowBounds {
+                display_id: Some(99),
+                ..window_bounds(3000., 3000., 1200., 800.)
+            }),
+            &displays,
+        ),
+        Some(1)
+    );
+}
+
+#[test]
+fn window_bounds_updates_are_separated_by_window_type() {
+    let main = window_bounds(10., 20., 1200., 800.);
+    let settings = window_bounds(30., 40., 960., 720.);
+    let mut state = WorkspaceState {
+        persisted: PersistedWorkspaceState::default(),
+        tabs: Vec::new(),
+        active_tab: None,
+        save_task: None,
+    };
+
+    assert!(state.update_persisted_window_bounds(WindowPlacementKind::Main, main));
+    assert!(!state.update_persisted_window_bounds(WindowPlacementKind::Main, main));
+    assert!(state.update_persisted_window_bounds(WindowPlacementKind::Settings, settings));
+
+    assert_eq!(state.persisted.main_window_bounds, Some(main));
+    assert_eq!(state.persisted.settings_window_bounds, Some(settings));
 }
 
 #[test]

--- a/app/ai-chat/src/views/home.rs
+++ b/app/ai-chat/src/views/home.rs
@@ -186,6 +186,10 @@ impl Render for HomeView {
                                 .child(
                                     resizable_panel()
                                         .size(sidebar_width)
+                                        .size_range(
+                                            state::workspace::SIDEBAR_MIN_WIDTH
+                                                ..state::workspace::SIDEBAR_MAX_WIDTH,
+                                        )
                                         .child(self.sidebar.clone()),
                                 )
                                 .child(self.tabs.clone().into_any_element()),

--- a/app/ai-chat/src/views/home.rs
+++ b/app/ai-chat/src/views/home.rs
@@ -4,7 +4,7 @@ use crate::{
         add_conversation::open_add_conversation_dialog, add_folder::open_add_folder_dialog,
     },
     i18n::I18n,
-    state::{self, AiChatConfig, WorkspaceStore},
+    state::{self, AiChatConfig, WindowPlacementKind, WorkspaceStore},
     views::home::{sidebar::SidebarView, tabs::TabsView},
 };
 use gpui::{prelude::FluentBuilder, *};
@@ -72,6 +72,21 @@ impl HomeView {
             _subscriptions: vec![
                 cx.observe(&workspace, |_state, _workspace, cx| {
                     cx.notify();
+                }),
+                cx.observe_window_bounds(window, |_state, window, cx| {
+                    let window_bounds = window.window_bounds();
+                    let display_id = window.display(cx).map(|display| display.id());
+                    cx.global::<WorkspaceStore>()
+                        .deref()
+                        .clone()
+                        .update(cx, |workspace, cx| {
+                            workspace.set_window_bounds(
+                                WindowPlacementKind::Main,
+                                window_bounds,
+                                display_id,
+                                cx,
+                            );
+                        });
                 }),
                 cx.observe_window_appearance(window, |_state, window, cx| {
                     let theme_registry = ThemeRegistry::global(cx);

--- a/app/ai-chat/src/views/home/sidebar.rs
+++ b/app/ai-chat/src/views/home/sidebar.rs
@@ -121,6 +121,8 @@ impl Render for SidebarView {
                 Sidebar::new("sidebar")
                     .side(Side::Left)
                     .w_full()
+                    .collapsible(false)
+                    .collapsed(false)
                     .header(SidebarHeader::new().child(app_title))
                     .child(SidebarSection::Tree(
                         SidebarGroup::new(conversation_tree_title).child(

--- a/app/ai-chat/src/views/home/sidebar.rs
+++ b/app/ai-chat/src/views/home/sidebar.rs
@@ -8,7 +8,6 @@ use crate::{
 use gpui::*;
 use gpui_component::{
     Collapsible, Side,
-    menu::ContextMenuExt,
     sidebar::{Sidebar, SidebarGroup, SidebarHeader, SidebarItem, SidebarMenu, SidebarMenuItem},
     v_flex,
 };
@@ -98,7 +97,6 @@ impl Render for SidebarView {
             template_list_label,
             add_conversation_label,
             add_folder_label,
-            root_label,
         ) = {
             let i18n = cx.global::<I18n>();
             (
@@ -110,9 +108,9 @@ impl Render for SidebarView {
                 i18n.t("sidebar-template-list"),
                 i18n.t("sidebar-add-conversation"),
                 i18n.t("sidebar-add-folder"),
-                i18n.t("sidebar-root"),
             )
         };
+        let root_label = cx.global::<I18n>().t("sidebar-root");
         v_flex()
             .key_context(CONTEXT)
             .track_focus(&self.focus_handle)
@@ -204,17 +202,5 @@ impl Render for SidebarView {
                         ),
                     )),
             )
-            .context_menu(move |this, _window, _cx| {
-                let add_conversation_label = add_conversation_label.clone();
-                let add_folder_label = add_folder_label.clone();
-                this.check_side(Side::Left)
-                    .external_link_icon(false)
-                    .menu_with_icon(
-                        add_conversation_label,
-                        IconName::Plus,
-                        Box::new(AddConversation),
-                    )
-                    .menu_with_icon(add_folder_label, IconName::Plus, Box::new(AddFolder))
-            })
     }
 }

--- a/app/ai-chat/src/views/home/sidebar/conversation_tree.rs
+++ b/app/ai-chat/src/views/home/sidebar/conversation_tree.rs
@@ -5,6 +5,7 @@ use crate::{
         add_conversation::open_add_conversation_dialog, add_folder::open_add_folder_dialog,
     },
     database::{Conversation, Folder},
+    i18n::I18n,
     state::{ChatData, ChatDataEvent, ChatDataInner},
 };
 use gpui::{prelude::FluentBuilder as _, *};
@@ -253,7 +254,8 @@ impl SidebarItem for ConversationTree {
                             .justify_center()
                             .text_sm()
                             .text_color(cx.theme().muted_foreground)
-                            .child(root_label),
+                            .child(root_label)
+                            .context_menu(root_context_menu),
                     )
                     .on_drag_move::<DragConversationTreeItem>({
                         move |event, window, cx| {
@@ -275,10 +277,8 @@ impl SidebarItem for ConversationTree {
                             return;
                         }
                         drag.move_to_root(cx);
-                    })
-                    .context_menu(root_context_menu),
+                    }),
             )
-            .context_menu(root_context_menu)
     }
 }
 
@@ -486,16 +486,17 @@ impl Render for DragConversationTreeItem {
 fn root_context_menu(
     menu: PopupMenu,
     _window: &mut Window,
-    _cx: &mut Context<PopupMenu>,
+    cx: &mut Context<PopupMenu>,
 ) -> PopupMenu {
+    let i18n = cx.global::<I18n>();
     menu.check_side(Side::Left)
         .item(
-            PopupMenuItem::new("Add Conversation")
+            PopupMenuItem::new(i18n.t("sidebar-add-conversation"))
                 .icon(IconName::Plus)
                 .on_click(|_, window, cx| open_add_conversation_dialog(None, None, window, cx)),
         )
         .item(
-            PopupMenuItem::new("Add Folder")
+            PopupMenuItem::new(i18n.t("sidebar-add-folder"))
                 .icon(IconName::Plus)
                 .on_click(|_, window, cx| open_add_folder_dialog(None, window, cx)),
         )

--- a/app/ai-chat/src/views/home/tabs/template_detail.rs
+++ b/app/ai-chat/src/views/home/tabs/template_detail.rs
@@ -17,7 +17,6 @@ use gpui_component::{
     h_flex,
     label::Label,
     notification::{Notification, NotificationType},
-    scroll::ScrollableElement,
     text::TextView,
     v_flex,
 };
@@ -192,8 +191,10 @@ impl Render for TemplateDetailView {
         let reload_label = cx.global::<I18n>().t("button-reload");
         v_flex()
             .size_full()
+            .overflow_hidden()
             .child(
                 h_flex()
+                    .flex_initial()
                     .items_center()
                     .justify_end()
                     .gap_2()
@@ -232,7 +233,8 @@ impl Render for TemplateDetailView {
             .child(match &self.template {
                 Ok(template) => render_template_detail(template, window, cx),
                 Err(err) => v_flex()
-                    .size_full()
+                    .flex_1()
+                    .min_h_0()
                     .items_center()
                     .justify_center()
                     .child(Label::new(format!("{load_template_failed}: {err}")).text_sm())
@@ -257,11 +259,13 @@ fn render_template_detail(
             .span(3),
     ];
 
-    div()
+    v_flex()
         .id(template.id)
         .flex_1()
+        .min_h_0()
         .gap_3()
         .px_4()
+        .py_3()
         .child(Label::new(i18n.t("section-information")).text_lg())
         .child(
             div().child(
@@ -272,21 +276,13 @@ fn render_template_detail(
             ),
         )
         .child(Label::new(i18n.t("field-prompts")).text_lg())
-        .child(
-            div().id("template-prompts").children(
-                template
-                    .prompts
-                    .iter()
-                    .enumerate()
-                    .map(|(index, prompt)| {
-                        render_prompt_message(template.id, index, prompt, window, cx)
-                    })
-                    .collect::<Vec<_>>(),
-            ),
-        )
-        .child(div().h_4())
-        .overflow_hidden()
-        .overflow_y_scrollbar()
+        .child(v_flex().id("template-prompts").children(
+            template.prompts.iter().enumerate().map(|(index, prompt)| {
+                render_prompt_message(template.id, index, prompt, window, cx)
+            }),
+        ))
+        .overflow_x_hidden()
+        .overflow_y_scroll()
         .into_any_element()
 }
 

--- a/app/ai-chat/src/views/settings.rs
+++ b/app/ai-chat/src/views/settings.rs
@@ -4,7 +4,7 @@ use crate::{
     components::hotkey_input::{HotkeyEvent, HotkeyInput, string_to_keystroke},
     i18n::{self, I18n},
     llm::provider_setting_groups,
-    state::{AiChatConfig, Language},
+    state::{AiChatConfig, Language, WindowPlacementKind, WorkspaceStore},
     tray,
 };
 use gpui::*;
@@ -17,7 +17,7 @@ use gpui_component::{
     setting::{SettingField, SettingGroup, SettingItem, SettingPage, Settings},
     v_flex,
 };
-use std::any::TypeId;
+use std::{any::TypeId, ops::Deref};
 use tracing::{Level, event};
 
 pub(super) mod appearance_settings;
@@ -33,6 +33,8 @@ enum SettingsOpenTarget {
     General,
     Provider,
 }
+
+const SETTINGS_WINDOW_FALLBACK_SIZE: Size<Pixels> = size(px(960.), px(720.));
 
 pub fn init(cx: &mut App) {
     cx.bind_keys([KeyBinding::new(
@@ -67,7 +69,28 @@ impl SettingsView {
         });
         let appearance_settings = cx.new(|cx| AppearanceSettingsPage::new(window, cx));
         let shortcut_settings = cx.new(|cx| ShortcutSettingsPage::new(window, cx));
-        let _subscriptions = vec![cx.subscribe(&hotkey_input, Self::subscribe_hotkey_changes)];
+        let _subscriptions = vec![
+            cx.subscribe(&hotkey_input, Self::subscribe_hotkey_changes),
+            cx.observe_window_bounds(window, |_settings, window, cx| {
+                if !cx.has_global::<WorkspaceStore>() {
+                    return;
+                }
+
+                let window_bounds = window.window_bounds();
+                let display_id = window.display(cx).map(|display| display.id());
+                cx.global::<WorkspaceStore>()
+                    .deref()
+                    .clone()
+                    .update(cx, |workspace, cx| {
+                        workspace.set_window_bounds(
+                            WindowPlacementKind::Settings,
+                            window_bounds,
+                            display_id,
+                            cx,
+                        );
+                    });
+            }),
+        ];
         Self {
             focus_handle,
             hotkey_input,
@@ -328,8 +351,15 @@ fn open_settings_window_to(target: SettingsOpenTarget, toggle_if_active: bool, c
 
 fn inner_open_settings_window(target: SettingsOpenTarget, cx: &mut App) {
     let title = cx.global::<I18n>().t("settings-title");
+    let placement = crate::state::workspace::restored_window_placement(
+        WindowPlacementKind::Settings,
+        SETTINGS_WINDOW_FALLBACK_SIZE,
+        cx,
+    );
     match cx.open_window(
         WindowOptions {
+            window_bounds: Some(placement.window_bounds),
+            display_id: placement.display_id,
             titlebar: Some(settings_titlebar_options(title)),
             window_background: WindowBackgroundAppearance::Blurred,
             ..Default::default()


### PR DESCRIPTION
## Summary

- Hardens `ai-chat` stability across known UI, layout, persistence, context menu, and Ollama provider bugs.
- Affected app: `ai-chat`.

## Motivation

This PR bundles the six ai-chat stability sub-issues tracked under the main hardening issue so the fixes can land together on `main`.

## Changes

- Improves model picker hover responsiveness by moving hover/selected styling to the row root and reducing unnecessary model picker state churn.
- Fixes sidebar resize so the visual sidebar width changes with the resizable panel and persisted widths are clamped to a usable range.
- Fixes template detail scrolling with a constrained flex layout so long template content can scroll instead of being clipped.
- Fixes duplicate sidebar context menus by narrowing root context menu attachment to the root/empty drop area and preserving row-specific menus.
- Persists main window and settings window bounds separately, restores them by window type, and validates saved bounds against current displays.
- Defaults Ollama boolean thinking models such as Qwen/Qianwen to `think: false` while preserving GPT-OSS level-thinking behavior.

## Validation

- [x] `cargo build`
- [x] `cargo test`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
cargo test -p ai-chat
passed; 216 passed, 0 failed

cargo build -p ai-chat
passed
```

Earlier child-branch validation also included targeted checks for model picker, sidebar width, template detail, context menu, window bounds, and Ollama request template behavior. Full clippy and final manual UI verification were not run in this step.

## Risks

- Several fixes are UI-behavior changes and should receive final manual verification in the desktop app before merge.
- Window bounds restore depends on real display/window-manager behavior; tests cover persistence and display validation, but manual multi-window validation is still useful.
- Existing saved Qwen/Qianwen templates that omitted `think` now resolve to `think: false`, matching the visible disabled toggle state.

## Related Issues

- Closes #66
- Closes #67
- Closes #68
- Closes #69
- Closes #70
- Closes #71
- Closes #72
