### PR TITLE
ai-chat: Add system accent theme and titlebar menus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7893,6 +7893,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 name = "platform-ext"
 version = "0.1.0"
 dependencies = [
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,7 +1063,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1084,7 +1084,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -1780,7 +1780,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "indexmap 2.14.0",
  "rustc-hash 2.1.2",
@@ -2578,7 +2578,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2776,7 +2776,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.8.9",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -4224,7 +4224,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.62.2",
+ "windows 0.56.0",
 ]
 
 [[package]]
@@ -4250,7 +4250,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -4288,7 +4288,6 @@ dependencies = [
  "mach2",
  "media",
  "metal",
- "naga 29.0.1",
  "num_cpus",
  "objc",
  "parking",
@@ -4331,7 +4330,7 @@ dependencies = [
 [[package]]
 name = "gpui-component"
 version = "0.5.1"
-source = "git+https://github.com/longbridge/gpui-component#9e252d8667e18039c4c3a64cde02758d6cfdf47a"
+source = "git+https://github.com/longbridge/gpui-component#41f51428c563597af4f04fb476141d3311a1c0c4"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4407,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "gpui-component-assets"
 version = "0.5.1"
-source = "git+https://github.com/longbridge/gpui-component#9e252d8667e18039c4c3a64cde02758d6cfdf47a"
+source = "git+https://github.com/longbridge/gpui-component#41f51428c563597af4f04fb476141d3311a1c0c4"
 dependencies = [
  "anyhow",
  "gpui",
@@ -4421,7 +4420,7 @@ dependencies = [
 [[package]]
 name = "gpui-component-macros"
 version = "0.5.1"
-source = "git+https://github.com/longbridge/gpui-component#9e252d8667e18039c4c3a64cde02758d6cfdf47a"
+source = "git+https://github.com/longbridge/gpui-component#41f51428c563597af4f04fb476141d3311a1c0c4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4431,7 +4430,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "anyhow",
  "as-raw-xcb-connection",
@@ -4480,7 +4479,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "anyhow",
  "async-task",
@@ -4523,7 +4522,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4534,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -4547,7 +4546,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "schemars 1.2.1",
  "serde",
@@ -4557,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "anyhow",
  "log",
@@ -4566,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -4590,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4618,7 +4617,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "anyhow",
  "collections",
@@ -5007,7 +5006,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -5139,7 +5138,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -5159,7 +5158,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.56.0",
 ]
 
 [[package]]
@@ -6275,7 +6274,7 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "anyhow",
  "bindgen 0.71.1",
@@ -6456,31 +6455,6 @@ dependencies = [
  "once_cell",
  "rustc-hash 1.1.0",
  "spirv",
- "thiserror 2.0.18",
- "unicode-ident",
-]
-
-[[package]]
-name = "naga"
-version = "29.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2630921705b9b01dcdd0b6864b9562ca3c1951eecd0f0c4f5f04f61e412647"
-dependencies = [
- "arrayvec",
- "bit-set",
- "bitflags 2.11.1",
- "cfg-if",
- "cfg_aliases",
- "codespan-reporting",
- "half",
- "hashbrown 0.16.1",
- "hexf-parse",
- "indexmap 2.14.0",
- "libm",
- "log",
- "num-traits",
- "once_cell",
- "rustc-hash 1.1.0",
  "thiserror 2.0.18",
  "unicode-ident",
 ]
@@ -6826,7 +6800,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7314,7 +7288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -7551,7 +7525,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "collections",
  "serde",
@@ -7611,7 +7585,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitfield",
  "block-padding",
  "blowfish",
@@ -8257,7 +8231,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.39",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8295,7 +8269,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8633,7 +8607,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "derive_refineable",
 ]
@@ -9280,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "async-task",
  "backtrace",
@@ -9786,7 +9760,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 6.0.0",
+ "dirs 5.0.1",
 ]
 
 [[package]]
@@ -10176,7 +10150,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "heapless",
  "log",
@@ -10383,7 +10357,7 @@ dependencies = [
  "memchr",
  "ntapi",
  "rayon",
- "windows 0.57.0",
+ "windows 0.56.0",
 ]
 
 [[package]]
@@ -11945,7 +11919,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "anyhow",
  "async-fs",
@@ -11984,7 +11958,7 @@ dependencies = [
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "perf",
  "quote",
@@ -12460,7 +12434,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "js-sys",
  "log",
- "naga 29.0.0",
+ "naga",
  "parking_lot",
  "portable-atomic",
  "profiling",
@@ -12490,7 +12464,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "log",
- "naga 29.0.0",
+ "naga",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -12555,7 +12529,7 @@ dependencies = [
  "libc",
  "libloading 0.8.9",
  "log",
- "naga 29.0.0",
+ "naga",
  "ndk-sys",
  "objc2 0.6.4",
  "objc2-core-foundation",
@@ -12588,7 +12562,7 @@ name = "wgpu-naga-bridge"
 version = "29.0.0"
 source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
 dependencies = [
- "naga 29.0.0",
+ "naga",
  "wgpu-types",
 ]
 
@@ -12666,7 +12640,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -12704,16 +12678,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
 dependencies = [
  "windows-core 0.56.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
  "windows-targets 0.52.6",
 ]
 
@@ -12798,18 +12762,6 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
@@ -12869,17 +12821,6 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
@@ -12894,17 +12835,6 @@ name = "windows-interface"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14183,7 +14113,7 @@ checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "anyhow",
  "chrono",
@@ -14240,7 +14170,7 @@ dependencies = [
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -14251,7 +14181,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#872faf0a7bb2f79ef5180f284ee80df97ef39b3b"
+source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
  "nom 8.0.0",
  "pinyin",
  "platform-ext",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "rust-embed",
  "serde",
  "serde_json",
@@ -630,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -1063,7 +1063,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1084,7 +1084,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1499,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1780,7 +1780,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "indexmap 2.14.0",
  "rustc-hash 2.1.2",
@@ -1820,9 +1820,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "bzip2 0.6.1",
  "compression-core",
@@ -1833,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -2259,22 +2259,22 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
-dependencies = [
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "ctor"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec09e802f5081de6157da9a75701d6c713d8dc3ba52571fd4bd25f412644e8a6"
 dependencies = [
- "ctor-proc-macro",
- "dtor",
+ "ctor-proc-macro 0.0.6",
+ "dtor 0.0.6",
+]
+
+[[package]]
+name = "ctor"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
+dependencies = [
+ "ctor-proc-macro 0.0.7",
+ "dtor 0.3.0",
 ]
 
 [[package]]
@@ -2282,6 +2282,12 @@ name = "ctor-proc-macro"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "ctr"
@@ -2426,9 +2432,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data-url"
@@ -2578,7 +2584,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2625,9 +2631,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.3.8"
+version = "2.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78df0e4e8c596662edb07fbfbb7f23769cca35049827df5f909084d956b6aeaf"
+checksum = "9940fb8467a0a06312218ed384185cb8536aa10d8ec017d0ce7fad2c1bd882d5"
 dependencies = [
  "diesel_derives",
  "downcast-rs 2.0.2",
@@ -2640,9 +2646,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.3.8"
+version = "2.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b79402bd1cfb25b65650f0f4901d0e79c095729e2139c8ab779d025968c7099"
+checksum = "d1817b7f4279b947fc4cafddec12b0e5f8727141706561ce3ac94a60bddd1cf5"
 dependencies = [
  "diesel_table_macro_syntax",
  "dsl_auto_type",
@@ -2776,7 +2782,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -2903,7 +2909,16 @@ version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
 dependencies = [
- "dtor-proc-macro",
+ "dtor-proc-macro 0.0.5",
+]
+
+[[package]]
+name = "dtor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
+dependencies = [
+ "dtor-proc-macro 0.0.6",
 ]
 
 [[package]]
@@ -2911,6 +2926,12 @@ name = "dtor-proc-macro"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"
@@ -3033,14 +3054,14 @@ dependencies = [
 
 [[package]]
 name = "embed-resource"
-version = "3.0.8"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a1d0de4f2249aa0ff5884d7080814f446bb241a559af6c170a41e878ed2d45"
+checksum = "c31a88c8d26de40ed18fe748c547845aa39de1db3afd958f8cb91579f3644bcb"
 dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "vswhom",
  "winreg 0.55.0",
 ]
@@ -3301,23 +3322,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -3343,7 +3350,7 @@ dependencies = [
  "gpui_platform",
  "nom 8.0.0",
  "regex",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "scraper",
  "sys-locale",
  "thiserror 2.0.18",
@@ -4224,7 +4231,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.56.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -4250,7 +4257,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -4430,7 +4437,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "anyhow",
  "as-raw-xcb-connection",
@@ -4479,7 +4486,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "anyhow",
  "async-task",
@@ -4522,7 +4529,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4533,7 +4540,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -4546,7 +4553,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "schemars 1.2.1",
  "serde",
@@ -4556,7 +4563,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "anyhow",
  "log",
@@ -4565,7 +4572,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -4589,7 +4596,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4617,7 +4624,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "anyhow",
  "collections",
@@ -5006,7 +5013,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -5114,7 +5121,7 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "rustls-native-certs 0.8.3",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -5138,7 +5145,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -5158,7 +5165,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.56.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5296,9 +5303,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -5362,9 +5369,9 @@ checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "imgref"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
 
 [[package]]
 name = "indexmap"
@@ -5623,6 +5630,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5662,9 +5699,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -6274,7 +6311,7 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "anyhow",
  "bindgen 0.71.1",
@@ -6416,9 +6453,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
+checksum = "0ae8844f63b5b118e334e205585b8c5c17b984121dbdb179d44aeb087ffad3cb"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -6429,9 +6466,9 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png 0.17.16",
+ "png 0.18.1",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6605,7 +6642,7 @@ dependencies = [
  "gpui-component-assets",
  "gpui_platform",
  "nom 8.0.0",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "scraper",
  "smol",
  "sys-locale",
@@ -6800,7 +6837,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7288,7 +7325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7525,7 +7562,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "collections",
  "serde",
@@ -7585,7 +7622,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitfield",
  "block-padding",
  "blowfish",
@@ -7883,13 +7920,13 @@ dependencies = [
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.38.4",
+ "quick-xml 0.39.2",
  "serde",
  "time",
 ]
@@ -8202,15 +8239,6 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
@@ -8230,8 +8258,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.2",
- "rustls 0.23.39",
- "socket2 0.5.10",
+ "rustls 0.23.40",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8251,7 +8279,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -8269,7 +8297,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8607,7 +8635,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "derive_refineable",
 ]
@@ -8691,9 +8719,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -8713,9 +8741,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.7.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -9044,9 +9072,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -9115,9 +9143,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -9131,10 +9159,31 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.0",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
- "rustls 0.23.39",
+ "rustls 0.23.40",
+ "rustls-native-certs 0.8.3",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.13",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls 0.23.40",
  "rustls-native-certs 0.8.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
@@ -9254,7 +9303,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "async-task",
  "backtrace",
@@ -9760,7 +9809,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 5.0.1",
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -9796,6 +9845,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simd_helpers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9803,6 +9862,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple-file-manifest"
@@ -10150,7 +10215,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "heapless",
  "log",
@@ -10357,7 +10422,7 @@ dependencies = [
  "memchr",
  "ntapi",
  "rayon",
- "windows 0.56.0",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -10500,9 +10565,9 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tauri-bundler"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0406e4f78c2caa61e312c2f98d4f9e97f11d0e3de55ced8f10cb3e34517c249"
+checksum = "048996da51f512d2a1927b1a221ba68eead6388524b2baf51702e043ed3e96c6"
 dependencies = [
  "anyhow",
  "ar",
@@ -10557,11 +10622,12 @@ dependencies = [
 
 [[package]]
 name = "tauri-macos-sign"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f96c9ec3386d9e9e72d0d4a1bae976e14c92245212689b0f19dd8fb98ac391b"
+checksum = "6b840687598c778dfb4a83f175a8885573d04c336266b8a2c2df5deabade92ea"
 dependencies = [
  "apple-codesign",
+ "base64 0.22.1",
  "chrono",
  "dirs 6.0.0",
  "log",
@@ -10580,12 +10646,12 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.8.3"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d"
+checksum = "55f61d2bf7188fbcf2b0ed095b67a6bc498f713c939314bb19eb700118a573b7"
 dependencies = [
  "anyhow",
- "ctor 0.2.9",
+ "ctor 0.8.0",
  "dunce",
  "glob",
  "http 1.4.0",
@@ -10594,6 +10660,7 @@ dependencies = [
  "log",
  "memchr",
  "phf 0.11.3",
+ "plist",
  "regex",
  "semver",
  "serde",
@@ -10601,7 +10668,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -10856,7 +10923,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -10899,21 +10966,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap 2.14.0",
- "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
@@ -10934,15 +10986,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]
@@ -11134,9 +11177,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.22.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9eb1da86bd0ab8931fad00650d2ba7473260c5bab06d6f24d04339edb88faa"
+checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
 dependencies = [
  "crossbeam-channel",
  "dirs 6.0.0",
@@ -11150,7 +11193,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11819,9 +11862,9 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "percent-encoding",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.6.2",
  "socks",
  "ureq-proto",
  "utf8-zero",
@@ -11919,7 +11962,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "anyhow",
  "async-fs",
@@ -11958,7 +12001,7 @@ dependencies = [
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "perf",
  "quote",
@@ -12120,9 +12163,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -12133,9 +12176,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12143,9 +12186,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -12153,9 +12196,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -12166,9 +12209,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -12360,9 +12403,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12640,7 +12683,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12678,6 +12721,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
 dependencies = [
  "windows-core 0.56.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
  "windows-targets 0.52.6",
 ]
 
@@ -12762,6 +12815,18 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
@@ -12821,6 +12886,17 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
@@ -12835,6 +12911,17 @@ name = "windows-interface"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13754,9 +13841,9 @@ checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
 
 [[package]]
 name = "yeslogic-fontconfig-sys"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503a066b4c037c440169d995b869046827dbc71263f6e8f3be6d77d4f3229dbd"
+checksum = "1d8b8abf912b9a29ff112e1671c97c33636903d13a69712037190e6805af4f76"
 dependencies = [
  "dlib",
  "once_cell",
@@ -13788,9 +13875,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.14.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -13815,7 +13902,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 0.7.15",
+ "winnow 1.0.2",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -13823,9 +13910,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.14.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -13838,12 +13925,12 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.3.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "winnow 0.7.15",
+ "winnow 1.0.2",
  "zvariant",
 ]
 
@@ -13897,7 +13984,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.39",
+ "rustls 0.23.40",
  "rustls-native-certs 0.8.3",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -14113,7 +14200,7 @@ checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "anyhow",
  "chrono",
@@ -14170,7 +14257,7 @@ dependencies = [
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -14181,7 +14268,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#c499a95218fa123b2400636b2e3c4e2ed05c0610"
+source = "git+https://github.com/zed-industries/zed#950161ff0ff34d313c795eef6c28b958cb487039"
 
 [[package]]
 name = "zune-core"
@@ -14224,24 +14311,24 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.10.0"
+version = "5.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+checksum = "c4db0ecb8987cf5e92653c57c098f7f0e39a03112edb796f4fe089fb7eaa14ff"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "serde_bytes",
- "winnow 0.7.15",
+ "winnow 1.0.2",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.10.0"
+version = "5.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+checksum = "5b949b639ab1b4bed763aa7481ba0e368af68d8b55532f8ed4bec86a59f2ca98"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -14252,13 +14339,13 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
  "syn 2.0.117",
- "winnow 0.7.15",
+ "winnow 1.0.2",
 ]

--- a/app/ai-chat/Cargo.toml
+++ b/app/ai-chat/Cargo.toml
@@ -48,7 +48,7 @@ platform-ext = { workspace = true }
 material-color-utils = { version = "0.1.3", default-features = false }
 rust-embed = { version = "8.11.0", features = ["interpolate-folder-path"] }
 anyhow = "1.0.102"
-tray-icon = { version = "0.22.1", default-features = false, features = ["common-controls-v6"] }
+tray-icon = { version = "0.23.1", default-features = false, features = ["common-controls-v6"] }
 image = { version = "0.25.10", default-features = false, features = ["png"] }
 
 # i18n
@@ -60,7 +60,7 @@ sys-locale = "0.3.2"
 thiserror = "2.0.18"
 
 # database
-diesel = { version = "2.3.8", features = [
+diesel = { version = "2.3.9", features = [
   "sqlite",
   "r2d2",
   "time",
@@ -80,7 +80,7 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["local-time"] }
 
 # http request
-reqwest = { version = "0.13.2", features = ["json", "stream"] }
+reqwest = { version = "0.13.3", features = ["json", "stream"] }
 tokio = { version = "1.52.1", features = [
   "rt",
   "rt-multi-thread",

--- a/app/ai-chat/src/app.rs
+++ b/app/ai-chat/src/app.rs
@@ -1,5 +1,5 @@
 use crate::errors::{AiChatError, AiChatResult};
-use crate::features::home::HomeView;
+use crate::features::{home::HomeView, settings::SettingsView};
 use crate::{components, database, features, foundation, state};
 use foundation::I18n;
 use gpui::*;
@@ -105,7 +105,7 @@ fn init(cx: &mut App) {
     state::config::init(cx);
     foundation::init_i18n(cx);
     menus::init(cx);
-    cx.set_menus(menus::app_menus(cx.global::<I18n>()));
+    menus::sync_app_menus(cx);
     #[cfg(target_os = "macos")]
     menus::ensure_localized_window_menu_registered();
     cx.activate(true);
@@ -183,10 +183,7 @@ pub(crate) fn open_main_window(cx: &mut App) -> Result<WindowHandle<Root>, anyho
         WindowOptions {
             window_bounds: Some(placement.window_bounds),
             display_id: placement.display_id,
-            titlebar: Some(TitlebarOptions {
-                title: Some(title.into()),
-                ..TitleBar::title_bar_options()
-            }),
+            titlebar: Some(main_titlebar_options(title)),
             window_background: WindowBackgroundAppearance::Opaque,
             ..Default::default()
         },
@@ -194,8 +191,34 @@ pub(crate) fn open_main_window(cx: &mut App) -> Result<WindowHandle<Root>, anyho
     )
 }
 
+fn main_titlebar_options(title: impl Into<SharedString>) -> TitlebarOptions {
+    TitlebarOptions {
+        title: Some(title.into()),
+        ..TitleBar::title_bar_options()
+    }
+}
+
 pub(crate) fn find_main_window(cx: &App) -> Option<WindowHandle<Root>> {
     find_window_by_view::<HomeView>(cx)
+}
+
+pub(crate) fn reload_app_menu_bars(cx: &mut App) {
+    let roots = cx
+        .windows()
+        .into_iter()
+        .filter_map(|window| window.downcast::<Root>())
+        .collect::<Vec<_>>();
+
+    for root in roots {
+        let _ = root.update(cx, |root, _window, cx| {
+            let _ = with_root_view::<HomeView, _>(root, cx, |home, cx| {
+                home.update(cx, |home, cx| home.reload_app_menu_bar(cx));
+            });
+            let _ = with_root_view::<SettingsView, _>(root, cx, |settings, cx| {
+                settings.update(cx, |settings, cx| settings.reload_app_menu_bar(cx));
+            });
+        });
+    }
 }
 
 pub(crate) fn show_or_create_main_window(cx: &mut App) {
@@ -304,13 +327,30 @@ pub(crate) fn run() -> AiChatResult<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::should_hide_main_window_on_close;
+    use super::{main_titlebar_options, should_hide_main_window_on_close};
+    use gpui_component::TitleBar;
 
     #[::core::prelude::v1::test]
     fn main_window_close_behavior_matches_platform_support() {
         assert_eq!(
             should_hide_main_window_on_close(),
             cfg!(any(target_os = "macos", target_os = "windows"))
+        );
+    }
+
+    #[test]
+    fn main_window_uses_component_titlebar_options() {
+        let titlebar = main_titlebar_options("AI Chat");
+        let expected = TitleBar::title_bar_options();
+
+        assert_eq!(
+            titlebar.title.as_ref().map(|title| title.as_ref()),
+            Some("AI Chat")
+        );
+        assert_eq!(titlebar.appears_transparent, expected.appears_transparent);
+        assert_eq!(
+            titlebar.traffic_light_position,
+            expected.traffic_light_position
         );
     }
 }

--- a/app/ai-chat/src/app/menus.rs
+++ b/app/ai-chat/src/app/menus.rs
@@ -6,7 +6,8 @@ use crate::{
 use fluent_bundle::FluentArgs;
 #[cfg(target_os = "macos")]
 use gpui::SystemMenuType;
-use gpui::{App, KeyBinding, Menu, MenuItem, actions};
+use gpui::{App, KeyBinding, Menu, MenuItem, OwnedMenu, actions};
+use gpui_component::GlobalState;
 #[cfg(target_os = "macos")]
 use tracing::{Level, event};
 
@@ -88,6 +89,21 @@ pub(crate) fn app_menus(i18n: &I18n) -> Vec<Menu> {
     ]
 }
 
+pub(crate) fn component_app_menus(i18n: &I18n) -> Vec<OwnedMenu> {
+    app_menus(i18n).into_iter().map(Menu::owned).collect()
+}
+
+pub(crate) fn sync_app_menus(cx: &mut App) {
+    let component_menus = component_app_menus(cx.global::<I18n>());
+
+    cx.set_menus(app_menus(cx.global::<I18n>()));
+    GlobalState::global_mut(cx).set_app_menus(component_menus);
+}
+
+pub(crate) const fn should_render_component_menu_bar() -> bool {
+    !cfg!(target_os = "macos")
+}
+
 #[cfg(target_os = "macos")]
 pub(crate) fn ensure_localized_window_menu_registered() {
     match platform_ext::app::set_windows_menu_from_main_menu_index(WINDOW_MENU_INDEX) {
@@ -137,6 +153,10 @@ mod tests {
         menus.iter().map(|menu| menu.name.to_string()).collect()
     }
 
+    fn owned_menu_names(menus: &[OwnedMenu]) -> Vec<String> {
+        menus.iter().map(|menu| menu.name.to_string()).collect()
+    }
+
     fn item_names(items: Vec<MenuItem>) -> Vec<String> {
         items
             .into_iter()
@@ -161,6 +181,24 @@ mod tests {
         let i18n = I18n::for_locale_tag("zh-CN");
 
         assert_eq!(menu_names(&app_menus(&i18n)), vec!["AI 对话", "窗口"]);
+    }
+
+    #[test]
+    fn builds_component_app_menus_from_app_menu_source() {
+        let i18n = I18n::english_for_test();
+
+        assert_eq!(
+            owned_menu_names(&component_app_menus(&i18n)),
+            menu_names(&app_menus(&i18n))
+        );
+    }
+
+    #[test]
+    fn component_menu_bar_visibility_matches_platform() {
+        assert_eq!(
+            should_render_component_menu_bar(),
+            !cfg!(target_os = "macos")
+        );
     }
 
     #[test]

--- a/app/ai-chat/src/app/menus.rs
+++ b/app/ai-chat/src/app/menus.rs
@@ -7,6 +7,7 @@ use fluent_bundle::FluentArgs;
 #[cfg(target_os = "macos")]
 use gpui::SystemMenuType;
 use gpui::{App, KeyBinding, Menu, MenuItem, actions};
+#[cfg(target_os = "macos")]
 use tracing::{Level, event};
 
 actions!(
@@ -25,6 +26,7 @@ actions!(
     ]
 );
 
+#[cfg(any(target_os = "macos", test))]
 const WINDOW_MENU_INDEX: usize = 1;
 
 pub(crate) fn init(cx: &mut App) {
@@ -86,6 +88,7 @@ pub(crate) fn app_menus(i18n: &I18n) -> Vec<Menu> {
     ]
 }
 
+#[cfg(target_os = "macos")]
 pub(crate) fn ensure_localized_window_menu_registered() {
     match platform_ext::app::set_windows_menu_from_main_menu_index(WINDOW_MENU_INDEX) {
         Ok(()) => {

--- a/app/ai-chat/src/app/tray.rs
+++ b/app/ai-chat/src/app/tray.rs
@@ -191,7 +191,7 @@ fn handle_tray_event(event: TrayIconEvent, cx: &mut AsyncApp) {
 #[cfg(not(target_os = "linux"))]
 fn build_tray_icon(strings: &TrayStrings) -> anyhow::Result<TrayIcon> {
     let menu = build_menu(strings)?;
-    let mut builder = TrayIconBuilder::new()
+    let builder = TrayIconBuilder::new()
         .with_id(TRAY_ICON_ID)
         .with_menu(Box::new(menu))
         .with_tooltip(strings.tooltip.clone())
@@ -199,9 +199,7 @@ fn build_tray_icon(strings: &TrayStrings) -> anyhow::Result<TrayIcon> {
         .with_icon(load_tray_icon()?);
 
     #[cfg(target_os = "macos")]
-    {
-        builder = builder.with_icon_as_template(true);
-    }
+    let builder = builder.with_icon_as_template(true);
 
     builder
         .build()

--- a/app/ai-chat/src/components.rs
+++ b/app/ai-chat/src/components.rs
@@ -7,7 +7,9 @@ pub mod delete_confirm;
 pub mod hotkey_input;
 pub mod message;
 pub(crate) mod search_list;
+pub(crate) mod title_bar_menu;
 
 pub(crate) fn init(cx: &mut App) {
     chat_form::init(cx);
+    title_bar_menu::init(cx);
 }

--- a/app/ai-chat/src/components/title_bar_menu.rs
+++ b/app/ai-chat/src/components/title_bar_menu.rs
@@ -1,0 +1,374 @@
+use crate::foundation::assets::APP_ICON_ASSET_PATH;
+use gpui::{
+    App, AppContext as _, ClickEvent, Context, DismissEvent, Entity, FocusHandle, Focusable,
+    InteractiveElement as _, IntoElement, KeyBinding, MouseButton, OwnedMenu, OwnedMenuItem,
+    ParentElement, Render, SharedString, StatefulInteractiveElement as _, Styled, Subscription,
+    Window, actions, anchored, deferred, div, img, prelude::FluentBuilder as _, px,
+};
+use gpui_component::{ActiveTheme, GlobalState, h_flex, menu::PopupMenu};
+
+actions!(
+    title_bar_app_menu,
+    [
+        CancelTitleBarMenu,
+        SelectPreviousTitleBarMenu,
+        SelectNextTitleBarMenu
+    ]
+);
+
+const CONTEXT: &str = "TitleBarAppMenuBar";
+
+pub(crate) fn init(cx: &mut App) {
+    cx.bind_keys([
+        KeyBinding::new("escape", CancelTitleBarMenu, Some(CONTEXT)),
+        KeyBinding::new("left", SelectPreviousTitleBarMenu, Some(CONTEXT)),
+        KeyBinding::new("right", SelectNextTitleBarMenu, Some(CONTEXT)),
+    ]);
+}
+
+pub(crate) fn title_bar_leading(menu_bar: Entity<TitleBarAppMenuBar>) -> impl IntoElement {
+    h_flex()
+        .items_center()
+        .h_full()
+        .flex_none()
+        .gap_1()
+        .pr_2()
+        .on_mouse_down(MouseButton::Left, |_, window, cx| {
+            window.prevent_default();
+            cx.stop_propagation();
+        })
+        .child(
+            img(APP_ICON_ASSET_PATH)
+                .size(px(16.))
+                .flex_none()
+                .rounded(px(3.)),
+        )
+        .child(menu_bar)
+}
+
+pub(crate) struct TitleBarAppMenuBar {
+    menus: Vec<Entity<TitleBarAppMenu>>,
+    selected_index: Option<usize>,
+    action_context: Option<FocusHandle>,
+}
+
+impl TitleBarAppMenuBar {
+    pub(crate) fn new(cx: &mut App) -> Entity<Self> {
+        cx.new(|cx| {
+            let mut this = Self {
+                menus: Vec::new(),
+                selected_index: None,
+                action_context: None,
+            };
+            this.reload(cx);
+            this
+        })
+    }
+
+    pub(crate) fn reload(&mut self, cx: &mut Context<Self>) {
+        let menu_bar = cx.entity();
+        let menus: Vec<OwnedMenu> = GlobalState::global(cx).app_menus().to_vec();
+        self.menus = menus
+            .iter()
+            .enumerate()
+            .map(|(ix, menu)| TitleBarAppMenu::new(ix, menu, menu_bar.clone(), cx))
+            .collect();
+        self.selected_index = None;
+        self.action_context = None;
+        cx.notify();
+    }
+
+    fn on_move_left(
+        &mut self,
+        _: &SelectPreviousTitleBarMenu,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(selected_index) = self.selected_index else {
+            return;
+        };
+
+        let new_ix = if selected_index == 0 {
+            self.menus.len().saturating_sub(1)
+        } else {
+            selected_index.saturating_sub(1)
+        };
+        self.set_selected_index(Some(new_ix), window, cx);
+    }
+
+    fn on_move_right(
+        &mut self,
+        _: &SelectNextTitleBarMenu,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(selected_index) = self.selected_index else {
+            return;
+        };
+
+        let new_ix = if selected_index + 1 >= self.menus.len() {
+            0
+        } else {
+            selected_index + 1
+        };
+        self.set_selected_index(Some(new_ix), window, cx);
+    }
+
+    fn on_cancel(&mut self, _: &CancelTitleBarMenu, window: &mut Window, cx: &mut Context<Self>) {
+        self.set_selected_index(None, window, cx);
+    }
+
+    fn set_selected_index(
+        &mut self,
+        ix: Option<usize>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.selected_index.is_none() && ix.is_some() {
+            self.action_context = window.focused(cx);
+        } else if ix.is_none() {
+            if let Some(action_context) = self.action_context.as_ref() {
+                action_context.focus(window, cx);
+            }
+            self.action_context = None;
+        }
+
+        self.selected_index = ix;
+        cx.notify();
+    }
+
+    #[inline]
+    fn has_activated_menu(&self) -> bool {
+        self.selected_index.is_some()
+    }
+}
+
+impl Render for TitleBarAppMenuBar {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        h_flex()
+            .id("title-bar-app-menu-bar")
+            .key_context(CONTEXT)
+            .on_action(cx.listener(Self::on_move_left))
+            .on_action(cx.listener(Self::on_move_right))
+            .on_action(cx.listener(Self::on_cancel))
+            .h_full()
+            .gap_x_1()
+            .overflow_x_scroll()
+            .children(self.menus.clone())
+    }
+}
+
+struct TitleBarAppMenu {
+    menu_bar: Entity<TitleBarAppMenuBar>,
+    ix: usize,
+    name: SharedString,
+    menu: OwnedMenu,
+    popup_menu: Option<Entity<PopupMenu>>,
+    _subscription: Option<Subscription>,
+}
+
+impl TitleBarAppMenu {
+    fn new(
+        ix: usize,
+        menu: &OwnedMenu,
+        menu_bar: Entity<TitleBarAppMenuBar>,
+        cx: &mut App,
+    ) -> Entity<Self> {
+        let name = menu.name.clone();
+        cx.new(|_| Self {
+            ix,
+            menu_bar,
+            name,
+            menu: menu.clone(),
+            popup_menu: None,
+            _subscription: None,
+        })
+    }
+
+    fn build_popup_menu(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Entity<PopupMenu> {
+        let action_context = self.menu_bar.read(cx).action_context.clone();
+        let popup_menu = match self.popup_menu.as_ref() {
+            None => {
+                let items = self.menu.items.clone();
+                let popup_menu = PopupMenu::build(window, cx, |menu, window, cx| {
+                    let menu = popup_menu_from_owned_items(menu, items, window, cx);
+                    if let Some(action_context) = action_context {
+                        menu.action_context(action_context)
+                    } else {
+                        menu
+                    }
+                });
+                self._subscription =
+                    Some(cx.subscribe_in(&popup_menu, window, Self::handle_dismiss));
+                self.popup_menu = Some(popup_menu.clone());
+
+                popup_menu
+            }
+            Some(menu) => menu.clone(),
+        };
+
+        let focus_handle = popup_menu.read(cx).focus_handle(cx);
+        if !focus_handle.contains_focused(window, cx) {
+            focus_handle.focus(window, cx);
+        }
+
+        popup_menu
+    }
+
+    fn handle_dismiss(
+        &mut self,
+        _: &Entity<PopupMenu>,
+        _: &DismissEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self._subscription.take();
+        self.popup_menu.take();
+        self.menu_bar.update(cx, |state, cx| {
+            state.on_cancel(&CancelTitleBarMenu, window, cx);
+        });
+    }
+
+    fn handle_trigger_click(
+        &mut self,
+        _: &ClickEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let is_selected = self.menu_bar.read(cx).selected_index == Some(self.ix);
+
+        self.menu_bar.update(cx, |state, cx| {
+            let new_ix = if is_selected { None } else { Some(self.ix) };
+            state.set_selected_index(new_ix, window, cx);
+        });
+    }
+
+    fn handle_hover(&mut self, hovered: &bool, window: &mut Window, cx: &mut Context<Self>) {
+        if !*hovered {
+            return;
+        }
+
+        let has_activated_menu = self.menu_bar.read(cx).has_activated_menu();
+        if !has_activated_menu {
+            return;
+        }
+
+        self.menu_bar.update(cx, |state, cx| {
+            state.set_selected_index(Some(self.ix), window, cx);
+        });
+    }
+}
+
+impl Render for TitleBarAppMenu {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let menu_bar = self.menu_bar.read(cx);
+        let is_selected = menu_bar.selected_index == Some(self.ix);
+
+        div()
+            .id(self.ix)
+            .relative()
+            .child(
+                title_bar_menu_trigger(self.name.clone(), is_selected, cx)
+                    .on_mouse_down(MouseButton::Left, |_, window, cx| {
+                        window.prevent_default();
+                        cx.stop_propagation();
+                    })
+                    .on_click(cx.listener(Self::handle_trigger_click)),
+            )
+            .on_hover(cx.listener(Self::handle_hover))
+            .when(is_selected, |this| {
+                this.child(deferred(
+                    anchored()
+                        .anchor(gpui::Anchor::TopLeft)
+                        .snap_to_window_with_margin(px(8.))
+                        .child(
+                            div()
+                                .size_full()
+                                .occlude()
+                                .top_1()
+                                .child(self.build_popup_menu(window, cx)),
+                        ),
+                ))
+            })
+    }
+}
+
+fn title_bar_menu_trigger(
+    label: impl Into<SharedString>,
+    is_selected: bool,
+    cx: &App,
+) -> gpui::Stateful<gpui::Div> {
+    div()
+        .id("title-bar-menu-trigger")
+        .flex()
+        .items_center()
+        .h(px(24.))
+        .px_2()
+        .py_0p5()
+        .rounded(px(4.))
+        .text_sm()
+        .line_height(gpui::relative(1.))
+        .text_color(cx.theme().foreground)
+        .child(label.into())
+        .hover(|this| this.bg(cx.theme().secondary_hover))
+        .when(is_selected, |this| this.bg(cx.theme().secondary_active))
+}
+
+fn popup_menu_from_owned_items(
+    mut menu: PopupMenu,
+    items: Vec<OwnedMenuItem>,
+    window: &mut Window,
+    cx: &mut Context<PopupMenu>,
+) -> PopupMenu {
+    for item in items {
+        match item {
+            OwnedMenuItem::Action {
+                name,
+                action,
+                checked,
+                disabled,
+                ..
+            } => {
+                menu =
+                    menu.menu_with_check_and_disabled(name, checked, action.boxed_clone(), disabled)
+            }
+            OwnedMenuItem::Separator => {
+                menu = menu.separator();
+            }
+            OwnedMenuItem::Submenu(submenu) => {
+                let submenu_items = submenu.items.clone();
+                menu = menu.submenu(submenu.name, window, cx, move |menu, window, cx| {
+                    popup_menu_from_owned_items(menu, submenu_items.clone(), window, cx)
+                });
+            }
+            OwnedMenuItem::SystemMenu(_) => {}
+        }
+    }
+
+    menu
+}
+
+#[cfg(test)]
+pub(crate) fn title_bar_menu_names(menus: &[OwnedMenu]) -> Vec<String> {
+    menus.iter().map(|menu| menu.name.to_string()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::title_bar_menu_names;
+    use crate::{app::menus, foundation::i18n::I18n};
+
+    #[test]
+    fn builds_title_bar_menu_names_from_owned_menus() {
+        let i18n = I18n::english_for_test();
+
+        assert_eq!(
+            title_bar_menu_names(&menus::component_app_menus(&i18n)),
+            vec!["AI Chat", "Window"]
+        );
+    }
+}

--- a/app/ai-chat/src/features/about.rs
+++ b/app/ai-chat/src/features/about.rs
@@ -1,4 +1,8 @@
-use crate::{app::APP_NAME, app::menus, foundation::i18n::I18n};
+use crate::{
+    app::APP_NAME,
+    app::menus,
+    foundation::{assets::APP_ICON_ASSET_PATH, i18n::I18n},
+};
 use fluent_bundle::FluentArgs;
 use gpui::{
     App, AppContext as _, Context, FocusHandle, Focusable, FontWeight, InteractiveElement,
@@ -8,8 +12,6 @@ use gpui::{
 #[cfg(target_os = "macos")]
 use gpui::{Point, point};
 use gpui_component::{ActiveTheme, Sizable, button::Button, h_flex, label::Label, v_flex};
-
-const ABOUT_APP_ICON: &str = "build-assets/icon/app-icon.ico";
 
 pub(crate) fn open_about_window(cx: &mut App) {
     if let Some(existing) = cx
@@ -133,7 +135,7 @@ impl Render for AboutWindow {
                 v_flex()
                     .items_center()
                     .gap_4()
-                    .child(img(ABOUT_APP_ICON).size(px(72.)).flex_shrink_0())
+                    .child(img(APP_ICON_ASSET_PATH).size(px(72.)).flex_shrink_0())
                     .child(
                         Label::new(i18n.t("app-title"))
                             .text_size(px(20.))

--- a/app/ai-chat/src/features/about.rs
+++ b/app/ai-chat/src/features/about.rs
@@ -52,9 +52,9 @@ fn about_window_size() -> gpui::Size<gpui::Pixels> {
 }
 
 #[cfg(target_os = "macos")]
-fn about_titlebar_options(_: &I18n) -> TitlebarOptions {
+fn about_titlebar_options(i18n: &I18n) -> TitlebarOptions {
     TitlebarOptions {
-        title: None,
+        title: Some(about_window_title(i18n).into()),
         appears_transparent: true,
         traffic_light_position: Some(about_traffic_light_position()),
     }
@@ -68,7 +68,6 @@ fn about_titlebar_options(i18n: &I18n) -> TitlebarOptions {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
 fn about_window_title(i18n: &I18n) -> String {
     let mut args = FluentArgs::new();
     args.set("app_name", i18n.t("app-title"));
@@ -184,10 +183,13 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn macos_about_titlebar_is_transparent_with_visible_traffic_lights() {
+    fn macos_about_titlebar_has_system_title_and_visible_traffic_lights() {
         let titlebar = about_titlebar_options(&I18n::english_for_test());
 
-        assert!(titlebar.title.is_none());
+        assert_eq!(
+            titlebar.title.as_ref().map(|title| title.as_ref()),
+            Some("About AI Chat")
+        );
         assert!(titlebar.appears_transparent);
         assert_eq!(
             titlebar.traffic_light_position,

--- a/app/ai-chat/src/features/home.rs
+++ b/app/ai-chat/src/features/home.rs
@@ -42,6 +42,13 @@ pub fn init(cx: &mut App) {
     tabs::init(cx);
 }
 
+fn apply_current_theme(window: &mut Window, cx: &mut App) {
+    let theme_registry = ThemeRegistry::global(cx);
+    let config = cx.global::<AiChatConfig>();
+    let config = config.gpui_theme(theme_registry, window);
+    Theme::global_mut(cx).apply_config(&config);
+}
+
 pub(crate) struct HomeView {
     sidebar: Entity<SidebarView>,
     tabs: Entity<TabsView>,
@@ -58,12 +65,7 @@ impl HomeView {
         let sidebar = cx.new(|cx| SidebarView::new(window, cx));
         let tabs = cx.new(TabsView::new);
         let workspace = cx.global::<WorkspaceStore>().deref().clone();
-        {
-            let theme_registry = ThemeRegistry::global(cx);
-            let config = cx.global::<AiChatConfig>();
-            let config = config.gpui_theme(theme_registry, window);
-            Theme::global_mut(cx).apply_config(&config);
-        }
+        apply_current_theme(window, cx);
 
         Self {
             sidebar,
@@ -89,19 +91,20 @@ impl HomeView {
                         });
                 }),
                 cx.observe_window_appearance(window, |_state, window, cx| {
-                    let theme_registry = ThemeRegistry::global(cx);
-                    let config = cx.global::<AiChatConfig>();
-                    let config = config.gpui_theme(theme_registry, window);
-                    Theme::global_mut(cx).apply_config(&config);
+                    apply_current_theme(window, cx);
                     cx.refresh_windows();
                 }),
                 cx.observe_global_in::<AiChatConfig>(window, |_state, window, cx| {
-                    let theme_registry = ThemeRegistry::global(cx);
-                    let config = cx.global::<AiChatConfig>();
-                    let config = config.gpui_theme(theme_registry, window);
-                    Theme::global_mut(cx).apply_config(&config);
+                    apply_current_theme(window, cx);
                     cx.refresh_windows();
                 }),
+                cx.observe_global_in::<state::theme::SystemAccentThemeState>(
+                    window,
+                    |_state, window, cx| {
+                        apply_current_theme(window, cx);
+                        cx.refresh_windows();
+                    },
+                ),
             ],
         }
     }

--- a/app/ai-chat/src/features/home.rs
+++ b/app/ai-chat/src/features/home.rs
@@ -1,7 +1,9 @@
 use crate::{
     app::menus,
     components::{
-        add_conversation::open_add_conversation_dialog, add_folder::open_add_folder_dialog,
+        add_conversation::open_add_conversation_dialog,
+        add_folder::open_add_folder_dialog,
+        title_bar_menu::{TitleBarAppMenuBar, title_bar_leading},
     },
     features::home::{sidebar::SidebarView, tabs::TabsView},
     foundation::i18n::I18n,
@@ -13,7 +15,6 @@ use gpui_component::{
     alert::Alert,
     h_flex,
     label::Label,
-    menu::AppMenuBar,
     resizable::{h_resizable, resizable_panel},
     v_flex,
 };
@@ -53,7 +54,7 @@ fn apply_current_theme(window: &mut Window, cx: &mut App) {
 pub(crate) struct HomeView {
     sidebar: Entity<SidebarView>,
     tabs: Entity<TabsView>,
-    app_menu_bar: Entity<AppMenuBar>,
+    app_menu_bar: Entity<TitleBarAppMenuBar>,
     focus_handle: FocusHandle,
     _subscriptions: Vec<Subscription>,
 }
@@ -66,7 +67,7 @@ impl HomeView {
         focus_handle.focus(window, cx);
         let sidebar = cx.new(|cx| SidebarView::new(window, cx));
         let tabs = cx.new(TabsView::new);
-        let app_menu_bar = AppMenuBar::new(cx);
+        let app_menu_bar = TitleBarAppMenuBar::new(cx);
         let workspace = cx.global::<WorkspaceStore>().deref().clone();
         apply_current_theme(window, cx);
 
@@ -236,7 +237,7 @@ impl Render for HomeView {
 }
 
 fn title_bar_content(
-    app_menu_bar: Entity<AppMenuBar>,
+    app_menu_bar: Entity<TitleBarAppMenuBar>,
     title: impl Into<SharedString>,
 ) -> impl IntoElement {
     h_flex()
@@ -245,23 +246,9 @@ fn title_bar_content(
         .min_w_0()
         .overflow_hidden()
         .when(menus::should_render_component_menu_bar(), |this| {
-            this.child(component_menu_bar(app_menu_bar))
+            this.child(title_bar_leading(app_menu_bar))
         })
         .child(title_bar_title(title))
-}
-
-fn component_menu_bar(app_menu_bar: Entity<AppMenuBar>) -> impl IntoElement {
-    div()
-        .flex()
-        .items_center()
-        .h_full()
-        .flex_none()
-        .pr_2()
-        .on_mouse_down(MouseButton::Left, |_, window, cx| {
-            window.prevent_default();
-            cx.stop_propagation();
-        })
-        .child(app_menu_bar)
 }
 
 fn title_bar_title(title: impl Into<SharedString>) -> impl IntoElement {

--- a/app/ai-chat/src/features/home.rs
+++ b/app/ai-chat/src/features/home.rs
@@ -13,6 +13,7 @@ use gpui_component::{
     alert::Alert,
     h_flex,
     label::Label,
+    menu::AppMenuBar,
     resizable::{h_resizable, resizable_panel},
     v_flex,
 };
@@ -52,6 +53,7 @@ fn apply_current_theme(window: &mut Window, cx: &mut App) {
 pub(crate) struct HomeView {
     sidebar: Entity<SidebarView>,
     tabs: Entity<TabsView>,
+    app_menu_bar: Entity<AppMenuBar>,
     focus_handle: FocusHandle,
     _subscriptions: Vec<Subscription>,
 }
@@ -64,12 +66,14 @@ impl HomeView {
         focus_handle.focus(window, cx);
         let sidebar = cx.new(|cx| SidebarView::new(window, cx));
         let tabs = cx.new(TabsView::new);
+        let app_menu_bar = AppMenuBar::new(cx);
         let workspace = cx.global::<WorkspaceStore>().deref().clone();
         apply_current_theme(window, cx);
 
         Self {
             sidebar,
             tabs,
+            app_menu_bar,
             focus_handle,
             _subscriptions: vec![
                 cx.observe(&workspace, |_state, _workspace, cx| {
@@ -118,6 +122,11 @@ impl HomeView {
             return;
         };
         panel.update(cx, |panel, cx| panel.focus_chat_form(window, cx));
+    }
+
+    pub(crate) fn reload_app_menu_bar(&mut self, cx: &mut Context<Self>) {
+        self.app_menu_bar
+            .update(cx, |app_menu_bar, cx| app_menu_bar.reload(cx));
     }
 
     fn minimize(&mut self, _: &menus::Minimize, window: &mut Window, _: &mut Context<Self>) {
@@ -182,7 +191,10 @@ impl Render for HomeView {
             .on_action(cx.listener(Self::add_folder))
             .child(
                 div()
-                    .child(TitleBar::new().child(title_bar_title(titlebar_title)))
+                    .child(
+                        TitleBar::new()
+                            .child(title_bar_content(self.app_menu_bar.clone(), titlebar_title)),
+                    )
                     .flex_initial(),
             )
             .map(|this| match chat_data {
@@ -223,9 +235,39 @@ impl Render for HomeView {
     }
 }
 
-fn title_bar_title(title: impl Into<SharedString>) -> impl IntoElement {
+fn title_bar_content(
+    app_menu_bar: Entity<AppMenuBar>,
+    title: impl Into<SharedString>,
+) -> impl IntoElement {
     h_flex()
         .w_full()
+        .h_full()
+        .min_w_0()
+        .overflow_hidden()
+        .when(menus::should_render_component_menu_bar(), |this| {
+            this.child(component_menu_bar(app_menu_bar))
+        })
+        .child(title_bar_title(title))
+}
+
+fn component_menu_bar(app_menu_bar: Entity<AppMenuBar>) -> impl IntoElement {
+    div()
+        .flex()
+        .items_center()
+        .h_full()
+        .flex_none()
+        .pr_2()
+        .on_mouse_down(MouseButton::Left, |_, window, cx| {
+            window.prevent_default();
+            cx.stop_propagation();
+        })
+        .child(app_menu_bar)
+}
+
+fn title_bar_title(title: impl Into<SharedString>) -> impl IntoElement {
+    h_flex()
+        .flex_1()
+        .min_w_0()
         .h_full()
         .justify_center()
         .overflow_hidden()

--- a/app/ai-chat/src/features/home/sidebar.rs
+++ b/app/ai-chat/src/features/home/sidebar.rs
@@ -8,7 +8,7 @@ use crate::{
 use gpui::*;
 use gpui_component::{
     Collapsible, Side,
-    sidebar::{Sidebar, SidebarGroup, SidebarHeader, SidebarItem, SidebarMenu, SidebarMenuItem},
+    sidebar::{Sidebar, SidebarGroup, SidebarItem, SidebarMenu, SidebarMenuItem},
     v_flex,
 };
 use std::ops::Deref;
@@ -89,7 +89,6 @@ impl Render for SidebarView {
         cx: &mut gpui::Context<Self>,
     ) -> impl gpui::IntoElement {
         let (
-            app_title,
             conversation_tree_title,
             actions_title,
             settings_label,
@@ -99,7 +98,6 @@ impl Render for SidebarView {
         ) = {
             let i18n = cx.global::<I18n>();
             (
-                i18n.t("sidebar-app-title"),
                 i18n.t("sidebar-conversation-tree"),
                 i18n.t("sidebar-actions"),
                 i18n.t("sidebar-settings"),
@@ -120,7 +118,6 @@ impl Render for SidebarView {
                     .border_r_0()
                     .collapsible(false)
                     .collapsed(false)
-                    .header(SidebarHeader::new().child(app_title))
                     .child(SidebarSection::Tree(
                         SidebarGroup::new(conversation_tree_title).child(
                             self.chat_data

--- a/app/ai-chat/src/features/settings.rs
+++ b/app/ai-chat/src/features/settings.rs
@@ -5,11 +5,12 @@ use crate::{
     llm::provider_settings_specs,
     state::{AiChatConfig, WindowPlacementKind, WorkspaceStore},
 };
-use gpui::*;
+use gpui::{prelude::FluentBuilder, *};
 use gpui_component::{
     Root, StyledExt, TitleBar, h_flex,
     input::{InputEvent, InputState},
     label::Label,
+    menu::AppMenuBar,
     v_flex,
 };
 use std::{any::TypeId, ops::Deref};
@@ -69,6 +70,7 @@ pub struct SettingsView {
     appearance_settings: Entity<AppearanceSettingsPage>,
     shortcut_settings: Entity<ShortcutSettingsPage>,
     template_settings: Entity<TemplateSettingsPage>,
+    app_menu_bar: Entity<AppMenuBar>,
     selected_page: SettingsPageKey,
     sidebar_width: Pixels,
     _subscriptions: Vec<Subscription>,
@@ -89,6 +91,7 @@ impl SettingsView {
         let appearance_settings = cx.new(|cx| AppearanceSettingsPage::new(window, cx));
         let shortcut_settings = cx.new(|cx| ShortcutSettingsPage::new(window, cx));
         let template_settings = cx.new(|cx| TemplateSettingsPage::new(window, cx));
+        let app_menu_bar = AppMenuBar::new(cx);
         let _subscriptions = vec![
             cx.subscribe(&hotkey_input, Self::subscribe_hotkey_changes),
             cx.subscribe_in(
@@ -123,10 +126,16 @@ impl SettingsView {
             appearance_settings,
             shortcut_settings,
             template_settings,
+            app_menu_bar,
             selected_page: page_key_from_open_target(open_target),
             sidebar_width: SETTINGS_SIDEBAR_DEFAULT_WIDTH,
             _subscriptions,
         }
+    }
+
+    pub(crate) fn reload_app_menu_bar(&mut self, cx: &mut Context<Self>) {
+        self.app_menu_bar
+            .update(cx, |app_menu_bar, cx| app_menu_bar.reload(cx));
     }
 
     fn subscribe_settings_search_changes(
@@ -239,7 +248,10 @@ impl Render for SettingsView {
             .on_action(cx.listener(Self::zoom))
             .child(
                 div()
-                    .child(TitleBar::new().child(settings_title_bar_title(settings_title.clone())))
+                    .child(TitleBar::new().child(settings_title_bar_content(
+                        self.app_menu_bar.clone(),
+                        settings_title.clone(),
+                    )))
                     .flex_initial(),
             )
             .child(
@@ -428,9 +440,39 @@ fn settings_page_specs(cx: &App) -> [SettingsPageSpec; 5] {
     ]
 }
 
-fn settings_title_bar_title(title: impl Into<SharedString>) -> impl IntoElement {
+fn settings_title_bar_content(
+    app_menu_bar: Entity<AppMenuBar>,
+    title: impl Into<SharedString>,
+) -> impl IntoElement {
     h_flex()
         .w_full()
+        .h_full()
+        .min_w_0()
+        .overflow_hidden()
+        .when(menus::should_render_component_menu_bar(), |this| {
+            this.child(settings_component_menu_bar(app_menu_bar))
+        })
+        .child(settings_title_bar_title(title))
+}
+
+fn settings_component_menu_bar(app_menu_bar: Entity<AppMenuBar>) -> impl IntoElement {
+    div()
+        .flex()
+        .items_center()
+        .h_full()
+        .flex_none()
+        .pr_2()
+        .on_mouse_down(MouseButton::Left, |_, window, cx| {
+            window.prevent_default();
+            cx.stop_propagation();
+        })
+        .child(app_menu_bar)
+}
+
+fn settings_title_bar_title(title: impl Into<SharedString>) -> impl IntoElement {
+    h_flex()
+        .flex_1()
+        .min_w_0()
         .h_full()
         .justify_center()
         .overflow_hidden()

--- a/app/ai-chat/src/features/settings.rs
+++ b/app/ai-chat/src/features/settings.rs
@@ -1,6 +1,9 @@
 use crate::{
     app::menus,
-    components::hotkey_input::{HotkeyEvent, HotkeyInput, string_to_keystroke},
+    components::{
+        hotkey_input::{HotkeyEvent, HotkeyInput, string_to_keystroke},
+        title_bar_menu::{TitleBarAppMenuBar, title_bar_leading},
+    },
     foundation::i18n::I18n,
     llm::provider_settings_specs,
     state::{AiChatConfig, WindowPlacementKind, WorkspaceStore},
@@ -10,7 +13,6 @@ use gpui_component::{
     Root, StyledExt, TitleBar, h_flex,
     input::{InputEvent, InputState},
     label::Label,
-    menu::AppMenuBar,
     v_flex,
 };
 use std::{any::TypeId, ops::Deref};
@@ -70,7 +72,7 @@ pub struct SettingsView {
     appearance_settings: Entity<AppearanceSettingsPage>,
     shortcut_settings: Entity<ShortcutSettingsPage>,
     template_settings: Entity<TemplateSettingsPage>,
-    app_menu_bar: Entity<AppMenuBar>,
+    app_menu_bar: Entity<TitleBarAppMenuBar>,
     selected_page: SettingsPageKey,
     sidebar_width: Pixels,
     _subscriptions: Vec<Subscription>,
@@ -91,7 +93,7 @@ impl SettingsView {
         let appearance_settings = cx.new(|cx| AppearanceSettingsPage::new(window, cx));
         let shortcut_settings = cx.new(|cx| ShortcutSettingsPage::new(window, cx));
         let template_settings = cx.new(|cx| TemplateSettingsPage::new(window, cx));
-        let app_menu_bar = AppMenuBar::new(cx);
+        let app_menu_bar = TitleBarAppMenuBar::new(cx);
         let _subscriptions = vec![
             cx.subscribe(&hotkey_input, Self::subscribe_hotkey_changes),
             cx.subscribe_in(
@@ -441,7 +443,7 @@ fn settings_page_specs(cx: &App) -> [SettingsPageSpec; 5] {
 }
 
 fn settings_title_bar_content(
-    app_menu_bar: Entity<AppMenuBar>,
+    app_menu_bar: Entity<TitleBarAppMenuBar>,
     title: impl Into<SharedString>,
 ) -> impl IntoElement {
     h_flex()
@@ -450,23 +452,9 @@ fn settings_title_bar_content(
         .min_w_0()
         .overflow_hidden()
         .when(menus::should_render_component_menu_bar(), |this| {
-            this.child(settings_component_menu_bar(app_menu_bar))
+            this.child(title_bar_leading(app_menu_bar))
         })
         .child(settings_title_bar_title(title))
-}
-
-fn settings_component_menu_bar(app_menu_bar: Entity<AppMenuBar>) -> impl IntoElement {
-    div()
-        .flex()
-        .items_center()
-        .h_full()
-        .flex_none()
-        .pr_2()
-        .on_mouse_down(MouseButton::Left, |_, window, cx| {
-            window.prevent_default();
-            cx.stop_propagation();
-        })
-        .child(app_menu_bar)
 }
 
 fn settings_title_bar_title(title: impl Into<SharedString>) -> impl IntoElement {

--- a/app/ai-chat/src/features/settings/appearance_settings.rs
+++ b/app/ai-chat/src/features/settings/appearance_settings.rs
@@ -195,6 +195,11 @@ impl AppearanceSettingsPage {
         };
         let selected_indicator =
             selected.then(|| selected_badge(selected_label, colors.primary).into_any_element());
+        let primary_swatch = if app_theme::is_system_accent_material_you_theme_id(&id) {
+            app_theme::system_accent_hsla().unwrap_or(colors.primary)
+        } else {
+            colors.primary
+        };
         let delete_button = app_theme::material_you_color_from_id(&id).map(|_| {
             let delete_id = id.clone();
             Button::new(SharedString::from(format!(
@@ -302,7 +307,7 @@ impl AppearanceSettingsPage {
                             .when_some(delete_button, |this, button| this.child(button)),
                     )
                     .child(h_flex().gap_1().children([
-                        swatch(colors.primary),
+                        swatch(primary_swatch),
                         swatch(colors.secondary),
                         swatch(colors.accent),
                         swatch(colors.muted),

--- a/app/ai-chat/src/features/settings/general_settings.rs
+++ b/app/ai-chat/src/features/settings/general_settings.rs
@@ -1,5 +1,5 @@
 use crate::{
-    app::{menus, tray},
+    app::{self, menus, tray},
     components::hotkey_input::HotkeyInput,
     foundation::assets::IconName,
     foundation::i18n::{self, I18n},
@@ -111,7 +111,8 @@ fn language_dropdown(cx: &mut App) -> AnyElement {
                                     config.set_language(language);
                                 }
                                 i18n::refresh_i18n(cx);
-                                cx.set_menus(menus::app_menus(cx.global::<I18n>()));
+                                menus::sync_app_menus(cx);
+                                app::reload_app_menu_bars(cx);
                                 tray::refresh(cx);
                                 cx.refresh_windows();
                             }),

--- a/app/ai-chat/src/foundation/assets.rs
+++ b/app/ai-chat/src/foundation/assets.rs
@@ -4,6 +4,8 @@ use gpui_component::IconNamed;
 use rust_embed::RustEmbed;
 use std::{borrow::Cow, collections::BTreeSet};
 
+pub(crate) const APP_ICON_ASSET_PATH: &str = "build-assets/icon/app-icon.ico";
+
 macro_rules! define_icon_assets {
     ($( $variant:ident => $slug:literal ),+ $(,)?) => {
         #[allow(dead_code)]
@@ -214,7 +216,7 @@ impl AssetSource for Assets {
 
 #[cfg(test)]
 mod tests {
-    use super::{Assets, IconName};
+    use super::{APP_ICON_ASSET_PATH, Assets, IconName};
     use gpui::{AssetSource, SharedString};
     use gpui_component::IconNamed;
 
@@ -243,6 +245,17 @@ mod tests {
 
         assert!(!send.is_empty());
         assert!(!trash.is_empty());
+    }
+
+    #[test]
+    fn app_icon_asset_loads() {
+        let assets = Assets::default();
+        let icon = assets
+            .load(APP_ICON_ASSET_PATH)
+            .expect("load app icon")
+            .expect("app icon exists");
+
+        assert!(!icon.is_empty());
     }
 
     #[test]

--- a/app/ai-chat/src/state/config.rs
+++ b/app/ai-chat/src/state/config.rs
@@ -623,6 +623,56 @@ darkTheme = "material-you:#00aa00"
     }
 
     #[test]
+    fn selected_system_accent_theme_does_not_enter_custom_theme_colors() -> anyhow::Result<()> {
+        let config: AiChatConfig = toml::from_str(
+            r##"
+[theme]
+theme = "system"
+lightTheme = "material-you:system-accent"
+darkTheme = "material-you:system-accent"
+customThemeColors = []
+"##,
+        )?;
+
+        assert_eq!(
+            config.light_theme_id(),
+            theme::SYSTEM_ACCENT_MATERIAL_YOU_THEME_ID
+        );
+        assert_eq!(
+            config.dark_theme_id(),
+            theme::SYSTEM_ACCENT_MATERIAL_YOU_THEME_ID
+        );
+        assert!(config.custom_theme_colors().is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn system_accent_theme_cannot_be_removed_as_custom_color() -> anyhow::Result<()> {
+        let mut config: AiChatConfig = toml::from_str(
+            r##"
+[theme]
+lightTheme = "material-you:system-accent"
+darkTheme = "material-you:system-accent"
+customThemeColors = ["#123456"]
+"##,
+        )?;
+
+        assert!(!config.remove_custom_theme_color(theme::SYSTEM_ACCENT_MATERIAL_YOU_THEME_ID));
+        assert_eq!(config.custom_theme_colors(), &["#123456".to_string()]);
+        assert_eq!(
+            config.light_theme_id(),
+            theme::SYSTEM_ACCENT_MATERIAL_YOU_THEME_ID
+        );
+        assert_eq!(
+            config.dark_theme_id(),
+            theme::SYSTEM_ACCENT_MATERIAL_YOU_THEME_ID
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn remove_custom_theme_color_removes_unselected_material_theme() -> anyhow::Result<()> {
         let mut config: AiChatConfig = toml::from_str(
             r##"

--- a/app/ai-chat/src/state/theme.rs
+++ b/app/ai-chat/src/state/theme.rs
@@ -1,7 +1,7 @@
 use crate::foundation::assets;
-use gpui::{App, SharedString};
+use gpui::{App, BorrowAppContext, Global, Hsla, SharedString, Task};
 use gpui_component::{
-    Theme, ThemeColor, ThemeConfig, ThemeConfigColors, ThemeMode as ComponentThemeMode,
+    Colorize, Theme, ThemeColor, ThemeConfig, ThemeConfigColors, ThemeMode as ComponentThemeMode,
     ThemeRegistry, highlighter::HighlightThemeStyle,
 };
 use material_color_utils::{
@@ -16,15 +16,22 @@ use material_color_utils::{
     theme_from_color,
     utils::color_utils::Argb,
 };
+use platform_ext::appearance::{SystemAccentColorObserver, observe_system_accent_color_changes};
 use serde_json::{Map, Value, json};
-use std::rc::Rc;
+use std::{
+    rc::Rc,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
 use tracing::{Level, event};
 
 const PRESET_PREFIX: &str = "preset:";
 const MATERIAL_YOU_PREFIX: &str = "material-you:";
+pub(crate) const SYSTEM_ACCENT_MATERIAL_YOU_THEME_ID: &str = "material-you:system-accent";
 pub(crate) const DEFAULT_LIGHT_THEME_ID: &str = "preset:Default Light";
 pub(crate) const DEFAULT_DARK_THEME_ID: &str = "preset:Default Dark";
 pub(crate) const DEFAULT_CUSTOM_THEME_COLOR: &str = "#3271AE";
+const SYSTEM_ACCENT_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const SEMANTIC_CHROMA: f64 = 60.0;
 const INFO_SEED_COLOR: Argb = Argb::from_rgb(0x0E, 0xA5, 0xE9);
 const SUCCESS_SEED_COLOR: Argb = Argb::from_rgb(0x22, 0xC5, 0x5E);
@@ -36,6 +43,7 @@ const MATERIAL_SOFT_DIVIDER_ALPHA: u8 = 0x1F;
 const MATERIAL_HOVER_STATE_LAYER_ALPHA: u8 = 0x14;
 const MATERIAL_PRESSED_STATE_LAYER_ALPHA: u8 = 0x1A;
 const MATERIAL_EDITOR_INVISIBLE_ALPHA: u8 = 0x66;
+static SYSTEM_ACCENT_CHANGE_VERSION: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone)]
 pub(crate) struct ThemeChoice {
@@ -44,6 +52,15 @@ pub(crate) struct ThemeChoice {
     pub(crate) config: Rc<ThemeConfig>,
 }
 
+pub(crate) struct SystemAccentThemeState {
+    _observer: Option<SystemAccentColorObserver>,
+    _task: Task<()>,
+    _version: u64,
+    _color: Option<String>,
+}
+
+impl Global for SystemAccentThemeState {}
+
 pub(crate) fn init(cx: &mut App) {
     let registry = ThemeRegistry::global_mut(cx);
     for theme_set in assets::bundled_theme_sets() {
@@ -51,6 +68,7 @@ pub(crate) fn init(cx: &mut App) {
             event!(Level::ERROR, "Failed to load bundled theme set: {}", err);
         }
     }
+    init_system_accent_theme(cx);
 }
 
 pub(crate) fn preset_theme_id(name: &str) -> String {
@@ -64,6 +82,9 @@ pub(crate) fn material_you_theme_id(color: &str) -> Option<String> {
 pub(crate) fn normalize_theme_id(id: &str) -> String {
     if id.starts_with(PRESET_PREFIX) {
         return id.to_string();
+    }
+    if is_system_accent_material_you_theme_id(id) {
+        return SYSTEM_ACCENT_MATERIAL_YOU_THEME_ID.to_string();
     }
     if id.starts_with(MATERIAL_YOU_PREFIX) {
         return material_you_color_from_id(id)
@@ -80,6 +101,18 @@ pub(crate) fn normalize_hex_color(color: &str) -> Option<String> {
 pub(crate) fn material_you_color_from_id(id: &str) -> Option<String> {
     id.strip_prefix(MATERIAL_YOU_PREFIX)
         .and_then(normalize_hex_color)
+}
+
+pub(crate) fn is_system_accent_material_you_theme_id(id: &str) -> bool {
+    id == SYSTEM_ACCENT_MATERIAL_YOU_THEME_ID
+}
+
+pub(crate) fn system_accent_color() -> Option<String> {
+    platform_ext::appearance::system_accent_color().map(|color| color.to_hex())
+}
+
+pub(crate) fn system_accent_hsla() -> Option<Hsla> {
+    system_accent_color().and_then(|color| Hsla::parse_hex(&color).ok())
 }
 
 pub(crate) fn theme_choices(
@@ -103,6 +136,10 @@ pub(crate) fn theme_choices(
             .iter()
             .filter_map(|color| generated_theme_choice(color, mode)),
     );
+
+    if let Some(choice) = system_accent_theme_choice(mode) {
+        choices.push(choice);
+    }
 
     choices
 }
@@ -128,6 +165,12 @@ pub(crate) fn resolve_theme_config(
         return Rc::new(theme);
     }
 
+    if is_system_accent_material_you_theme_id(&theme_id)
+        && let Some(theme) = system_accent_theme_config(mode)
+    {
+        return Rc::new(theme);
+    }
+
     match mode {
         ComponentThemeMode::Light => Rc::clone(registry.default_light_theme()),
         ComponentThemeMode::Dark => Rc::clone(registry.default_dark_theme()),
@@ -145,6 +188,44 @@ pub(crate) fn preview_theme(config: &Rc<ThemeConfig>) -> Theme {
     theme
 }
 
+fn init_system_accent_theme(cx: &mut App) {
+    let observer = observe_system_accent_color_changes(|| {
+        SYSTEM_ACCENT_CHANGE_VERSION.fetch_add(1, Ordering::Relaxed);
+    });
+    let color = system_accent_color();
+    let mut version = SYSTEM_ACCENT_CHANGE_VERSION.load(Ordering::Relaxed);
+    let mut current_color = color.clone();
+    let task = cx.spawn(async move |cx| {
+        loop {
+            cx.background_executor()
+                .timer(SYSTEM_ACCENT_POLL_INTERVAL)
+                .await;
+            let next_version = SYSTEM_ACCENT_CHANGE_VERSION.load(Ordering::Relaxed);
+            let next_color = system_accent_color();
+            if next_version == version && next_color == current_color {
+                continue;
+            }
+
+            version = next_version;
+            current_color = next_color.clone();
+            cx.update(|cx| {
+                cx.update_global::<SystemAccentThemeState, _>(|state, _cx| {
+                    state._version = next_version;
+                    state._color = next_color;
+                });
+                cx.refresh_windows();
+            });
+        }
+    });
+
+    cx.set_global(SystemAccentThemeState {
+        _observer: observer,
+        _task: task,
+        _version: version,
+        _color: color,
+    });
+}
+
 fn generated_theme_choice(color: &str, mode: ComponentThemeMode) -> Option<ThemeChoice> {
     let color = normalize_hex_color(color)?;
     let config = generated_theme_config(&color, mode)?;
@@ -153,6 +234,25 @@ fn generated_theme_choice(color: &str, mode: ComponentThemeMode) -> Option<Theme
         name: config.name.clone(),
         config: Rc::new(config),
     })
+}
+
+fn system_accent_theme_choice(mode: ComponentThemeMode) -> Option<ThemeChoice> {
+    let config = system_accent_theme_config(mode)?;
+    Some(ThemeChoice {
+        id: SYSTEM_ACCENT_MATERIAL_YOU_THEME_ID.to_string(),
+        name: config.name.clone(),
+        config: Rc::new(config),
+    })
+}
+
+fn system_accent_theme_config(mode: ComponentThemeMode) -> Option<ThemeConfig> {
+    let color = system_accent_color()?;
+    let mut config = generated_theme_config(&color, mode)?;
+    config.name = SharedString::from(format!(
+        "System Accent Material You {}",
+        if mode.is_dark() { "Dark" } else { "Light" }
+    ));
+    Some(config)
 }
 
 fn generated_theme_config(color: &str, mode: ComponentThemeMode) -> Option<ThemeConfig> {

--- a/app/ai-chat/src/state/theme.rs
+++ b/app/ai-chat/src/state/theme.rs
@@ -18,11 +18,7 @@ use material_color_utils::{
 };
 use platform_ext::appearance::{SystemAccentColorObserver, observe_system_accent_color_changes};
 use serde_json::{Map, Value, json};
-use std::{
-    rc::Rc,
-    sync::atomic::{AtomicU64, Ordering},
-    time::Duration,
-};
+use std::rc::Rc;
 use tracing::{Level, event};
 
 const PRESET_PREFIX: &str = "preset:";
@@ -31,7 +27,6 @@ pub(crate) const SYSTEM_ACCENT_MATERIAL_YOU_THEME_ID: &str = "material-you:syste
 pub(crate) const DEFAULT_LIGHT_THEME_ID: &str = "preset:Default Light";
 pub(crate) const DEFAULT_DARK_THEME_ID: &str = "preset:Default Dark";
 pub(crate) const DEFAULT_CUSTOM_THEME_COLOR: &str = "#3271AE";
-const SYSTEM_ACCENT_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const SEMANTIC_CHROMA: f64 = 60.0;
 const INFO_SEED_COLOR: Argb = Argb::from_rgb(0x0E, 0xA5, 0xE9);
 const SUCCESS_SEED_COLOR: Argb = Argb::from_rgb(0x22, 0xC5, 0x5E);
@@ -43,7 +38,6 @@ const MATERIAL_SOFT_DIVIDER_ALPHA: u8 = 0x1F;
 const MATERIAL_HOVER_STATE_LAYER_ALPHA: u8 = 0x14;
 const MATERIAL_PRESSED_STATE_LAYER_ALPHA: u8 = 0x1A;
 const MATERIAL_EDITOR_INVISIBLE_ALPHA: u8 = 0x66;
-static SYSTEM_ACCENT_CHANGE_VERSION: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone)]
 pub(crate) struct ThemeChoice {
@@ -54,9 +48,8 @@ pub(crate) struct ThemeChoice {
 
 pub(crate) struct SystemAccentThemeState {
     _observer: Option<SystemAccentColorObserver>,
-    _task: Task<()>,
-    _version: u64,
-    _color: Option<String>,
+    _task: Option<Task<()>>,
+    color: Option<String>,
 }
 
 impl Global for SystemAccentThemeState {}
@@ -189,41 +182,38 @@ pub(crate) fn preview_theme(config: &Rc<ThemeConfig>) -> Theme {
 }
 
 fn init_system_accent_theme(cx: &mut App) {
-    let observer = observe_system_accent_color_changes(|| {
-        SYSTEM_ACCENT_CHANGE_VERSION.fetch_add(1, Ordering::Relaxed);
+    let (tx, rx) = smol::channel::bounded(1);
+    let observer = observe_system_accent_color_changes(move || {
+        let _ = tx.try_send(());
     });
     let color = system_accent_color();
-    let mut version = SYSTEM_ACCENT_CHANGE_VERSION.load(Ordering::Relaxed);
-    let mut current_color = color.clone();
-    let task = cx.spawn(async move |cx| {
-        loop {
-            cx.background_executor()
-                .timer(SYSTEM_ACCENT_POLL_INTERVAL)
-                .await;
-            let next_version = SYSTEM_ACCENT_CHANGE_VERSION.load(Ordering::Relaxed);
-            let next_color = system_accent_color();
-            if next_version == version && next_color == current_color {
-                continue;
-            }
-
-            version = next_version;
-            current_color = next_color.clone();
-            cx.update(|cx| {
-                cx.update_global::<SystemAccentThemeState, _>(|state, _cx| {
-                    state._version = next_version;
-                    state._color = next_color;
+    let task = observer.as_ref().map(|_| {
+        cx.spawn(async move |cx| {
+            while rx.recv().await.is_ok() {
+                let next_color = system_accent_color();
+                cx.update(|cx| {
+                    if system_accent_color_changed(
+                        &cx.global::<SystemAccentThemeState>().color,
+                        &next_color,
+                    ) {
+                        cx.update_global::<SystemAccentThemeState, _>(|state, _cx| {
+                            state.color = next_color;
+                        });
+                    }
                 });
-                cx.refresh_windows();
-            });
-        }
+            }
+        })
     });
 
     cx.set_global(SystemAccentThemeState {
         _observer: observer,
         _task: task,
-        _version: version,
-        _color: color,
+        color,
     });
+}
+
+fn system_accent_color_changed(current: &Option<String>, next: &Option<String>) -> bool {
+    current != next
 }
 
 fn generated_theme_choice(color: &str, mode: ComponentThemeMode) -> Option<ThemeChoice> {

--- a/app/ai-chat/src/state/theme/tests.rs
+++ b/app/ai-chat/src/state/theme/tests.rs
@@ -92,6 +92,15 @@ fn material_you_id_normalizes_hex_color() {
 }
 
 #[test]
+fn system_accent_material_you_id_is_stable() {
+    assert_eq!(
+        normalize_theme_id(SYSTEM_ACCENT_MATERIAL_YOU_THEME_ID),
+        SYSTEM_ACCENT_MATERIAL_YOU_THEME_ID
+    );
+    assert!(material_you_color_from_id(SYSTEM_ACCENT_MATERIAL_YOU_THEME_ID).is_none());
+}
+
+#[test]
 fn normalize_theme_id_canonicalizes_material_you_color() {
     assert_eq!(
         normalize_theme_id("material-you:#aabbcc"),

--- a/app/ai-chat/src/state/theme/tests.rs
+++ b/app/ai-chat/src/state/theme/tests.rs
@@ -101,6 +101,27 @@ fn system_accent_material_you_id_is_stable() {
 }
 
 #[test]
+fn system_accent_color_changed_only_updates_on_real_changes() {
+    assert!(!system_accent_color_changed(&None, &None));
+    assert!(!system_accent_color_changed(
+        &Some("#123456".to_string()),
+        &Some("#123456".to_string())
+    ));
+    assert!(system_accent_color_changed(
+        &Some("#123456".to_string()),
+        &Some("#654321".to_string())
+    ));
+    assert!(system_accent_color_changed(
+        &Some("#123456".to_string()),
+        &None
+    ));
+    assert!(system_accent_color_changed(
+        &None,
+        &Some("#123456".to_string())
+    ));
+}
+
+#[test]
 fn normalize_theme_id_canonicalizes_material_you_color() {
     assert_eq!(
         normalize_theme_id("material-you:#aabbcc"),

--- a/app/feiwen/Cargo.toml
+++ b/app/feiwen/Cargo.toml
@@ -17,7 +17,7 @@ sys-locale = "0.3.2"
 thiserror = "2.0.18"
 
 # http
-reqwest = {version = "0.13.2",features=["query"]}
+reqwest = {version = "0.13.3",features=["query"]}
 async-compat = "0.2.5"
 
 # html
@@ -27,7 +27,7 @@ regex = "1.12.3"
 url = "2.5.8"
 
 # database
-diesel = { version = "2.3.8", features = ["sqlite", "r2d2"] }
+diesel = { version = "2.3.9", features = ["sqlite", "r2d2"] }
 dirs-next = "2.0.0"
 
 # log

--- a/app/novel-download/Cargo.toml
+++ b/app/novel-download/Cargo.toml
@@ -17,7 +17,7 @@ sys-locale = "0.3.2"
 thiserror = "2.0.18"
 
 # http
-reqwest = { version = "0.13.2", features = [
+reqwest = { version = "0.13.3", features = [
     "gzip",
     "charset",
     "query"

--- a/crates/platform-ext/Cargo.toml
+++ b/crates/platform-ext/Cargo.toml
@@ -12,6 +12,7 @@ tracing = "0.1.44"
 windows-bindgen = "0.66.0"
 
 [target.'cfg(target_os="macos")'.dependencies]
+block2 = "0.6.2"
 objc2 = "0.6.4"
 objc2-app-kit = "0.3.2"
 objc2-core-foundation = "0.3.2"
@@ -23,7 +24,7 @@ objc2-core-graphics = { version = "0.3.2", features = [
   "CGImage",
   "CGWindow",
 ] }
-objc2-foundation = "0.3.2"
+objc2-foundation = { version = "0.3.2", features = ["block2"] }
 
 [target.'cfg(target_os="windows")'.dependencies]
 windows = { version = "0.62.2", features = [
@@ -31,6 +32,7 @@ windows = { version = "0.62.2", features = [
   "Graphics_Imaging",
   "Media_Ocr",
   "Storage_Streams",
+  "UI_ViewManagement",
   "Win32_Graphics_Gdi",
   "Win32_System_WinRT",
   "Win32_UI_WindowsAndMessaging",

--- a/crates/platform-ext/src/appearance.rs
+++ b/crates/platform-ext/src/appearance.rs
@@ -1,0 +1,201 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SystemAccentColor {
+    pub red: u8,
+    pub green: u8,
+    pub blue: u8,
+}
+
+impl SystemAccentColor {
+    pub fn new(red: u8, green: u8, blue: u8) -> Self {
+        Self { red, green, blue }
+    }
+
+    pub fn to_hex(self) -> String {
+        format!("#{:02X}{:02X}{:02X}", self.red, self.green, self.blue)
+    }
+}
+
+pub struct SystemAccentColorObserver {
+    _inner: ObserverInner,
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+impl SystemAccentColorObserver {
+    fn new(inner: ObserverInner) -> Self {
+        Self { _inner: inner }
+    }
+}
+
+#[cfg(target_os = "macos")]
+enum ObserverInner {
+    Mac { _observer: macos::MacObserver },
+}
+
+#[cfg(target_os = "windows")]
+enum ObserverInner {
+    Windows { _observer: windows::WindowsObserver },
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+enum ObserverInner {}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::{ObserverInner, SystemAccentColor, SystemAccentColorObserver};
+    use block2::RcBlock;
+    use objc2::{
+        rc::Retained,
+        runtime::{AnyObject, NSObjectProtocol, ProtocolObject},
+    };
+    use objc2_app_kit::{NSColor, NSColorSpace, NSSystemColorsDidChangeNotification};
+    use objc2_foundation::{NSNotification, NSNotificationCenter, NSOperationQueue};
+    use std::{ptr::NonNull, sync::Arc};
+
+    pub(super) struct MacObserver {
+        center: Retained<NSNotificationCenter>,
+        token: Retained<ProtocolObject<dyn NSObjectProtocol>>,
+        _block: RcBlock<dyn Fn(NonNull<NSNotification>) + 'static>,
+    }
+
+    impl Drop for MacObserver {
+        fn drop(&mut self) {
+            let token: &ProtocolObject<dyn NSObjectProtocol> = &self.token;
+            let token: &AnyObject = token.as_ref();
+            unsafe {
+                self.center.removeObserver(token);
+            }
+        }
+    }
+
+    pub(super) fn system_accent_color() -> Option<SystemAccentColor> {
+        let color = NSColor::controlAccentColor();
+        let color_space = NSColorSpace::sRGBColorSpace();
+        let color = color.colorUsingColorSpace(&color_space)?;
+        Some(SystemAccentColor::new(
+            component_to_u8(color.redComponent()),
+            component_to_u8(color.greenComponent()),
+            component_to_u8(color.blueComponent()),
+        ))
+    }
+
+    pub(super) fn observe_system_accent_color_changes(
+        callback: impl Fn() + Send + Sync + 'static,
+    ) -> Option<SystemAccentColorObserver> {
+        let callback: Arc<dyn Fn() + Send + Sync> = Arc::new(callback);
+        let block_callback = Arc::clone(&callback);
+        let block: RcBlock<dyn Fn(NonNull<NSNotification>) + 'static> =
+            RcBlock::new(move |_notification| {
+                block_callback();
+            });
+
+        let center = NSNotificationCenter::defaultCenter();
+        let queue = NSOperationQueue::mainQueue();
+        let token = unsafe {
+            center.addObserverForName_object_queue_usingBlock(
+                Some(NSSystemColorsDidChangeNotification),
+                None,
+                Some(&queue),
+                &block,
+            )
+        };
+
+        Some(SystemAccentColorObserver::new(ObserverInner::Mac {
+            _observer: MacObserver {
+                center,
+                token,
+                _block: block,
+            },
+        }))
+    }
+
+    fn component_to_u8(component: f64) -> u8 {
+        (component.clamp(0.0, 1.0) * 255.0).round() as u8
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod windows {
+    use super::{ObserverInner, SystemAccentColor, SystemAccentColorObserver};
+    use std::sync::Arc;
+    use windows::{
+        Foundation::TypedEventHandler,
+        UI::ViewManagement::{UIColorType, UISettings},
+    };
+    use windows_core::IInspectable;
+
+    pub(super) struct WindowsObserver {
+        settings: UISettings,
+        token: i64,
+        _handler: TypedEventHandler<UISettings, IInspectable>,
+    }
+
+    impl Drop for WindowsObserver {
+        fn drop(&mut self) {
+            let _ = self.settings.RemoveColorValuesChanged(self.token);
+        }
+    }
+
+    pub(super) fn system_accent_color() -> Option<SystemAccentColor> {
+        let settings = UISettings::new().ok()?;
+        let color = settings.GetColorValue(UIColorType::Accent).ok()?;
+        Some(SystemAccentColor::new(color.R, color.G, color.B))
+    }
+
+    pub(super) fn observe_system_accent_color_changes(
+        callback: impl Fn() + Send + Sync + 'static,
+    ) -> Option<SystemAccentColorObserver> {
+        let callback: Arc<dyn Fn() + Send + Sync> = Arc::new(callback);
+        let handler_callback = Arc::clone(&callback);
+        let handler = TypedEventHandler::<UISettings, IInspectable>::new(move |_, _| {
+            handler_callback();
+            Ok(())
+        });
+        let settings = UISettings::new().ok()?;
+        let token = settings.ColorValuesChanged(&handler).ok()?;
+
+        Some(SystemAccentColorObserver::new(ObserverInner::Windows {
+            _observer: WindowsObserver {
+                settings,
+                token,
+                _handler: handler,
+            },
+        }))
+    }
+}
+
+pub fn system_accent_color() -> Option<SystemAccentColor> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::system_accent_color()
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        windows::system_accent_color()
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        None
+    }
+}
+
+pub fn observe_system_accent_color_changes(
+    callback: impl Fn() + Send + Sync + 'static,
+) -> Option<SystemAccentColorObserver> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::observe_system_accent_color_changes(callback)
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        windows::observe_system_accent_color_changes(callback)
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        let _ = callback;
+        None
+    }
+}

--- a/crates/platform-ext/src/lib.rs
+++ b/crates/platform-ext/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod appearance;
 mod error;
 pub mod ocr;
 

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -7,12 +7,12 @@ publish = false
 [dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
 image = "0.25.10"
-plist = "1.8.0"
+plist = "1.9.0"
 serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.18"
 toml = "1.1.2"
-tauri-bundler = "2.8.1"
-tauri-utils = "2.8.3"
+tauri-bundler = "2.9.0"
+tauri-utils = "2.9.0"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["local-time"] }
 walkdir = "2.5.0"

--- a/crates/xtask/src/bundle.rs
+++ b/crates/xtask/src/bundle.rs
@@ -35,13 +35,17 @@ pub fn run(args: BundleAiChatArgs) -> Result<()> {
 
     let manifest_path = app_dir.join("Cargo.toml");
     let main_bin_name = get_main_binary_name(&manifest_path)?;
-    let (package_settings, mut bundle_settings) = settings::read_bundle_settings(&manifest_path)?;
+    let (package_settings, bundle_settings) = settings::read_bundle_settings(&manifest_path)?;
 
     let out_dir = bundle_out_dir(&workspace_dir, &main_bin_name)?;
     info!(bundle_out_dir = %out_dir.display(), "using bundle output dir");
 
     #[cfg(target_os = "macos")]
-    macos::prepare_bundle_settings(&mut bundle_settings)?;
+    let bundle_settings = {
+        let mut bundle_settings = bundle_settings;
+        macos::prepare_bundle_settings(&mut bundle_settings)?;
+        bundle_settings
+    };
 
     let mut settings_builder = SettingsBuilder::new()
         .project_out_directory(&out_dir)


### PR DESCRIPTION
## Summary

- Added system accent Material You theme support for `ai-chat`, including platform appearance plumbing and theme/config tests.
- Kept custom titlebars for ordinary `ai-chat` windows and rendered app menus inside the titlebar on Windows/Linux while macOS continues using the system menu.
- Polished the titlebar menu by using a local foreground-colored menu trigger, adding the app icon on non-macOS, and removing the inactive sidebar `AI Chat` header.

## Motivation

- Windows currently does not expose GPUI app menus through the native Win32 menu path when using the component titlebar, so the application menu needs to remain visible inside the custom titlebar.
- The titlebar menu should match the app theme contrast without changing global Material You secondary tokens.
- The sidebar should avoid non-actionable header text that looks like a selectable item.

## Changes

- Added system accent Material You theme generation and persistence flow for `ai-chat`, with `platform-ext` support for querying platform appearance.
- Added synchronized app menu state for GPUI and `gpui-component`, plus non-macOS component titlebar menus for main/settings windows.
- Replaced `gpui_component::menu::AppMenuBar` usage in `ai-chat` titlebars with a local `TitleBarAppMenuBar` that reuses the same `OwnedMenu` data and `PopupMenu` actions but uses titlebar-appropriate foreground styling.
- Added a shared app icon asset path, reused it in About, and rendered a 16px app icon before the non-macOS titlebar menu.
- Removed the inactive sidebar app title header while preserving the conversation tree root drop target and actions area.

## Validation

- [ ] `cargo build`
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
cargo fmt: passed
cargo test -p ai-chat: passed, 251 tests
cargo clippy --all-targets --all-features -- -D warnings: passed
git diff --check: passed

cargo build was not run separately; clippy compiled the workspace targets used for linting.
Manual GUI verification was not run in this session.
```

## Risks

- The non-macOS titlebar menu is an `ai-chat` local GPUI component that mirrors the app menu behavior through `OwnedMenu`/`PopupMenu`; future gpui-component menu API changes may require keeping this wrapper in sync.
- Manual Windows/Linux visual verification is still needed for exact titlebar spacing and menu contrast.

## Related Issues

- Related to #