### PR TITLE
[codex] Add feiwen critical path logs

### DIFF
--- a/app/feiwen/src/features/fetch.rs
+++ b/app/feiwen/src/features/fetch.rs
@@ -208,6 +208,16 @@ impl FetchTaskState {
         if clear_logs {
             self.logs.clear();
         }
+        event!(
+            Level::INFO,
+            start_page = self.start_page,
+            end_page = self.end_page,
+            run_start_page,
+            ?last_success_page,
+            total,
+            clear_logs,
+            "fetch run state started"
+        );
         self.status = FetchStatus::Running(FetchProgress {
             start_page: self.start_page,
             end_page: self.end_page,
@@ -218,13 +228,22 @@ impl FetchTaskState {
     }
 
     fn interrupt(&mut self) {
+        event!(Level::INFO, "interrupting fetch run");
         self.task = None;
         if let FetchStatus::Running(progress) = self.status {
+            event!(
+                Level::INFO,
+                current_page = progress.current_page,
+                last_success_page = ?progress.last_success_page,
+                total = progress.total,
+                "fetch run interrupted"
+            );
             self.status = FetchStatus::Interrupted(progress);
         }
     }
 
     fn mark_page_started(&mut self, page: u32) {
+        event!(Level::INFO, page, "fetch page started");
         if let FetchStatus::Running(progress) = &mut self.status {
             progress.current_page = page;
         }
@@ -238,6 +257,14 @@ impl FetchTaskState {
     }
 
     fn mark_page_succeeded(&mut self, page: u32, inserted: usize, total: i64, elapsed_ms: u128) {
+        event!(
+            Level::INFO,
+            page,
+            inserted,
+            total,
+            elapsed_ms,
+            "fetch page succeeded"
+        );
         if let FetchStatus::Running(progress) = &mut self.status {
             progress.current_page = page;
             progress.last_success_page = Some(page);
@@ -253,6 +280,14 @@ impl FetchTaskState {
     }
 
     fn mark_failed(&mut self, error: FetchPageError, elapsed_ms: Option<u128>) {
+        event!(
+            Level::ERROR,
+            page = error.page,
+            kind = %error.kind,
+            message = %error.message,
+            ?elapsed_ms,
+            "fetch run failed"
+        );
         let progress = match &self.status {
             FetchStatus::Running(progress) => *progress,
             FetchStatus::Interrupted(progress) => *progress,
@@ -285,6 +320,14 @@ impl FetchTaskState {
     fn mark_succeeded(&mut self) {
         self.task = None;
         if let FetchStatus::Running(progress) = self.status {
+            event!(
+                Level::INFO,
+                start_page = progress.start_page,
+                end_page = progress.end_page,
+                completed_pages = progress.completed_pages(),
+                total = progress.total,
+                "fetch run succeeded"
+            );
             self.status = FetchStatus::Success(progress);
         }
     }
@@ -332,13 +375,26 @@ struct Runner<'a> {
 
 impl Runner<'_> {
     async fn run(&mut self) {
+        event!(
+            Level::INFO,
+            start_page = self.request.start_page,
+            end_page = self.request.end_page,
+            has_cookie = !self.request.cookie.is_empty(),
+            "fetch runner started"
+        );
         let mut total = match Novel::count(&mut self.conn) {
             Ok(total) => total,
             Err(err) => {
+                event!(
+                    Level::ERROR,
+                    error = %err,
+                    "failed to count novels before fetch run"
+                );
                 self.mark_failed(FetchPageError::new(self.request.start_page, err), None);
                 return;
             }
         };
+        event!(Level::INFO, total, "initial novel count loaded");
 
         let start_page = self.request.start_page;
         self.update_state(|state| state.begin_run(start_page, total, false));
@@ -353,6 +409,13 @@ impl Runner<'_> {
                 {
                     Ok(novels) => novels,
                     Err(err) => {
+                        event!(
+                            Level::ERROR,
+                            page,
+                            error = %err,
+                            elapsed_ms = started_at.elapsed().as_millis(),
+                            "failed to fetch page data"
+                        );
                         self.mark_failed(
                             FetchPageError::new(page, err),
                             Some(started_at.elapsed().as_millis()),
@@ -364,6 +427,13 @@ impl Runner<'_> {
             let inserted = novels.len();
             for novel in novels {
                 if let Err(err) = novel.save(&mut self.conn) {
+                    event!(
+                        Level::ERROR,
+                        page,
+                        error = %err,
+                        elapsed_ms = started_at.elapsed().as_millis(),
+                        "failed to save fetched novel"
+                    );
                     self.mark_failed(
                         FetchPageError::new(page, err),
                         Some(started_at.elapsed().as_millis()),
@@ -375,6 +445,13 @@ impl Runner<'_> {
             match Novel::count(&mut self.conn) {
                 Ok(next_total) => total = next_total,
                 Err(err) => {
+                    event!(
+                        Level::ERROR,
+                        page,
+                        error = %err,
+                        elapsed_ms = started_at.elapsed().as_millis(),
+                        "failed to count novels after page fetch"
+                    );
                     self.mark_failed(
                         FetchPageError::new(page, err),
                         Some(started_at.elapsed().as_millis()),
@@ -387,6 +464,13 @@ impl Runner<'_> {
             });
         }
 
+        event!(
+            Level::INFO,
+            start_page = self.request.start_page,
+            end_page = self.request.end_page,
+            total,
+            "fetch runner completed"
+        );
         self.update_state(FetchTaskState::mark_succeeded);
     }
 
@@ -620,9 +704,16 @@ impl FetchView {
     }
 
     fn start_fetch_from(&mut self, mode: RunMode, cx: &mut Context<Self>) {
+        event!(Level::INFO, mode = mode.label(), "starting fetch request");
         let conn = match cx.global::<Db>().get() {
             Ok(conn) => conn,
             Err(err) => {
+                event!(
+                    Level::ERROR,
+                    mode = mode.label(),
+                    error = %err,
+                    "failed to get database pool for fetch"
+                );
                 self.task_state.update(cx, |state, cx| {
                     state.mark_failed(
                         FetchPageError {
@@ -641,12 +732,23 @@ impl FetchView {
         let (request, clear_logs) = {
             let state = self.task_state.read(cx);
             if state.is_running() {
+                event!(
+                    Level::INFO,
+                    mode = mode.label(),
+                    "ignored fetch request while running"
+                );
                 return;
             }
             let start_page = match mode {
                 RunMode::Fresh => {
                     if state.start_page > state.end_page {
                         let message = cx.global::<I18n>().t("fetch-error-invalid-page-range");
+                        event!(
+                            Level::ERROR,
+                            start_page = state.start_page,
+                            end_page = state.end_page,
+                            "invalid fetch page range"
+                        );
                         self.task_state.update(cx, |state, cx| {
                             state.mark_failed(
                                 FetchPageError {
@@ -669,7 +771,14 @@ impl FetchView {
                         state.end_page,
                     ) {
                         Some(page) => page,
-                        None => return,
+                        None => {
+                            event!(
+                                Level::INFO,
+                                mode = mode.label(),
+                                "no interrupted fetch page to resume"
+                            );
+                            return;
+                        }
                     }
                 }
                 RunMode::RetryFailed => {
@@ -679,7 +788,14 @@ impl FetchView {
                         state.end_page,
                     ) {
                         Some(page) => page,
-                        None => return,
+                        None => {
+                            event!(
+                                Level::INFO,
+                                mode = mode.label(),
+                                "no failed fetch page to retry"
+                            );
+                            return;
+                        }
                     }
                 }
             };
@@ -688,6 +804,15 @@ impl FetchView {
                 matches!(mode, RunMode::Fresh),
             )
         };
+        event!(
+            Level::INFO,
+            mode = mode.label(),
+            start_page = request.start_page,
+            end_page = request.end_page,
+            has_cookie = !request.cookie.is_empty(),
+            clear_logs,
+            "fetch task scheduled"
+        );
 
         let task_state = self.task_state.downgrade();
         self.task_state.update(cx, |state, cx| {
@@ -724,6 +849,16 @@ enum RunMode {
     Fresh,
     ResumeInterrupted,
     RetryFailed,
+}
+
+impl RunMode {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Fresh => "fresh",
+            Self::ResumeInterrupted => "resume_interrupted",
+            Self::RetryFailed => "retry_failed",
+        }
+    }
 }
 
 impl Render for FetchView {

--- a/app/feiwen/src/features/query.rs
+++ b/app/feiwen/src/features/query.rs
@@ -22,6 +22,7 @@ use gpui_component::{
     v_flex,
 };
 use results_table::ResultsTableDelegate;
+use tracing::{Level, event};
 
 mod advanced;
 mod results_table;
@@ -288,12 +289,14 @@ impl Render for QueryView {
 impl QueryView {
     fn start_search(&mut self, cx: &mut Context<Self>) {
         if self.search.is_searching() {
+            event!(Level::INFO, "ignored query request while search is running");
             return;
         }
 
         let spec = match self.advanced.query_spec(cx) {
             Ok(spec) => spec,
             Err(err) => {
+                event!(Level::ERROR, error = %err, "query validation failed");
                 self.set_results_table(Vec::new(), false, cx);
                 self.search = SearchState::Error(QueryError::Validation(err));
                 cx.notify();
@@ -301,6 +304,7 @@ impl QueryView {
             }
         };
 
+        event!(Level::INFO, "starting feiwen query");
         let pool = cx.global::<Db>().pool();
         let this = cx.entity().downgrade();
 
@@ -310,9 +314,15 @@ impl QueryView {
         let task = cx.spawn(async move |_, cx| {
             let result = cx
                 .background_spawn(async move {
+                    event!(Level::INFO, "running feiwen query in background");
                     let mut conn = pool.get()?;
                     let options = QueryOptions::load(&mut conn)?;
                     let novels = Novel::query(&spec, &mut conn)?;
+                    event!(
+                        Level::INFO,
+                        result_count = novels.len(),
+                        "feiwen query completed in background"
+                    );
                     Ok(SearchResult { options, novels })
                 })
                 .await;
@@ -327,11 +337,13 @@ impl QueryView {
         match result {
             Ok(result) => {
                 let count = result.novels.len();
+                event!(Level::INFO, result_count = count, "feiwen query succeeded");
                 self.advanced.set_options(result.options, cx);
                 self.set_results_table(result.novels, false, cx);
                 self.search = SearchState::Data { count };
             }
             Err(err) => {
+                event!(Level::ERROR, error = %err, "feiwen query failed");
                 self.set_results_table(Vec::new(), false, cx);
                 self.search = SearchState::Error(QueryError::Runtime(err));
             }

--- a/app/feiwen/src/features/workspace.rs
+++ b/app/feiwen/src/features/workspace.rs
@@ -1,4 +1,5 @@
 use gpui::*;
+use tracing::{Level, event};
 
 use super::{
     fetch::{FetchTaskState, FetchView},
@@ -34,10 +35,11 @@ pub(crate) struct WorkspaceView {
 
 impl WorkspaceView {
     pub(crate) fn new(window: &mut Window, workspace_cx: &mut Context<Self>) -> Self {
+        event!(Level::INFO, "creating feiwen workspace");
         let workspace = workspace_cx.new(|_cx| Default::default());
         let fetch_task = workspace_cx.new(|_cx| FetchTaskState::default());
         let _subscriptions = vec![workspace_cx.subscribe(&workspace, Self::subscribe)];
-        Self {
+        let this = Self {
             focus_handle: workspace_cx.focus_handle(),
             fetch_view: workspace_cx
                 .new(|cx| FetchView::new(window, workspace.clone(), fetch_task.clone(), cx)),
@@ -46,7 +48,9 @@ impl WorkspaceView {
             _fetch_task: fetch_task,
             workspace,
             _subscriptions,
-        }
+        };
+        event!(Level::INFO, "feiwen workspace created");
+        this
     }
     fn child_view(&self, cx: &mut Context<Self>) -> impl gpui::IntoElement {
         match self.workspace.read(cx).router {
@@ -63,9 +67,24 @@ impl WorkspaceView {
         match emitter {
             WorkspaceEvent::UpdateRouter(router) => {
                 subscriber.update(cx, |data, _| {
+                    event!(
+                        Level::INFO,
+                        from = %data.router.label(),
+                        to = %router.label(),
+                        "switching feiwen route"
+                    );
                     data.router = *router;
                 });
             }
+        }
+    }
+}
+
+impl RouterType {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Fetch => "fetch",
+            Self::Query => "query",
         }
     }
 }

--- a/app/feiwen/src/fetch.rs
+++ b/app/feiwen/src/fetch.rs
@@ -6,6 +6,7 @@ use crate::{
     errors::{FeiwenError, FeiwenResult},
     store::service::Novel,
 };
+use tracing::{Level, event};
 
 use self::parse_novel::parse_page;
 
@@ -83,8 +84,21 @@ pub(crate) async fn fetch_page(
     cookies: &str,
     client: &Client,
 ) -> FeiwenResult<Vec<Novel>> {
+    event!(
+        Level::INFO,
+        page,
+        has_cookie = !cookies.is_empty(),
+        "fetching feiwen page"
+    );
     let body = get_content::get_content(url, page, cookies, client).await?;
+    event!(
+        Level::INFO,
+        page,
+        body_len = body.len(),
+        "feiwen page response received"
+    );
     let data = parse_page(body)?;
+    event!(Level::INFO, page, count = data.len(), "feiwen page parsed");
     Ok(data)
 }
 

--- a/app/feiwen/src/fetch/get_content.rs
+++ b/app/feiwen/src/fetch/get_content.rs
@@ -4,6 +4,7 @@ use reqwest::{
 };
 
 use crate::errors::FeiwenResult;
+use tracing::{Level, event};
 
 pub(crate) async fn get_content(
     url: &str,
@@ -11,7 +12,13 @@ pub(crate) async fn get_content(
     cookies: &str,
     client: &Client,
 ) -> FeiwenResult<String> {
-    let body = client
+    event!(
+        Level::INFO,
+        page,
+        has_cookie = !cookies.is_empty(),
+        "sending feiwen page request"
+    );
+    let response = client
         .get(url)
         .header(COOKIE, cookies)
         .header(
@@ -36,8 +43,20 @@ pub(crate) async fn get_content(
         )
         .query(&[("page", page)])
         .send()
-        .await?
-        .text()
         .await?;
+    let status = response.status();
+    event!(
+        Level::INFO,
+        page,
+        status = %status,
+        "feiwen page request completed"
+    );
+    let body = response.text().await?;
+    event!(
+        Level::INFO,
+        page,
+        body_len = body.len(),
+        "feiwen page body read"
+    );
     Ok(body)
 }

--- a/app/feiwen/src/main.rs
+++ b/app/feiwen/src/main.rs
@@ -25,6 +25,7 @@ fn quit(_: &Quit, cx: &mut App) {
 }
 
 fn init(cx: &mut App) {
+    event!(Level::INFO, "initializing feiwen app");
     gpui_component::init(cx);
     cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
     cx.activate(true);
@@ -32,6 +33,7 @@ fn init(cx: &mut App) {
 
     foundation::i18n::init_i18n(cx);
     store::init_store(cx);
+    event!(Level::INFO, "feiwen app initialized");
 }
 
 fn get_logs_dir() -> FeiwenResult<PathBuf> {
@@ -48,12 +50,16 @@ fn get_logs_dir() -> FeiwenResult<PathBuf> {
     if let Ok(path) = &path
         && !path.exists()
     {
+        event!(Level::INFO, path = %path.display(), "creating log directory");
         create_dir_all(path).map_err(|_| FeiwenError::LogFileNotFound)?;
     }
     path
 }
 
 fn main() -> FeiwenResult<()> {
+    let logs_dir = get_logs_dir()?;
+    let log_file = logs_dir.join("data.log");
+
     // tracing
     tracing_subscriber::registry()
         .with(
@@ -63,7 +69,7 @@ fn main() -> FeiwenResult<()> {
                     std::fs::OpenOptions::new()
                         .append(true)
                         .create(true)
-                        .open(get_logs_dir()?.join("data.log"))
+                        .open(&log_file)
                         .map_err(|_| FeiwenError::LogFileNotFound)?,
                 )
                 .with_filter(LevelFilter::INFO),
@@ -76,6 +82,13 @@ fn main() -> FeiwenResult<()> {
         )
         .init();
 
+    event!(
+        Level::INFO,
+        logs_dir = %logs_dir.display(),
+        log_file = %log_file.display(),
+        "tracing initialized"
+    );
+
     let span = tracing::info_span!("init");
     let _enter = span.enter();
     let app = gpui_platform::application().with_assets(foundation::Assets::default());
@@ -84,7 +97,8 @@ fn main() -> FeiwenResult<()> {
     app.run(|cx: &mut App| {
         init(cx);
         let title = cx.global::<I18n>().t("app-title");
-        if let Err(err) = cx.open_window(
+        event!(Level::INFO, title = %title, "opening main window");
+        match cx.open_window(
             WindowOptions {
                 titlebar: Some(TitlebarOptions {
                     title: Some(title.into()),
@@ -98,9 +112,9 @@ fn main() -> FeiwenResult<()> {
                 cx.new(|cx| Root::new(view, window, cx))
             },
         ) {
-            event!(Level::ERROR, "{}", err)
-        };
-        event!(Level::INFO, "window opened");
+            Ok(_) => event!(Level::INFO, "main window opened"),
+            Err(err) => event!(Level::ERROR, error = %err, "failed to open main window"),
+        }
     });
     Ok(())
 }

--- a/app/feiwen/src/store.rs
+++ b/app/feiwen/src/store.rs
@@ -41,26 +41,36 @@ impl Db {
 }
 
 pub(crate) fn init_store(cx: &mut App) {
+    event!(Level::INFO, "initializing feiwen store");
     let conn = match establish_connection() {
         Ok(conn) => conn,
         Err(err) => {
-            event!(Level::ERROR, "init_store failed: {}", err);
+            event!(Level::ERROR, error = %err, "failed to initialize feiwen store");
             return;
         }
     };
     cx.set_global(Db(conn));
+    event!(Level::INFO, "feiwen store global registered");
 }
 
 fn establish_connection() -> FeiwenResult<DbConn> {
     let url_path = get_data_url()?;
+    event!(Level::INFO, db_path = %url_path.display(), "opening feiwen database");
     let not_exists = check_data_file(&url_path)?;
     let url = url_path.to_str().ok_or(FeiwenError::DbPath)?;
     let manager = ConnectionManager::<SqliteConnection>::new(url);
     let pool = Pool::builder().test_on_check_out(true).build(manager)?;
+    event!(
+        Level::INFO,
+        db_path = %url_path.display(),
+        created = not_exists,
+        "database connection pool created"
+    );
     if not_exists {
         create_tables(&pool)?;
     }
     migrate_tables(&pool)?;
+    event!(Level::INFO, db_path = %url_path.display(), "database ready");
     Ok(pool)
 }
 
@@ -75,6 +85,7 @@ fn get_data_url() -> FeiwenResult<PathBuf> {
 fn check_data_file(url: &PathBuf) -> FeiwenResult<bool> {
     use std::fs::File;
     if !url.exists() {
+        event!(Level::INFO, db_path = %url.display(), "creating database file");
         std::fs::create_dir_all(url.parent().ok_or(FeiwenError::DbPath)?)?;
         File::create(url)?;
         return Ok(true);
@@ -82,21 +93,31 @@ fn check_data_file(url: &PathBuf) -> FeiwenResult<bool> {
     Ok(false)
 }
 fn create_tables(conn: &DbConn) -> FeiwenResult<()> {
+    event!(Level::INFO, "creating initial database tables");
     let conn = &mut conn.get()?;
     conn.batch_execute(include_str!("../migrations/2022-05-15-162950_novel/up.sql"))?;
     conn.batch_execute(include_str!("../migrations/2022-05-15-163112_tag/up.sql"))?;
     conn.batch_execute(include_str!(
         "../migrations/2022-05-16-064913_novel_tag/up.sql"
     ))?;
+    event!(Level::INFO, "initial database tables created");
     Ok(())
 }
 
 fn migrate_tables(conn: &DbConn) -> FeiwenResult<()> {
     let conn = &mut conn.get()?;
-    if novel_counts_are_not_null(conn)? {
+    let needs_nullable_counts_migration = novel_counts_are_not_null(conn)?;
+    event!(
+        Level::INFO,
+        needs_nullable_counts_migration,
+        "checked database migrations"
+    );
+    if needs_nullable_counts_migration {
+        event!(Level::INFO, "running nullable novel counts migration");
         conn.batch_execute(include_str!(
             "../migrations/2026-05-06-000001_nullable_novel_counts/up.sql"
         ))?;
+        event!(Level::INFO, "nullable novel counts migration completed");
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Add structured tracing logs across the `feiwen` app critical paths.
- Affected app: `feiwen`.

## Motivation

- The app already initialized tracing, but startup, database setup, fetch tasks, query tasks, and route changes were only partially observable from logs.
- This makes critical failures easier to diagnose from `~/Library/Logs/top.sushao.feiwen/data.log` without relying only on UI state.

## Changes

- Log startup, log path setup, app initialization, and main window creation.
- Log database path discovery, data file creation, connection pool creation, table setup, migration checks, migration execution, and store global registration.
- Log workspace creation and Fetch/Query route changes.
- Log fetch run start/resume/retry/interrupt, invalid ranges, database access failures, task lifecycle, page-level success/failure, inserted counts, totals, and elapsed time.
- Log HTTP request/response/parse boundaries while only recording `has_cookie`, never raw cookie values.
- Log query start, validation failures, background query success/failure, and result counts.

## Validation

- [ ] `cargo build`
- [x] `cargo test`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
cargo fmt
cargo test -p feiwen
  58 passed; 0 failed
cargo check -p feiwen
  finished successfully
git diff --check
  no whitespace errors
```

## Risks

- Logging volume increases during fetch runs because each page now has request, response, parse, and persistence lifecycle events.
- Sensitive cookies are intentionally excluded from logs; only `has_cookie` is recorded.

## Related Issues

- Closes #109
