### PR TITLE
[ai-chat] Fix conversation scroll ordering and initial position

### DIFF
--- a/app/ai-chat/src/components/message.rs
+++ b/app/ai-chat/src/components/message.rs
@@ -16,7 +16,7 @@ use gpui_component::{
     popover::Popover,
     scroll::ScrollableElement,
     spinner::Spinner,
-    text::TextView,
+    text::{TextView, TextViewState},
     v_flex,
 };
 use std::{
@@ -25,11 +25,16 @@ use std::{
 };
 
 #[derive(IntoElement)]
-pub(crate) struct MessageView<T: MessageViewExt>(T);
+pub(crate) struct MessageView<T: MessageViewExt>(T, Option<Entity<TextViewState>>);
 
 impl<T: MessageViewExt> MessageView<T> {
     pub fn new(data: T) -> Self {
-        Self(data)
+        Self(data, None)
+    }
+
+    pub(crate) fn with_text_state(mut self, text_state: Option<Entity<TextViewState>>) -> Self {
+        self.1 = text_state;
+        self
     }
 }
 
@@ -186,6 +191,7 @@ fn message_actions(can_resend: bool) -> Vec<MessageAction> {
 impl<T: MessageViewExt + 'static> RenderOnce for MessageView<T> {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
         let data = self.0;
+        let text_state = self.1;
         let (
             copy_success_title,
             copy_success_message,
@@ -311,6 +317,7 @@ impl<T: MessageViewExt + 'static> RenderOnce for MessageView<T> {
                     .into_any_element(),
             })
             .collect::<Vec<_>>();
+
         v_flex()
             .group("message")
             .w_full()
@@ -394,10 +401,14 @@ impl<T: MessageViewExt + 'static> RenderOnce for MessageView<T> {
                                     ),
                                 )
                             })
-                            .child(
-                                TextView::markdown(text_id, &copy_text)
-                                    .selectable(true),
-                            )
+                            .child(match text_state {
+                                Some(text_state) => {
+                                    TextView::new(&text_state).selectable(true).into_any_element()
+                                }
+                                None => TextView::markdown(text_id, &copy_text)
+                                    .selectable(true)
+                                    .into_any_element(),
+                            })
                             .when_some(message_error, |this, error| {
                                 this.child(
                                     div().child(

--- a/app/ai-chat/src/features/conversation/detail.rs
+++ b/app/ai-chat/src/features/conversation/detail.rs
@@ -26,10 +26,16 @@ use gpui_component::{
 
 actions!([DetailEscape]);
 
+pub(crate) trait MessageRevisionExt {
+    type Id: Copy + Eq + 'static;
+
+    fn message_id(&self) -> Self::Id;
+}
+
 pub(crate) trait ConversationDetailViewExt: Sized + 'static {
     type Message: Clone + crate::components::message::MessageViewExt<Id = Self::MessageId>;
     type MessageId: Copy + Eq + 'static;
-    type Revision: Clone + PartialEq + Eq + 'static;
+    type Revision: Clone + PartialEq + Eq + MessageRevisionExt<Id = Self::MessageId> + 'static;
 
     fn title(&self, cx: &App) -> SharedString;
     fn subtitle(&self, _cx: &App) -> Option<SharedString> {
@@ -621,7 +627,19 @@ fn first_revision_diff<T: PartialEq>(
         })
 }
 
-fn message_list_sync_operation<T: PartialEq>(
+fn first_message_identity_diff<T: MessageRevisionExt>(
+    previous_revisions: &[T],
+    next_revisions: &[T],
+    start_index: usize,
+) -> Option<usize> {
+    previous_revisions[start_index..]
+        .iter()
+        .zip(next_revisions[start_index..].iter())
+        .position(|(left, right)| left.message_id() != right.message_id())
+        .map(|offset| start_index + offset)
+}
+
+fn message_list_sync_operation<T: PartialEq + MessageRevisionExt>(
     list_item_count: usize,
     previous_revisions: &[T],
     next_revisions: &[T],
@@ -637,8 +655,17 @@ fn message_list_sync_operation<T: PartialEq>(
     };
 
     if previous_revisions.len() == next_revisions.len() {
-        MessageListSyncOperation::Remeasure {
-            range: first_diff..next_revisions.len(),
+        if let Some(first_identity_diff) =
+            first_message_identity_diff(previous_revisions, next_revisions, first_diff)
+        {
+            MessageListSyncOperation::Splice {
+                old_range: first_identity_diff..previous_revisions.len(),
+                count: next_revisions.len().saturating_sub(first_identity_diff),
+            }
+        } else {
+            MessageListSyncOperation::Remeasure {
+                range: first_diff..next_revisions.len(),
+            }
         }
     } else {
         MessageListSyncOperation::Splice {

--- a/app/ai-chat/src/features/conversation/detail.rs
+++ b/app/ai-chat/src/features/conversation/detail.rs
@@ -1,7 +1,7 @@
 use crate::{
     components::{
         chat_form::{ChatForm, ChatFormEvent},
-        message::MessageView,
+        message::{MessageView, MessageViewExt},
     },
     foundation::assets::IconName,
     foundation::i18n::I18n,
@@ -10,7 +10,7 @@ use crate::{
 use gpui::actions;
 use gpui::{
     AlignItems, AnyElement, App, AppContext, Context, Entity, FocusHandle, InteractiveElement,
-    IntoElement, ListAlignment, ListOffset, ListState, ParentElement, Render, SharedString, Styled,
+    IntoElement, ListAlignment, ListState, ParentElement, Render, SharedString, Styled,
     Subscription, Task, Window, div, list, prelude::FluentBuilder, px,
 };
 use gpui_component::{
@@ -20,6 +20,7 @@ use gpui_component::{
     h_flex,
     label::Label,
     scroll::ScrollableElement,
+    text::TextViewState,
     v_flex,
 };
 
@@ -57,7 +58,7 @@ pub(crate) trait ConversationDetailViewExt: Sized + 'static {
     fn message_list_alignment(&self) -> ListAlignment {
         ListAlignment::Top
     }
-    fn auto_scroll_new_messages_when_at_end(&self) -> bool {
+    fn measure_all_message_list(&self) -> bool {
         false
     }
 
@@ -145,33 +146,43 @@ pub(crate) struct ConversationDetailView<T: ConversationDetailViewExt> {
     focus_handle: FocusHandle,
     pub(crate) message_list: ListState,
     pub(crate) message_revisions: Vec<T::Revision>,
+    message_ids: Vec<T::MessageId>,
+    message_text_states: Vec<MessageTextState<T::MessageId>>,
     pub(crate) chat_form: Entity<ChatForm>,
     pub(crate) _subscriptions: Vec<Subscription>,
     pub(crate) task: Option<RunningTask<T::MessageId>>,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-struct MessageListChange {
-    item_count_increased: bool,
-    latest_revision_changed: bool,
+struct MessageTextState<I> {
+    id: I,
+    state: Entity<TextViewState>,
+    _subscription: Subscription,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct PreservedScrollOffset {
-    item_ix: usize,
-    offset_in_item: gpui::Pixels,
+#[derive(Debug, PartialEq, Eq)]
+enum MessageListSyncOperation {
+    None,
+    Reset {
+        count: usize,
+    },
+    Remeasure {
+        range: std::ops::Range<usize>,
+    },
+    Splice {
+        old_range: std::ops::Range<usize>,
+        count: usize,
+    },
 }
 
 impl<T: ConversationDetailViewExt> ConversationDetailView<T> {
     pub(crate) fn new_with_detail(detail: T, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let alignment = detail.message_list_alignment();
-        let auto_scroll_new_messages = detail.auto_scroll_new_messages_when_at_end();
         let should_focus = detail.focus_on_init();
         let focus_handle = cx.focus_handle();
         if should_focus {
             focus_handle.focus(window, cx);
         }
-        let message_list = if should_measure_all_message_list(auto_scroll_new_messages) {
+        let message_list = if detail.measure_all_message_list() {
             ListState::new(0, alignment, px(1000.)).measure_all()
         } else {
             ListState::new(0, alignment, px(1000.))
@@ -191,6 +202,8 @@ impl<T: ConversationDetailViewExt> ConversationDetailView<T> {
             focus_handle,
             message_list,
             message_revisions: Vec::new(),
+            message_ids: Vec::new(),
+            message_text_states: Vec::new(),
             chat_form,
             _subscriptions,
             task: None,
@@ -279,69 +292,96 @@ impl<T: ConversationDetailViewExt> ConversationDetailView<T> {
         }
     }
 
-    fn sync_message_list(&mut self, next_revisions: Vec<T::Revision>) -> MessageListChange {
-        let change = message_list_change(&self.message_revisions, &next_revisions);
+    fn sync_message_list(&mut self, next_revisions: Vec<T::Revision>) {
+        let list_count = self.message_list.item_count();
+        let operation =
+            message_list_sync_operation(list_count, &self.message_revisions, &next_revisions);
 
-        if self.message_list.item_count() != self.message_revisions.len() {
-            self.message_list.reset(next_revisions.len());
-            self.message_revisions = next_revisions;
-            return change;
-        }
-
-        if self.message_revisions == next_revisions {
-            return change;
-        }
-
-        let first_diff = self
-            .message_revisions
-            .iter()
-            .zip(next_revisions.iter())
-            .position(|(left, right)| left != right)
-            .unwrap_or_else(|| self.message_revisions.len().min(next_revisions.len()));
-        let preserved_scroll_offset = preserved_tail_item_scroll_offset(
-            &self.message_list,
-            self.message_revisions.len(),
-            next_revisions.len(),
-            first_diff,
-        );
-
-        self.message_list.splice(
-            first_diff..self.message_revisions.len(),
-            next_revisions.len().saturating_sub(first_diff),
-        );
-        if let Some(scroll_offset) = preserved_scroll_offset {
-            self.message_list.scroll_to(ListOffset {
-                item_ix: scroll_offset.item_ix,
-                offset_in_item: scroll_offset.offset_in_item,
-            });
+        match operation {
+            MessageListSyncOperation::None => return,
+            MessageListSyncOperation::Reset { count } => self.message_list.reset(count),
+            MessageListSyncOperation::Remeasure { range } => {
+                self.message_list.remeasure_items(range);
+            }
+            MessageListSyncOperation::Splice { old_range, count } => {
+                self.message_list.splice(old_range, count);
+            }
         }
         self.message_revisions = next_revisions;
-        change
     }
 
-    fn maybe_reveal_latest_message(&mut self, change: MessageListChange, was_at_end: bool) {
-        if should_reveal_latest_message(
-            self.detail.auto_scroll_new_messages_when_at_end(),
-            was_at_end,
-            change,
-            self.message_revisions.len(),
-        ) {
-            scroll_to_message_end(
-                &self.message_list,
-                self.detail.message_list_alignment(),
-                self.message_revisions.len(),
-            );
+    fn sync_message_text_states(&mut self, cx: &mut Context<ConversationDetailView<T>>) {
+        if !self.detail.measure_all_message_list() {
+            return;
         }
+
+        let sources_label = cx.global::<I18n>().t("field-sources");
+        let mut next_ids = Vec::with_capacity(self.message_revisions.len());
+
+        for index in 0..self.message_revisions.len() {
+            let Some(message) = self.detail.message_at(index, cx) else {
+                continue;
+            };
+            let message_id = message.id();
+            let source = message.content().display_markdown(&sources_label);
+            self.ensure_message_text_state(message_id, &source, cx);
+            next_ids.push(message_id);
+        }
+
+        self.message_text_states
+            .retain(|entry| next_ids.contains(&entry.id));
+        self.message_ids = next_ids;
+    }
+
+    fn ensure_message_text_state(
+        &mut self,
+        message_id: T::MessageId,
+        source: &str,
+        cx: &mut Context<ConversationDetailView<T>>,
+    ) {
+        if let Some(entry) = self
+            .message_text_states
+            .iter()
+            .find(|entry| entry.id == message_id)
+        {
+            entry
+                .state
+                .update(cx, |state, cx| state.set_text(source, cx));
+            return;
+        }
+
+        let state = cx.new(|cx| TextViewState::markdown(source, cx));
+        let subscription = cx.observe(&state, move |this, _, cx| {
+            if let Some(index) = this
+                .message_ids
+                .iter()
+                .position(|current_id| *current_id == message_id)
+            {
+                this.message_list.remeasure_items(index..index + 1);
+                cx.notify();
+            }
+        });
+
+        self.message_text_states.push(MessageTextState {
+            id: message_id,
+            state,
+            _subscription: subscription,
+        });
+    }
+
+    fn message_text_state(&self, message_id: T::MessageId) -> Option<Entity<TextViewState>> {
+        self.message_text_states
+            .iter()
+            .find(|entry| entry.id == message_id)
+            .map(|entry| entry.state.clone())
     }
 }
 
 impl<T: ConversationDetailViewExt> Render for ConversationDetailView<T> {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let message_revisions = self.detail.message_revisions(cx);
-        let alignment = self.detail.message_list_alignment();
-        let was_at_end = list_is_at_end(&self.message_list, alignment);
-        let change = self.sync_message_list(message_revisions);
-        self.maybe_reveal_latest_message(change, was_at_end);
+        self.sync_message_list(message_revisions);
+        self.sync_message_text_states(cx);
         let message_count = self.message_revisions.len();
 
         let title = self.detail.title(cx);
@@ -471,10 +511,11 @@ impl<T: ConversationDetailViewExt> Render for ConversationDetailView<T> {
                             list(message_list.clone(), move |ix, _window, cx| {
                                 this.upgrade()
                                     .and_then(|view| {
-                                        view.read(cx)
-                                            .detail
-                                            .message_at(ix, cx)
-                                            .map(MessageView::new)
+                                        let view = view.read(cx);
+                                        view.detail.message_at(ix, cx).map(|message| {
+                                            let text_state = view.message_text_state(message.id());
+                                            MessageView::new(message).with_text_state(text_state)
+                                        })
                                     })
                                     .map(|message| message.into_any_element())
                                     .unwrap_or_else(|| div().into_any_element())
@@ -506,105 +547,45 @@ impl<T: ConversationDetailViewExt> Render for ConversationDetailView<T> {
     }
 }
 
-fn should_measure_all_message_list(auto_scroll_new_messages: bool) -> bool {
-    auto_scroll_new_messages
-}
-
-const SCROLL_END_EPSILON_PX: f32 = 1.;
-
-fn scroll_to_message_end(message_list: &ListState, alignment: ListAlignment, item_count: usize) {
-    if item_count == 0 {
-        return;
-    }
-
-    match alignment {
-        ListAlignment::Bottom => message_list.scroll_to_reveal_item(item_count - 1),
-        ListAlignment::Top => message_list.scroll_to(ListOffset {
-            item_ix: item_count,
-            offset_in_item: px(0.),
-        }),
-    }
-}
-fn list_is_at_end(message_list: &ListState, alignment: ListAlignment) -> bool {
-    match alignment {
-        ListAlignment::Bottom => {
-            let scroll_top = message_list.logical_scroll_top();
-            scroll_top.item_ix >= message_list.item_count() && scroll_top.offset_in_item == px(0.)
-        }
-        ListAlignment::Top => {
-            let max_offset = message_list.max_offset_for_scrollbar().y;
-            if max_offset == px(0.) {
-                true
-            } else {
-                let current_offset = (-message_list.scroll_px_offset_for_scrollbar().y).max(px(0.));
-                current_offset + px(SCROLL_END_EPSILON_PX) >= max_offset
-            }
-        }
-    }
-}
-
-fn latest_revision_changed<T: PartialEq>(
-    previous_revision: Option<&T>,
-    next_revision: Option<&T>,
-) -> bool {
-    match (previous_revision, next_revision) {
-        (Some(previous), Some(next)) => previous != next,
-        _ => false,
-    }
-}
-
-fn preserved_tail_item_scroll_offset(
-    message_list: &ListState,
-    previous_item_count: usize,
-    next_item_count: usize,
-    first_diff: usize,
-) -> Option<PreservedScrollOffset> {
-    if previous_item_count == 0
-        || previous_item_count != next_item_count
-        || first_diff + 1 != previous_item_count
-    {
-        return None;
-    }
-
-    let scroll_top = message_list.logical_scroll_top();
-    if scroll_top.item_ix != first_diff || scroll_top.offset_in_item == px(0.) {
-        return None;
-    }
-
-    Some(PreservedScrollOffset {
-        item_ix: scroll_top.item_ix,
-        offset_in_item: scroll_top.offset_in_item,
-    })
-}
-
-fn message_list_change<T: PartialEq>(
+fn first_revision_diff<T: PartialEq>(
     previous_revisions: &[T],
     next_revisions: &[T],
-) -> MessageListChange {
-    MessageListChange {
-        item_count_increased: next_revisions.len() > previous_revisions.len(),
-        latest_revision_changed: latest_revision_changed(
-            previous_revisions.last(),
-            next_revisions.last(),
-        ),
-    }
+) -> Option<usize> {
+    previous_revisions
+        .iter()
+        .zip(next_revisions.iter())
+        .position(|(left, right)| left != right)
+        .or_else(|| {
+            (previous_revisions.len() != next_revisions.len())
+                .then(|| previous_revisions.len().min(next_revisions.len()))
+        })
 }
 
-fn should_reveal_latest_message(
-    auto_scroll_new_messages: bool,
-    was_at_end: bool,
-    change: MessageListChange,
-    next_item_count: usize,
-) -> bool {
-    if !auto_scroll_new_messages || next_item_count == 0 {
-        return false;
+fn message_list_sync_operation<T: PartialEq>(
+    list_item_count: usize,
+    previous_revisions: &[T],
+    next_revisions: &[T],
+) -> MessageListSyncOperation {
+    if list_item_count != previous_revisions.len() {
+        return MessageListSyncOperation::Reset {
+            count: next_revisions.len(),
+        };
     }
 
-    if change.item_count_increased {
-        return true;
-    }
+    let Some(first_diff) = first_revision_diff(previous_revisions, next_revisions) else {
+        return MessageListSyncOperation::None;
+    };
 
-    was_at_end && change.latest_revision_changed
+    if previous_revisions.len() == next_revisions.len() {
+        MessageListSyncOperation::Remeasure {
+            range: first_diff..next_revisions.len(),
+        }
+    } else {
+        MessageListSyncOperation::Splice {
+            old_range: first_diff..previous_revisions.len(),
+            count: next_revisions.len().saturating_sub(first_diff),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/app/ai-chat/src/features/conversation/detail.rs
+++ b/app/ai-chat/src/features/conversation/detail.rs
@@ -61,6 +61,9 @@ pub(crate) trait ConversationDetailViewExt: Sized + 'static {
     fn measure_all_message_list(&self) -> bool {
         false
     }
+    fn initially_reveal_latest_message(&self) -> bool {
+        false
+    }
 
     fn message_revisions(&self, cx: &App) -> Vec<Self::Revision>;
     fn message_at(&self, index: usize, cx: &App) -> Option<Self::Message>;
@@ -148,6 +151,7 @@ pub(crate) struct ConversationDetailView<T: ConversationDetailViewExt> {
     pub(crate) message_revisions: Vec<T::Revision>,
     message_ids: Vec<T::MessageId>,
     message_text_states: Vec<MessageTextState<T::MessageId>>,
+    initial_message_reveal: InitialMessageReveal,
     pub(crate) chat_form: Entity<ChatForm>,
     pub(crate) _subscriptions: Vec<Subscription>,
     pub(crate) task: Option<RunningTask<T::MessageId>>,
@@ -157,6 +161,36 @@ struct MessageTextState<I> {
     id: I,
     state: Entity<TextViewState>,
     _subscription: Subscription,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct InitialMessageReveal {
+    enabled: bool,
+    pending: bool,
+}
+
+impl InitialMessageReveal {
+    fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+            pending: enabled,
+        }
+    }
+
+    fn record_sync_operation(&mut self, operation: &MessageListSyncOperation) {
+        if self.enabled && matches!(operation, MessageListSyncOperation::Reset { .. }) {
+            self.pending = true;
+        }
+    }
+
+    fn take_if_ready(&mut self, message_count: usize) -> bool {
+        if self.enabled && self.pending && message_count > 0 {
+            self.pending = false;
+            true
+        } else {
+            false
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -177,6 +211,7 @@ enum MessageListSyncOperation {
 impl<T: ConversationDetailViewExt> ConversationDetailView<T> {
     pub(crate) fn new_with_detail(detail: T, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let alignment = detail.message_list_alignment();
+        let initially_reveal_latest_message = detail.initially_reveal_latest_message();
         let should_focus = detail.focus_on_init();
         let focus_handle = cx.focus_handle();
         if should_focus {
@@ -204,6 +239,7 @@ impl<T: ConversationDetailViewExt> ConversationDetailView<T> {
             message_revisions: Vec::new(),
             message_ids: Vec::new(),
             message_text_states: Vec::new(),
+            initial_message_reveal: InitialMessageReveal::new(initially_reveal_latest_message),
             chat_form,
             _subscriptions,
             task: None,
@@ -296,6 +332,8 @@ impl<T: ConversationDetailViewExt> ConversationDetailView<T> {
         let list_count = self.message_list.item_count();
         let operation =
             message_list_sync_operation(list_count, &self.message_revisions, &next_revisions);
+        self.initial_message_reveal
+            .record_sync_operation(&operation);
 
         match operation {
             MessageListSyncOperation::None => return,
@@ -375,6 +413,27 @@ impl<T: ConversationDetailViewExt> ConversationDetailView<T> {
             .find(|entry| entry.id == message_id)
             .map(|entry| entry.state.clone())
     }
+
+    fn schedule_initial_message_reveal(
+        &mut self,
+        window: &Window,
+        cx: &mut Context<ConversationDetailView<T>>,
+    ) {
+        if !self
+            .initial_message_reveal
+            .take_if_ready(self.message_revisions.len())
+        {
+            return;
+        }
+
+        cx.defer_in(window, |this, _window, cx| {
+            if this.message_revisions.is_empty() {
+                return;
+            }
+            this.message_list.scroll_to_end();
+            cx.notify();
+        });
+    }
 }
 
 impl<T: ConversationDetailViewExt> Render for ConversationDetailView<T> {
@@ -382,6 +441,7 @@ impl<T: ConversationDetailViewExt> Render for ConversationDetailView<T> {
         let message_revisions = self.detail.message_revisions(cx);
         self.sync_message_list(message_revisions);
         self.sync_message_text_states(cx);
+        self.schedule_initial_message_reveal(window, cx);
         let message_count = self.message_revisions.len();
 
         let title = self.detail.title(cx);

--- a/app/ai-chat/src/features/conversation/detail.rs
+++ b/app/ai-chat/src/features/conversation/detail.rs
@@ -655,12 +655,10 @@ fn message_list_sync_operation<T: PartialEq + MessageRevisionExt>(
     };
 
     if previous_revisions.len() == next_revisions.len() {
-        if let Some(first_identity_diff) =
-            first_message_identity_diff(previous_revisions, next_revisions, first_diff)
-        {
+        if first_message_identity_diff(previous_revisions, next_revisions, first_diff).is_some() {
             MessageListSyncOperation::Splice {
-                old_range: first_identity_diff..previous_revisions.len(),
-                count: next_revisions.len().saturating_sub(first_identity_diff),
+                old_range: first_diff..previous_revisions.len(),
+                count: next_revisions.len().saturating_sub(first_diff),
             }
         } else {
             MessageListSyncOperation::Remeasure {

--- a/app/ai-chat/src/features/conversation/detail/tests.rs
+++ b/app/ai-chat/src/features/conversation/detail/tests.rs
@@ -103,6 +103,21 @@ fn message_list_sync_splices_equal_length_identity_changes() {
 }
 
 #[test]
+fn message_list_sync_splices_from_first_diff_when_identity_change_follows_content_change() {
+    assert_eq!(
+        message_list_sync_operation(
+            3,
+            &[revision(1, 1), revision(2, 1), revision(3, 1)],
+            &[revision(1, 2), revision(2, 1), revision(4, 1)]
+        ),
+        MessageListSyncOperation::Splice {
+            old_range: 0..3,
+            count: 3,
+        }
+    );
+}
+
+#[test]
 fn first_revision_diff_finds_content_and_length_changes() {
     assert_eq!(first_revision_diff(&[1, 2, 3], &[1, 9, 3]), Some(1));
     assert_eq!(first_revision_diff(&[1, 2], &[1, 2, 3]), Some(2));

--- a/app/ai-chat/src/features/conversation/detail/tests.rs
+++ b/app/ai-chat/src/features/conversation/detail/tests.rs
@@ -1,8 +1,29 @@
 use super::{
-    InitialMessageReveal, MessageListSyncOperation, RunningTask, first_revision_diff,
-    message_list_sync_operation,
+    InitialMessageReveal, MessageListSyncOperation, MessageRevisionExt, RunningTask,
+    first_revision_diff, message_list_sync_operation,
 };
 use gpui::Task;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct TestRevision {
+    id: usize,
+    content_version: usize,
+}
+
+impl MessageRevisionExt for TestRevision {
+    type Id = usize;
+
+    fn message_id(&self) -> Self::Id {
+        self.id
+    }
+}
+
+fn revision(id: usize, content_version: usize) -> TestRevision {
+    TestRevision {
+        id,
+        content_version,
+    }
+}
 
 #[test]
 fn running_task_binds_and_matches_messages() {
@@ -19,23 +40,65 @@ fn running_task_binds_and_matches_messages() {
 #[test]
 fn message_list_sync_remeasures_existing_items_instead_of_splicing_them() {
     assert_eq!(
-        message_list_sync_operation(2, &[1, 2], &[1, 3]),
+        message_list_sync_operation(
+            2,
+            &[revision(1, 1), revision(2, 1)],
+            &[revision(1, 1), revision(2, 2)]
+        ),
         MessageListSyncOperation::Remeasure { range: 1..2 }
     );
     assert_eq!(
-        message_list_sync_operation(2, &[1, 2], &[1, 2, 3]),
+        message_list_sync_operation(
+            2,
+            &[revision(1, 1), revision(2, 1)],
+            &[revision(1, 1), revision(2, 1), revision(3, 1)]
+        ),
         MessageListSyncOperation::Splice {
             old_range: 2..2,
             count: 1,
         }
     );
     assert_eq!(
-        message_list_sync_operation(1, &[1, 2], &[1, 3]),
+        message_list_sync_operation(
+            1,
+            &[revision(1, 1), revision(2, 1)],
+            &[revision(1, 1), revision(2, 2)]
+        ),
         MessageListSyncOperation::Reset { count: 2 }
     );
     assert_eq!(
-        message_list_sync_operation(2, &[1, 2], &[1, 2]),
+        message_list_sync_operation(
+            2,
+            &[revision(1, 1), revision(2, 1)],
+            &[revision(1, 1), revision(2, 1)]
+        ),
         MessageListSyncOperation::None
+    );
+}
+
+#[test]
+fn message_list_sync_splices_equal_length_identity_changes() {
+    assert_eq!(
+        message_list_sync_operation(
+            2,
+            &[revision(1, 1), revision(2, 1)],
+            &[revision(1, 1), revision(3, 1)]
+        ),
+        MessageListSyncOperation::Splice {
+            old_range: 1..2,
+            count: 1,
+        }
+    );
+    assert_eq!(
+        message_list_sync_operation(
+            3,
+            &[revision(1, 1), revision(2, 1), revision(3, 1)],
+            &[revision(1, 1), revision(3, 1), revision(2, 1)]
+        ),
+        MessageListSyncOperation::Splice {
+            old_range: 1..3,
+            count: 2,
+        }
     );
 }
 

--- a/app/ai-chat/src/features/conversation/detail/tests.rs
+++ b/app/ai-chat/src/features/conversation/detail/tests.rs
@@ -1,9 +1,7 @@
 use super::{
-    MessageListChange, PreservedScrollOffset, RunningTask, latest_revision_changed, list_is_at_end,
-    message_list_change, preserved_tail_item_scroll_offset, should_measure_all_message_list,
-    should_reveal_latest_message,
+    MessageListSyncOperation, RunningTask, first_revision_diff, message_list_sync_operation,
 };
-use gpui::{ListAlignment, ListState, Task, px};
+use gpui::Task;
 
 #[test]
 fn running_task_binds_and_matches_messages() {
@@ -18,113 +16,32 @@ fn running_task_binds_and_matches_messages() {
 }
 
 #[test]
-fn auto_scrolling_lists_use_full_measurement() {
-    assert!(should_measure_all_message_list(true));
-    assert!(!should_measure_all_message_list(false));
-}
-
-#[test]
-fn bottom_aligned_list_is_at_end_only_at_bottom_offset() {
-    let state = ListState::new(3, ListAlignment::Bottom, px(100.));
-    assert!(list_is_at_end(&state, ListAlignment::Bottom));
-
-    state.scroll_to_reveal_item(0);
-    assert!(!list_is_at_end(&state, ListAlignment::Bottom));
-    assert!(list_is_at_end(&state, ListAlignment::Top));
-}
-
-#[test]
-fn latest_revision_change_only_tracks_last_message() {
-    assert!(latest_revision_changed(Some(&2), Some(&3)));
-    assert!(!latest_revision_changed(Some(&2), Some(&2)));
-    assert!(!latest_revision_changed::<i32>(None, None));
-}
-
-#[test]
-fn message_list_change_tracks_new_items_and_tail_updates() {
+fn message_list_sync_remeasures_existing_items_instead_of_splicing_them() {
     assert_eq!(
-        message_list_change(&[1], &[1, 2]),
-        MessageListChange {
-            item_count_increased: true,
-            latest_revision_changed: true,
+        message_list_sync_operation(2, &[1, 2], &[1, 3]),
+        MessageListSyncOperation::Remeasure { range: 1..2 }
+    );
+    assert_eq!(
+        message_list_sync_operation(2, &[1, 2], &[1, 2, 3]),
+        MessageListSyncOperation::Splice {
+            old_range: 2..2,
+            count: 1,
         }
     );
     assert_eq!(
-        message_list_change(&[1, 2], &[9, 2]),
-        MessageListChange {
-            item_count_increased: false,
-            latest_revision_changed: false,
-        }
+        message_list_sync_operation(1, &[1, 2], &[1, 3]),
+        MessageListSyncOperation::Reset { count: 2 }
     );
-}
-
-#[test]
-fn preserves_scroll_offset_for_last_item_only_when_viewport_is_inside_it() {
-    let state = ListState::new(2, ListAlignment::Top, px(100.));
-    state.scroll_to(gpui::ListOffset {
-        item_ix: 1,
-        offset_in_item: px(42.),
-    });
-
     assert_eq!(
-        preserved_tail_item_scroll_offset(&state, 2, 2, 1),
-        Some(PreservedScrollOffset {
-            item_ix: 1,
-            offset_in_item: px(42.),
-        })
+        message_list_sync_operation(2, &[1, 2], &[1, 2]),
+        MessageListSyncOperation::None
     );
-    assert_eq!(preserved_tail_item_scroll_offset(&state, 2, 2, 0), None);
-    assert_eq!(preserved_tail_item_scroll_offset(&state, 2, 3, 1), None);
-
-    state.scroll_to(gpui::ListOffset {
-        item_ix: 1,
-        offset_in_item: px(0.),
-    });
-    assert_eq!(preserved_tail_item_scroll_offset(&state, 2, 2, 1), None);
 }
 
 #[test]
-fn reveal_latest_message_for_new_message_or_tail_chunk_at_end() {
-    assert!(should_reveal_latest_message(
-        true,
-        false,
-        MessageListChange {
-            item_count_increased: true,
-            latest_revision_changed: true,
-        },
-        2,
-    ));
-    assert!(should_reveal_latest_message(
-        true,
-        true,
-        MessageListChange {
-            item_count_increased: false,
-            latest_revision_changed: true,
-        },
-        2,
-    ));
-    assert!(!should_reveal_latest_message(
-        true,
-        false,
-        MessageListChange {
-            item_count_increased: false,
-            latest_revision_changed: true,
-        },
-        2,
-    ));
-    assert!(!should_reveal_latest_message(
-        true,
-        true,
-        MessageListChange::default(),
-        2,
-    ));
-    assert!(!should_reveal_latest_message(
-        false,
-        true,
-        MessageListChange {
-            item_count_increased: true,
-            latest_revision_changed: true,
-        },
-        2,
-    ));
+fn first_revision_diff_finds_content_and_length_changes() {
+    assert_eq!(first_revision_diff(&[1, 2, 3], &[1, 9, 3]), Some(1));
+    assert_eq!(first_revision_diff(&[1, 2], &[1, 2, 3]), Some(2));
+    assert_eq!(first_revision_diff(&[1, 2, 3], &[1, 2]), Some(2));
+    assert_eq!(first_revision_diff(&[1, 2], &[1, 2]), None);
 }

--- a/app/ai-chat/src/features/conversation/detail/tests.rs
+++ b/app/ai-chat/src/features/conversation/detail/tests.rs
@@ -1,5 +1,6 @@
 use super::{
-    MessageListSyncOperation, RunningTask, first_revision_diff, message_list_sync_operation,
+    InitialMessageReveal, MessageListSyncOperation, RunningTask, first_revision_diff,
+    message_list_sync_operation,
 };
 use gpui::Task;
 
@@ -44,4 +45,39 @@ fn first_revision_diff_finds_content_and_length_changes() {
     assert_eq!(first_revision_diff(&[1, 2], &[1, 2, 3]), Some(2));
     assert_eq!(first_revision_diff(&[1, 2, 3], &[1, 2]), Some(2));
     assert_eq!(first_revision_diff(&[1, 2], &[1, 2]), None);
+}
+
+#[test]
+fn initial_message_reveal_waits_for_first_non_empty_message_list() {
+    let mut reveal = InitialMessageReveal::new(true);
+
+    assert!(!reveal.take_if_ready(0));
+    assert!(reveal.take_if_ready(1));
+    assert!(!reveal.take_if_ready(1));
+}
+
+#[test]
+fn initial_message_reveal_is_rearmed_only_by_reset() {
+    let mut reveal = InitialMessageReveal::new(true);
+    assert!(reveal.take_if_ready(2));
+
+    reveal.record_sync_operation(&MessageListSyncOperation::Remeasure { range: 1..2 });
+    assert!(!reveal.take_if_ready(2));
+
+    reveal.record_sync_operation(&MessageListSyncOperation::Splice {
+        old_range: 2..2,
+        count: 1,
+    });
+    assert!(!reveal.take_if_ready(3));
+
+    reveal.record_sync_operation(&MessageListSyncOperation::Reset { count: 3 });
+    assert!(reveal.take_if_ready(3));
+}
+
+#[test]
+fn initial_message_reveal_stays_disabled_when_not_configured() {
+    let mut reveal = InitialMessageReveal::new(false);
+
+    reveal.record_sync_operation(&MessageListSyncOperation::Reset { count: 2 });
+    assert!(!reveal.take_if_ready(2));
 }

--- a/app/ai-chat/src/features/home/tabs/conversation_panel.rs
+++ b/app/ai-chat/src/features/home/tabs/conversation_panel.rs
@@ -7,7 +7,9 @@ use crate::{
     database::{Content, Conversation, Db, Message, Mode, NewMessage, Role, Status},
     errors::{AiChatError, AiChatResult},
     export::{ExportType, export_conversation_to_path, suggested_export_file_name},
-    features::conversation::detail::{ConversationDetailView, ConversationDetailViewExt},
+    features::conversation::detail::{
+        ConversationDetailView, ConversationDetailViewExt, MessageRevisionExt,
+    },
     foundation::assets::IconName,
     foundation::i18n::I18n,
     llm::{FetchRunner, FetchUpdate, provider_by_name},
@@ -73,6 +75,14 @@ impl MessageRevision {
             content_len,
             error_len: message.error.as_ref().map_or(0, String::len),
         }
+    }
+}
+
+impl MessageRevisionExt for MessageRevision {
+    type Id = i32;
+
+    fn message_id(&self) -> Self::Id {
+        self.id
     }
 }
 

--- a/app/ai-chat/src/features/home/tabs/conversation_panel.rs
+++ b/app/ai-chat/src/features/home/tabs/conversation_panel.rs
@@ -172,10 +172,14 @@ impl ConversationDetailViewExt for ConversationPanelState {
     }
 
     fn message_list_alignment(&self) -> ListAlignment {
-        ListAlignment::Bottom
+        ListAlignment::Top
     }
 
     fn measure_all_message_list(&self) -> bool {
+        true
+    }
+
+    fn initially_reveal_latest_message(&self) -> bool {
         true
     }
 

--- a/app/ai-chat/src/features/home/tabs/conversation_panel.rs
+++ b/app/ai-chat/src/features/home/tabs/conversation_panel.rs
@@ -172,10 +172,10 @@ impl ConversationDetailViewExt for ConversationPanelState {
     }
 
     fn message_list_alignment(&self) -> ListAlignment {
-        ListAlignment::Top
+        ListAlignment::Bottom
     }
 
-    fn auto_scroll_new_messages_when_at_end(&self) -> bool {
+    fn measure_all_message_list(&self) -> bool {
         true
     }
 

--- a/app/ai-chat/src/features/home/tabs/conversation_panel/tests.rs
+++ b/app/ai-chat/src/features/home/tabs/conversation_panel/tests.rs
@@ -22,7 +22,7 @@ fn make_message(id: i32, role: Role, status: Status, content: Content) -> Messag
 }
 
 #[test]
-fn conversation_panel_message_list_starts_at_bottom_with_full_measurement() {
+fn conversation_panel_message_list_uses_top_order_with_initial_reveal() {
     let state = ConversationPanelState {
         conversation_id: 1,
         conversation_icon: "chat".into(),
@@ -30,8 +30,9 @@ fn conversation_panel_message_list_starts_at_bottom_with_full_measurement() {
         conversation_info: None,
     };
 
-    assert_eq!(state.message_list_alignment(), ListAlignment::Bottom);
+    assert_eq!(state.message_list_alignment(), ListAlignment::Top);
     assert!(state.measure_all_message_list());
+    assert!(state.initially_reveal_latest_message());
 }
 
 #[test]

--- a/app/ai-chat/src/features/home/tabs/conversation_panel/tests.rs
+++ b/app/ai-chat/src/features/home/tabs/conversation_panel/tests.rs
@@ -22,6 +22,19 @@ fn make_message(id: i32, role: Role, status: Status, content: Content) -> Messag
 }
 
 #[test]
+fn conversation_panel_message_list_starts_at_bottom_with_full_measurement() {
+    let state = ConversationPanelState {
+        conversation_id: 1,
+        conversation_icon: "chat".into(),
+        conversation_title: "Default".into(),
+        conversation_info: None,
+    };
+
+    assert_eq!(state.message_list_alignment(), ListAlignment::Bottom);
+    assert!(state.measure_all_message_list());
+}
+
+#[test]
 fn get_history_contextual_includes_all_normal_messages_and_user() {
     let contents = build_history_messages(
         vec![

--- a/app/ai-chat/src/features/temporary/detail.rs
+++ b/app/ai-chat/src/features/temporary/detail.rs
@@ -10,7 +10,9 @@ use crate::{
     features::hotkey::GlobalHotkeyState,
     features::{
         conversation::{
-            detail::{ConversationDetailView, ConversationDetailViewExt, DetailEscape},
+            detail::{
+                ConversationDetailView, ConversationDetailViewExt, DetailEscape, MessageRevisionExt,
+            },
             preview::{MessagePreviewExt, open_message_preview_window},
         },
         temporary::TemporaryView,
@@ -345,6 +347,14 @@ impl TemporaryMessageRevision {
             content_len,
             error_len: message.error.as_ref().map_or(0, String::len),
         }
+    }
+}
+
+impl MessageRevisionExt for TemporaryMessageRevision {
+    type Id = usize;
+
+    fn message_id(&self) -> Self::Id {
+        self.id
     }
 }
 


### PR DESCRIPTION
## Summary

- Fixes ai-chat conversation list scrolling behavior on the home page.
- Keeps messages visually ordered from top to bottom.
- Reveals the latest message once on initial load or reset without reintroducing continuous auto-follow.

## Motivation

- The home conversation list used bottom alignment to start at the latest message, but that caused short conversations to be laid out from the bottom upward.
- Earlier scroll jank came from lazy measurement of variable-height Markdown items while scrolling, so the home conversation list now keeps full measurement and stable `TextViewState` instances.

## Changes

- Adds a crate-private `initially_reveal_latest_message()` detail-view configuration point.
- Adds one-shot initial reveal state inside `ConversationDetailView`.
- Keeps homepage conversations on `ListAlignment::Top`, enables full measurement, and schedules a single deferred `scroll_to_end()` after the message list and text states are synchronized.
- Preserves existing splice/reset/remeasure synchronization behavior and does not use `FollowMode::Tail`.

## Validation

- [ ] `cargo build`
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Manual verification completed for the affected app or flow

Validation details:

```text
cargo fmt
cargo test -p ai-chat features::conversation::detail
cargo test -p ai-chat features::home::tabs::conversation_panel
cargo clippy -p ai-chat --all-targets --all-features -- -D warnings
cargo run -p xtask -- bundle-ai-chat

Manual verification used target/release/bundle/macos/AI Chat.app with Computer Use:
- Short homepage conversation messages render from top to bottom.
- Long homepage conversation initially opens at the bottom.
- Scrolling upward stays on the historical position and is not pulled back to the bottom.
- Scrolling downward returns to the latest message normally.

The bundle command completed successfully. actool/CoreSimulator icon injection warnings were non-blocking and the app bundle was produced.
```

## Risks

- Home conversation lists trade extra initial measurement work for stable scrolling on variable-height Markdown content.
- Temporary conversation windows keep their existing default behavior.

## Related Issues

- Closes #99
