### PR TITLE
[bug] feiwen: make book-list crawling resilient to current markup

### DIFF
--- a/app/feiwen/migrations/2026-05-06-000001_nullable_novel_counts/down.sql
+++ b/app/feiwen/migrations/2026-05-06-000001_nullable_novel_counts/down.sql
@@ -1,0 +1,44 @@
+CREATE TABLE novel_old
+(
+    id                  integer NOT NULL PRIMARY key,
+    name                text    NOT NULL,
+    desc                text    NOT NULL,
+    is_limit            boolean NOT NULL,
+    latest_chapter_name text    NOT NULL,
+    latest_chapter_id   integer NOT NULL,
+    word_count          integer NOT NULL,
+    read_count          integer NOT NULL,
+    reply_count         integer NOT NULL,
+    author_id           integer,
+    author_name         text    not null
+);
+
+INSERT INTO novel_old (
+    id,
+    name,
+    desc,
+    is_limit,
+    latest_chapter_name,
+    latest_chapter_id,
+    word_count,
+    read_count,
+    reply_count,
+    author_id,
+    author_name
+)
+SELECT
+    id,
+    name,
+    desc,
+    is_limit,
+    latest_chapter_name,
+    latest_chapter_id,
+    word_count,
+    COALESCE(read_count, 0),
+    COALESCE(reply_count, 0),
+    author_id,
+    author_name
+FROM novel;
+
+DROP TABLE novel;
+ALTER TABLE novel_old RENAME TO novel;

--- a/app/feiwen/migrations/2026-05-06-000001_nullable_novel_counts/up.sql
+++ b/app/feiwen/migrations/2026-05-06-000001_nullable_novel_counts/up.sql
@@ -1,0 +1,44 @@
+CREATE TABLE novel_new
+(
+    id                  integer NOT NULL PRIMARY key,
+    name                text    NOT NULL,
+    desc                text    NOT NULL,
+    is_limit            boolean NOT NULL,
+    latest_chapter_name text    NOT NULL,
+    latest_chapter_id   integer NOT NULL,
+    word_count          integer NOT NULL,
+    read_count          integer,
+    reply_count         integer,
+    author_id           integer,
+    author_name         text    not null
+);
+
+INSERT INTO novel_new (
+    id,
+    name,
+    desc,
+    is_limit,
+    latest_chapter_name,
+    latest_chapter_id,
+    word_count,
+    read_count,
+    reply_count,
+    author_id,
+    author_name
+)
+SELECT
+    id,
+    name,
+    desc,
+    is_limit,
+    latest_chapter_name,
+    latest_chapter_id,
+    word_count,
+    read_count,
+    reply_count,
+    author_id,
+    author_name
+FROM novel;
+
+DROP TABLE novel;
+ALTER TABLE novel_new RENAME TO novel;

--- a/app/feiwen/src/errors.rs
+++ b/app/feiwen/src/errors.rs
@@ -32,12 +32,14 @@ pub(crate) enum FeiwenError {
     ChapterIdParse(String),
     #[error("count 解析错误")]
     CountParse,
+    #[error("文库页面被站点拦截")]
+    FetchBlocked,
+    #[error("文库页面需要登录")]
+    FetchLogin,
+    #[error("文库列表解析为空")]
+    NovelListParse,
     #[error("word count 解析错误")]
     WordCountParse,
-    #[error("read count 解析错误")]
-    ReadCountParse,
-    #[error("reply count 解析错误")]
-    ReplyCountParse,
     #[error("count uint 解析错误,{}",.0)]
     CountUintParse(String),
     #[error("log file not found")]

--- a/app/feiwen/src/features/fetch.rs
+++ b/app/feiwen/src/features/fetch.rs
@@ -159,15 +159,16 @@ impl Runner<'_> {
                     self.form_emit(FetchFormEvent::FetchNetworkError);
                 }
                 FeiwenError::DescParse
+                | FeiwenError::FetchBlocked
+                | FeiwenError::FetchLogin
                 | FeiwenError::HrefParse
+                | FeiwenError::NovelListParse
                 | FeiwenError::CountParse
-                | FeiwenError::ReadCountParse
                 | FeiwenError::WordCountParse
                 | FeiwenError::AuthorNameParse
                 | FeiwenError::NovelIdParse(_)
                 | FeiwenError::AuthorIdParse(_)
                 | FeiwenError::ChapterIdParse(_)
-                | FeiwenError::ReplyCountParse
                 | FeiwenError::CountUintParse(_) => {
                     event!(Level::ERROR, "Failed to fetch parse: {:?}", err);
                     self.form_emit(FetchFormEvent::FetchParseError);
@@ -481,7 +482,7 @@ impl FetchView {
         let cookie = form.cookie.clone();
         let form = subscriber.downgrade();
         let task = cx.spawn(async move |_, cx| {
-            let span = tracing::info_span!("send", url, start_page, end_page, cookie);
+            let span = tracing::info_span!("send", url, start_page, end_page);
             let mut runner = Runner {
                 conn,
                 url,

--- a/app/feiwen/src/fetch/get_content.rs
+++ b/app/feiwen/src/fetch/get_content.rs
@@ -1,4 +1,7 @@
-use reqwest::Client;
+use reqwest::{
+    Client,
+    header::{ACCEPT, ACCEPT_LANGUAGE, CACHE_CONTROL, COOKIE, PRAGMA, REFERER, USER_AGENT},
+};
 
 use crate::errors::FeiwenResult;
 
@@ -10,7 +13,27 @@ pub(crate) async fn get_content(
 ) -> FeiwenResult<String> {
     let body = client
         .get(url)
-        .header("cookie", cookies)
+        .header(COOKIE, cookies)
+        .header(
+            ACCEPT,
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+        )
+        .header(ACCEPT_LANGUAGE, "zh-CN,zh;q=0.9")
+        .header(CACHE_CONTROL, "no-cache")
+        .header(PRAGMA, "no-cache")
+        .header(REFERER, url)
+        .header("sec-ch-ua", "\"Chromium\";v=\"147\", \"Not.A/Brand\";v=\"8\"")
+        .header("sec-ch-ua-mobile", "?0")
+        .header("sec-ch-ua-platform", "\"macOS\"")
+        .header("sec-fetch-dest", "document")
+        .header("sec-fetch-mode", "navigate")
+        .header("sec-fetch-site", "same-origin")
+        .header("sec-fetch-user", "?1")
+        .header("upgrade-insecure-requests", "1")
+        .header(
+            USER_AGENT,
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36",
+        )
         .query(&[("page", page)])
         .send()
         .await?

--- a/app/feiwen/src/fetch/parse_novel.rs
+++ b/app/feiwen/src/fetch/parse_novel.rs
@@ -32,14 +32,31 @@ static SELECTOR_RAT: LazyLock<Selector> = LazyLock::new(|| {
 });
 static SELECTOR_DESC: LazyLock<Selector> =
     LazyLock::new(|| Selector::parse("div.col-xs-12.h5.brief-0 > span.smaller-5").unwrap());
+static SELECTOR_FIREWALL: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("body.firewall-page").unwrap());
+static SELECTOR_FORM: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("form[action]").unwrap());
 
 pub(crate) fn parse_page(body: String) -> FeiwenResult<Vec<Novel>> {
     let document = Html::parse_document(&body);
+    if document.select(&SELECTOR_FIREWALL).next().is_some() {
+        return Err(FeiwenError::FetchBlocked);
+    }
+    if document.select(&SELECTOR_FORM).any(|form| {
+        form.value()
+            .attr("action")
+            .is_some_and(|action| action.ends_with("/login"))
+    }) {
+        return Err(FeiwenError::FetchLogin);
+    }
     let novels = document
         .select(&SELECTOR_ARTICLE)
         .map(|x| Html::parse_document(&x.inner_html()))
         .map(parse_novel)
         .collect::<FeiwenResult<Vec<_>>>()?;
+    if novels.is_empty() {
+        return Err(FeiwenError::NovelListParse);
+    }
     Ok(novels)
 }
 
@@ -64,4 +81,32 @@ fn parse_novel(doc: Html) -> FeiwenResult<Novel> {
         tags,
         is_limit,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::errors::FeiwenError;
+
+    use super::parse_page;
+
+    #[test]
+    fn parse_page_rejects_firewall_page() {
+        let err = parse_page(r#"<body class="firewall-page"></body>"#.to_owned()).unwrap_err();
+        assert!(matches!(err, FeiwenError::FetchBlocked));
+    }
+
+    #[test]
+    fn parse_page_rejects_login_page() {
+        let err = parse_page(
+            r#"<form method="POST" action="https://xn--pxtr7m.com/login"></form>"#.to_owned(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, FeiwenError::FetchLogin));
+    }
+
+    #[test]
+    fn parse_page_rejects_empty_novel_list() {
+        let err = parse_page("<html></html>".to_owned()).unwrap_err();
+        assert!(matches!(err, FeiwenError::NovelListParse));
+    }
 }

--- a/app/feiwen/src/fetch/parse_novel/parse_count.rs
+++ b/app/feiwen/src/fetch/parse_novel/parse_count.rs
@@ -25,27 +25,26 @@ static SELECTOR_COUNT: LazyLock<Selector> = LazyLock::new(|| {
 });
 
 pub(crate) fn parse_count(doc: &Html) -> FeiwenResult<NovelCount> {
-    let mut count = doc
+    let count = doc
         .select(&SELECTOR_COUNT)
         .next()
-        .ok_or(FeiwenError::CountParse)?
-        .text();
-    let word_count = count
-        .next()
-        .ok_or(FeiwenError::WordCountParse)?
+        .ok_or(FeiwenError::CountParse)?;
+    let count = count.text().collect::<String>();
+    let count = count
         .split('/')
-        .next()
-        .ok_or(FeiwenError::WordCountParse)?;
-    let read_count = count
-        .next()
-        .ok_or(FeiwenError::ReadCountParse)?
-        .split('/')
-        .next()
-        .ok_or(FeiwenError::ReadCountParse)?;
-    let reply_count = count.next().ok_or(FeiwenError::ReplyCountParse)?;
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>();
+    let word_count = count.first().ok_or(FeiwenError::WordCountParse)?;
     let word_count = parse_num_with_unit(word_count)?;
-    let read_count = parse_num_with_unit(read_count)?;
-    let reply_count = parse_num_with_unit(reply_count)?;
+    let read_count = count
+        .get(1)
+        .map(|read_count| parse_num_with_unit(read_count))
+        .transpose()?;
+    let reply_count = count
+        .get(2)
+        .map(|reply_count| parse_num_with_unit(reply_count))
+        .transpose()?;
     Ok(NovelCount {
         word_count,
         read_count,
@@ -58,22 +57,73 @@ fn parse_num_with_unit(num: &str) -> FeiwenResult<i32> {
         enum Flag {
             Qian,
             Wan,
+            K,
         }
         let (input, (num, flag)) = (
             float,
             opt(alt((
                 value(Flag::Qian, tag("千")),
                 value(Flag::Wan, tag("万")),
+                value(Flag::K, tag("k")),
+                value(Flag::K, tag("K")),
             ))),
         )
             .parse(num)?;
         let num = match flag {
             Some(Flag::Qian) => num * 1000f32,
             Some(Flag::Wan) => num * 10000f32,
+            Some(Flag::K) => num * 1000f32,
             None => num,
         };
         Ok((input, num as i32))
     }
-    let (_, num) = inner_parse(num).map_err(|err| FeiwenError::CountUintParse(err.to_string()))?;
+    let num = num.trim().replace(',', "");
+    let (_, num) = inner_parse(&num).map_err(|err| FeiwenError::CountUintParse(err.to_string()))?;
     Ok(num)
+}
+
+#[cfg(test)]
+mod tests {
+    use scraper::Html;
+
+    use super::{parse_count, parse_num_with_unit};
+
+    #[test]
+    fn parses_current_books_count_with_only_word_count() {
+        let doc = Html::parse_document(
+            r#"
+            <div class="col-xs-12 h5 brief-0">
+                <span class="smaller-5">简介</span>
+                <span class = "pull-right smaller-30"><em><span class="glyphicon glyphicon-pencil"></span>16万</em></span>
+            </div>
+            "#,
+        );
+
+        let count = parse_count(&doc).unwrap();
+        assert_eq!(count.word_count, 160000);
+        assert_eq!(count.read_count, None);
+        assert_eq!(count.reply_count, None);
+    }
+
+    #[test]
+    fn parses_legacy_books_count_when_all_counts_are_present() {
+        let doc = Html::parse_document(
+            r#"
+            <div class="col-xs-12 h5 brief-0">
+                <span class = "pull-right smaller-30"><em>16万 / 2.5万 / 30</em></span>
+            </div>
+            "#,
+        );
+
+        let count = parse_count(&doc).unwrap();
+        assert_eq!(count.word_count, 160000);
+        assert_eq!(count.read_count, Some(25000));
+        assert_eq!(count.reply_count, Some(30));
+    }
+
+    #[test]
+    fn parses_k_suffix() {
+        assert_eq!(parse_num_with_unit("63k").unwrap(), 63000);
+        assert_eq!(parse_num_with_unit("1.5K").unwrap(), 1500);
+    }
 }

--- a/app/feiwen/src/store.rs
+++ b/app/feiwen/src/store.rs
@@ -5,7 +5,7 @@ use crate::{
     errors::{FeiwenError, FeiwenResult},
 };
 use diesel::{
-    SqliteConnection,
+    RunQueryDsl, SqliteConnection,
     connection::SimpleConnection,
     r2d2::{ConnectionManager, Pool},
 };
@@ -53,6 +53,7 @@ fn establish_connection() -> FeiwenResult<DbConn> {
     if not_exists {
         create_tables(&pool)?;
     }
+    migrate_tables(&pool)?;
     Ok(pool)
 }
 
@@ -81,4 +82,29 @@ fn create_tables(conn: &DbConn) -> FeiwenResult<()> {
         "../migrations/2022-05-16-064913_novel_tag/up.sql"
     ))?;
     Ok(())
+}
+
+fn migrate_tables(conn: &DbConn) -> FeiwenResult<()> {
+    let conn = &mut conn.get()?;
+    if novel_counts_are_not_null(conn)? {
+        conn.batch_execute(include_str!(
+            "../migrations/2026-05-06-000001_nullable_novel_counts/up.sql"
+        ))?;
+    }
+    Ok(())
+}
+
+fn novel_counts_are_not_null(conn: &mut SqliteConnection) -> FeiwenResult<bool> {
+    #[derive(diesel::QueryableByName)]
+    struct TableColumn {
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        name: String,
+        #[diesel(sql_type = diesel::sql_types::Integer)]
+        notnull: i32,
+    }
+
+    let columns = diesel::sql_query("PRAGMA table_info(novel)").load::<TableColumn>(conn)?;
+    Ok(columns.iter().any(|column| {
+        matches!(column.name.as_str(), "read_count" | "reply_count") && column.notnull != 0
+    }))
 }

--- a/app/feiwen/src/store/model/novel.rs
+++ b/app/feiwen/src/store/model/novel.rs
@@ -19,8 +19,8 @@ pub(crate) struct NovelModel {
     pub(crate) latest_chapter_name: String,
     pub(crate) latest_chapter_id: i32,
     pub(crate) word_count: i32,
-    pub(crate) read_count: i32,
-    pub(crate) reply_count: i32,
+    pub(crate) read_count: Option<i32>,
+    pub(crate) reply_count: Option<i32>,
     pub(crate) author_id: Option<i32>,
     pub(crate) author_name: String,
 }
@@ -31,9 +31,39 @@ impl NovelModel {
         let data = dsl::novel.load::<Self>(conn)?;
         Ok(data)
     }
-    pub(crate) fn save(self, conn: &mut SqliteConnection) -> FeiwenResult<()> {
-        diesel::insert_or_ignore_into(novel::table)
-            .values(self)
+    pub(crate) fn save(mut self, conn: &mut SqliteConnection) -> FeiwenResult<()> {
+        use super::super::schema::novel::dsl;
+
+        if let Some((read_count, reply_count)) = dsl::novel
+            .find(self.id)
+            .select((dsl::read_count, dsl::reply_count))
+            .first::<(Option<i32>, Option<i32>)>(conn)
+            .optional()?
+        {
+            if self.read_count.is_none() {
+                self.read_count = read_count;
+            }
+            if self.reply_count.is_none() {
+                self.reply_count = reply_count;
+            }
+        }
+
+        diesel::insert_into(novel::table)
+            .values(&self)
+            .on_conflict(novel::id)
+            .do_update()
+            .set((
+                novel::name.eq(&self.name),
+                novel::desc.eq(&self.desc),
+                novel::is_limit.eq(self.is_limit),
+                novel::latest_chapter_name.eq(&self.latest_chapter_name),
+                novel::latest_chapter_id.eq(self.latest_chapter_id),
+                novel::word_count.eq(self.word_count),
+                novel::read_count.eq(self.read_count),
+                novel::reply_count.eq(self.reply_count),
+                novel::author_id.eq(self.author_id),
+                novel::author_name.eq(&self.author_name),
+            ))
             .execute(conn)?;
         Ok(())
     }
@@ -62,5 +92,78 @@ impl From<Novel> for NovelModel {
             read_count: value.count.read_count,
             reply_count: value.count.reply_count,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diesel::{Connection, connection::SimpleConnection};
+
+    fn connection() -> SqliteConnection {
+        let mut conn = SqliteConnection::establish(":memory:").unwrap();
+        conn.batch_execute(
+            r#"
+            CREATE TABLE novel
+            (
+                id                  integer NOT NULL PRIMARY key,
+                name                text    NOT NULL,
+                desc                text    NOT NULL,
+                is_limit            boolean NOT NULL,
+                latest_chapter_name text    NOT NULL,
+                latest_chapter_id   integer NOT NULL,
+                word_count          integer NOT NULL,
+                read_count          integer,
+                reply_count         integer,
+                author_id           integer,
+                author_name         text    not null
+            );
+            "#,
+        )
+        .unwrap();
+        conn
+    }
+
+    fn model(id: i32, read_count: Option<i32>, reply_count: Option<i32>) -> NovelModel {
+        NovelModel {
+            id,
+            name: format!("name-{id}"),
+            desc: "desc".to_owned(),
+            is_limit: false,
+            latest_chapter_name: "chapter".to_owned(),
+            latest_chapter_id: 10,
+            word_count: 1000,
+            read_count,
+            reply_count,
+            author_id: Some(1),
+            author_name: "author".to_owned(),
+        }
+    }
+
+    #[test]
+    fn save_preserves_existing_counts_when_new_counts_are_missing() {
+        let mut conn = connection();
+        model(1, Some(12), Some(34)).save(&mut conn).unwrap();
+
+        let mut updated = model(1, None, None);
+        updated.name = "updated".to_owned();
+        updated.author_id = None;
+        updated.save(&mut conn).unwrap();
+
+        let row = novel::table.find(1).first::<NovelModel>(&mut conn).unwrap();
+        assert_eq!(row.name, "updated");
+        assert_eq!(row.author_id, None);
+        assert_eq!(row.read_count, Some(12));
+        assert_eq!(row.reply_count, Some(34));
+    }
+
+    #[test]
+    fn save_allows_missing_counts_for_new_novel() {
+        let mut conn = connection();
+        model(1, None, None).save(&mut conn).unwrap();
+
+        let row = novel::table.find(1).first::<NovelModel>(&mut conn).unwrap();
+        assert_eq!(row.read_count, None);
+        assert_eq!(row.reply_count, None);
     }
 }

--- a/app/feiwen/src/store/schema.rs
+++ b/app/feiwen/src/store/schema.rs
@@ -9,8 +9,8 @@ diesel::table! {
         latest_chapter_name -> Text,
         latest_chapter_id -> Integer,
         word_count -> Integer,
-        read_count -> Integer,
-        reply_count -> Integer,
+        read_count -> Nullable<Integer>,
+        reply_count -> Nullable<Integer>,
         author_id -> Nullable<Integer>,
         author_name -> Text,
     }

--- a/app/feiwen/src/store/types.rs
+++ b/app/feiwen/src/store/types.rs
@@ -13,8 +13,8 @@ pub(crate) enum Author {
 #[derive(Debug, Clone)]
 pub(crate) struct NovelCount {
     pub(crate) word_count: i32,
-    pub(crate) read_count: i32,
-    pub(crate) reply_count: i32,
+    pub(crate) read_count: Option<i32>,
+    pub(crate) reply_count: Option<i32>,
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]


### PR DESCRIPTION
## Summary

- Fix `feiwen` book-list crawling against the current source markup and request behavior.
- Affected app: `feiwen`.

## Motivation

- Minimal HTTP requests can be rejected by the source site with firewall/login responses.
- The current book-list page only reliably exposes word count, while the old parser required read and reply counts.
- Existing database values for read/reply counts should not be cleared when a new fetch cannot provide those fields.

## Changes

- Add browser-compatible request headers for book-list fetches and remove raw cookies from the tracing span.
- Return explicit parse errors for firewall pages, login pages, and empty book-list responses.
- Add a SQLite migration that makes `novel.read_count` and `novel.reply_count` nullable; rollback restores non-null columns with `COALESCE(..., 0)`.
- Update `NovelCount`, `NovelModel`, and the Diesel schema so read/reply counts are `Option<i32>`.
- Change novel persistence to upsert by `novel.id`; `None` read/reply values preserve existing database values, while new novels can store `NULL`.
- Update count parsing so the current list page only needs word count, while preserving compatibility for the older three-count format and `k/K` suffixes.
- Add parser and persistence unit tests.

## Validation

- [x] `cargo build`
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Manual verification completed for the affected app or flow

Validation details:

```text
cargo fmt
cargo test -p feiwen
  11 passed
cargo clippy -p feiwen --all-targets --all-features -- -D warnings
  passed
cargo build -p feiwen
  passed
cargo run -p feiwen
  app launched and window opened; live fetch now reports an explicit empty-list parse error when the source returns a page without book articles.
```

## Risks

- `read_count` and `reply_count` remain in the database, but new novels can now have `NULL` values for these fields until another source is added.
- Source-site behavior is volatile; blocking/login/empty-list responses are now explicit errors instead of silent empty results.
- UI display for nullable counts is intentionally left unchanged in this PR.

## Related Issues

- Closes #103
