### PR TITLE
ai-chat: split tree-sitter features and refine Material You theme

### DIFF
--- a/app/ai-chat/Cargo.toml
+++ b/app/ai-chat/Cargo.toml
@@ -24,7 +24,29 @@ streaming responses, and web search support.
 category = "DeveloperTool"
 
 [features]
+default = ["tree-sitter-languages-basic"]
 dhat-heap = ["dep:dhat"]
+tree-sitter-languages-basic = [
+  "gpui-component/tree-sitter-bash",
+  "gpui-component/tree-sitter-c",
+  "gpui-component/tree-sitter-css",
+  "gpui-component/tree-sitter-diff",
+  "gpui-component/tree-sitter-go",
+  "gpui-component/tree-sitter-graphql",
+  "gpui-component/tree-sitter-html",
+  "gpui-component/tree-sitter-java",
+  "gpui-component/tree-sitter-javascript",
+  "gpui-component/tree-sitter-markdown",
+  "gpui-component/tree-sitter-python",
+  "gpui-component/tree-sitter-rust",
+  "gpui-component/tree-sitter-sql",
+  "gpui-component/tree-sitter-svelte",
+  "gpui-component/tree-sitter-toml",
+  "gpui-component/tree-sitter-tsx",
+  "gpui-component/tree-sitter-typescript",
+  "gpui-component/tree-sitter-yaml",
+]
+tree-sitter-languages-full = ["gpui-component/tree-sitter-languages"]
 
 [dependencies]
 dhat = { version = "0.3.3", optional = true }

--- a/crates/app-theme/src/lib.rs
+++ b/crates/app-theme/src/lib.rs
@@ -33,8 +33,18 @@ const INFO_SEED_COLOR: Argb = Argb::from_rgb(0x0E, 0xA5, 0xE9);
 const SUCCESS_SEED_COLOR: Argb = Argb::from_rgb(0x22, 0xC5, 0x5E);
 const WARNING_SEED_COLOR: Argb = Argb::from_rgb(0xF5, 0x9E, 0x0B);
 const CHART_EXTRA_SEED_COLOR: Argb = Argb::from_rgb(0xA8, 0x55, 0xF7);
-const SYNTAX_KEYWORD_SEED_COLOR: Argb = Argb::from_rgb(0xA8, 0x55, 0xF7);
-const SYNTAX_FUNCTION_SEED_COLOR: Argb = Argb::from_rgb(0xF9, 0x73, 0x16);
+const SYNTAX_KEYWORD_SEED_COLOR: Argb = Argb::from_rgb(0xD9, 0x46, 0xEF);
+const SYNTAX_FUNCTION_SEED_COLOR: Argb = Argb::from_rgb(0x63, 0x66, 0xF1);
+const SYNTAX_TYPE_SEED_COLOR: Argb = Argb::from_rgb(0xEA, 0xB3, 0x08);
+const SYNTAX_PROPERTY_SEED_COLOR: Argb = Argb::from_rgb(0x06, 0xB6, 0xD4);
+const SYNTAX_PROPERTY_CHROMA: f64 = 54.0;
+const SYNTAX_ATTRIBUTE_SEED_COLOR: Argb = Argb::from_rgb(0xF4, 0x3F, 0x5E);
+const SYNTAX_ATTRIBUTE_CHROMA: f64 = 36.0;
+const SYNTAX_TAG_SEED_COLOR: Argb = Argb::from_rgb(0xEC, 0x48, 0x99);
+const SYNTAX_TAG_CHROMA: f64 = 84.0;
+const SYNTAX_STRING_SEED_COLOR: Argb = SUCCESS_SEED_COLOR;
+const SYNTAX_CONSTANT_SEED_COLOR: Argb = Argb::from_rgb(0xF9, 0x73, 0x16);
+const SYNTAX_CONSTANT_CHROMA: f64 = 78.0;
 const MATERIAL_SOFT_DIVIDER_ALPHA: u8 = 0x1F;
 const MATERIAL_HOVER_STATE_LAYER_ALPHA: u8 = 0x14;
 const MATERIAL_PRESSED_STATE_LAYER_ALPHA: u8 = 0x1A;
@@ -609,24 +619,12 @@ fn material_status_tokens(
     scheme: &MaterializedScheme,
     palette: &MaterialPalette,
 ) -> MaterialStatusTokens {
-    let primary_roles = material_error_roles_for_palette(scheme, scheme.primary_palette.clone());
-    let danger_roles = material_error_roles_for_palette(scheme, scheme.error_palette.clone());
-    let info_roles = material_error_roles_for_palette(
-        scheme,
-        semantic_palette(scheme.source_color, INFO_SEED_COLOR, SEMANTIC_CHROMA),
-    );
-    let success_roles = material_error_roles_for_palette(
-        scheme,
-        semantic_palette(scheme.source_color, SUCCESS_SEED_COLOR, SEMANTIC_CHROMA),
-    );
-    let warning_roles = material_error_roles_for_palette(
-        scheme,
-        semantic_palette(scheme.source_color, WARNING_SEED_COLOR, SEMANTIC_CHROMA),
-    );
-    let chart_extra_roles = material_error_roles_for_palette(
-        scheme,
-        semantic_palette(scheme.source_color, CHART_EXTRA_SEED_COLOR, SEMANTIC_CHROMA),
-    );
+    let primary_roles = material_semantic_roles_for_palette(scheme, scheme.primary_palette.clone());
+    let danger_roles = material_semantic_roles_for_palette(scheme, scheme.error_palette.clone());
+    let info_roles = material_semantic_roles_for_seed(scheme, INFO_SEED_COLOR);
+    let success_roles = material_semantic_roles_for_seed(scheme, SUCCESS_SEED_COLOR);
+    let warning_roles = material_semantic_roles_for_seed(scheme, WARNING_SEED_COLOR);
+    let chart_extra_roles = material_semantic_roles_for_seed(scheme, CHART_EXTRA_SEED_COLOR);
 
     MaterialStatusTokens {
         chart_1: hex(primary_roles.color),
@@ -776,34 +774,34 @@ impl From<MaterialThemeColors> for ThemeConfigColors {
 }
 
 fn apply_material_highlight_tokens(scheme: &MaterializedScheme) -> HighlightThemeStyle {
-    let danger_roles = material_error_roles_for_palette(scheme, scheme.error_palette.clone());
-    let info_roles = material_error_roles_for_palette(
+    let danger_roles = material_semantic_roles_for_palette(scheme, scheme.error_palette.clone());
+    let info_roles = material_semantic_roles_for_seed(scheme, INFO_SEED_COLOR);
+    let success_roles = material_semantic_roles_for_seed(scheme, SUCCESS_SEED_COLOR);
+    let warning_roles = material_semantic_roles_for_seed(scheme, WARNING_SEED_COLOR);
+    let syntax_keyword_roles = material_semantic_roles_for_seed(scheme, SYNTAX_KEYWORD_SEED_COLOR);
+    let syntax_function_roles =
+        material_semantic_roles_for_seed(scheme, SYNTAX_FUNCTION_SEED_COLOR);
+    let syntax_type_roles = material_semantic_roles_for_seed(scheme, SYNTAX_TYPE_SEED_COLOR);
+    let syntax_property_roles = material_semantic_roles_for_seed_and_chroma(
         scheme,
-        semantic_palette(scheme.source_color, INFO_SEED_COLOR, SEMANTIC_CHROMA),
+        SYNTAX_PROPERTY_SEED_COLOR,
+        SYNTAX_PROPERTY_CHROMA,
     );
-    let success_roles = material_error_roles_for_palette(
+    let syntax_attribute_roles = material_semantic_roles_for_seed_and_chroma(
         scheme,
-        semantic_palette(scheme.source_color, SUCCESS_SEED_COLOR, SEMANTIC_CHROMA),
+        SYNTAX_ATTRIBUTE_SEED_COLOR,
+        SYNTAX_ATTRIBUTE_CHROMA,
     );
-    let warning_roles = material_error_roles_for_palette(
+    let syntax_tag_roles = material_semantic_roles_for_seed_and_chroma(
         scheme,
-        semantic_palette(scheme.source_color, WARNING_SEED_COLOR, SEMANTIC_CHROMA),
+        SYNTAX_TAG_SEED_COLOR,
+        SYNTAX_TAG_CHROMA,
     );
-    let keyword_roles = material_error_roles_for_palette(
+    let syntax_string_roles = material_semantic_roles_for_seed(scheme, SYNTAX_STRING_SEED_COLOR);
+    let syntax_constant_roles = material_semantic_roles_for_seed_and_chroma(
         scheme,
-        semantic_palette(
-            scheme.source_color,
-            SYNTAX_KEYWORD_SEED_COLOR,
-            SEMANTIC_CHROMA,
-        ),
-    );
-    let function_roles = material_error_roles_for_palette(
-        scheme,
-        semantic_palette(
-            scheme.source_color,
-            SYNTAX_FUNCTION_SEED_COLOR,
-            SEMANTIC_CHROMA,
-        ),
+        SYNTAX_CONSTANT_SEED_COLOR,
+        SYNTAX_CONSTANT_CHROMA,
     );
 
     let editor_background = hex(scheme.surface_container_lowest);
@@ -862,43 +860,43 @@ fn apply_material_highlight_tokens(scheme: &MaterializedScheme) -> HighlightThem
         )),
     );
     root.insert("success.border".into(), json!(hex(success_roles.color)));
-    root.insert("hint".into(), json!(hex(keyword_roles.color)));
+    root.insert("hint".into(), json!(hex(syntax_keyword_roles.color)));
     root.insert(
         "hint.background".into(),
         json!(hex_alpha(
-            keyword_roles.color,
+            syntax_keyword_roles.color,
             MATERIAL_PRESSED_STATE_LAYER_ALPHA
         )),
     );
-    root.insert("hint.border".into(), json!(hex(keyword_roles.color)));
+    root.insert("hint.border".into(), json!(hex(syntax_keyword_roles.color)));
 
     let mut syntax = Map::new();
-    insert_syntax_color(&mut syntax, "attribute", hex(info_roles.color));
-    insert_syntax_color(&mut syntax, "boolean", hex(warning_roles.color));
+    insert_syntax_color(&mut syntax, "attribute", hex(syntax_attribute_roles.color));
+    insert_syntax_color(&mut syntax, "boolean", hex(syntax_constant_roles.color));
     insert_syntax_color(&mut syntax, "comment", hex(scheme.on_surface_variant));
     insert_syntax_color(&mut syntax, "comment.doc", hex(scheme.on_surface_variant));
-    insert_syntax_color(&mut syntax, "constant", hex(warning_roles.color));
-    insert_syntax_color(&mut syntax, "constructor", hex(info_roles.color));
+    insert_syntax_color(&mut syntax, "constant", hex(syntax_constant_roles.color));
+    insert_syntax_color(&mut syntax, "constructor", hex(syntax_type_roles.color));
     insert_syntax_color(&mut syntax, "embedded", editor_foreground.clone());
-    insert_syntax_color(&mut syntax, "function", hex(function_roles.color));
-    insert_syntax_color(&mut syntax, "keyword", hex(keyword_roles.color));
+    insert_syntax_color(&mut syntax, "function", hex(syntax_function_roles.color));
+    insert_syntax_color(&mut syntax, "keyword", hex(syntax_keyword_roles.color));
     insert_syntax_text_style(
         &mut syntax,
         "link_text",
-        hex(info_roles.color),
+        hex(syntax_attribute_roles.color),
         Some("normal"),
         None,
     );
     insert_syntax_text_style(
         &mut syntax,
         "link_uri",
-        hex(info_roles.color),
+        hex(syntax_attribute_roles.color),
         Some("italic"),
         None,
     );
-    insert_syntax_color(&mut syntax, "number", hex(warning_roles.color));
+    insert_syntax_color(&mut syntax, "number", hex(syntax_constant_roles.color));
     insert_syntax_color(&mut syntax, "operator", hex(scheme.on_surface_variant));
-    insert_syntax_color(&mut syntax, "property", editor_foreground.clone());
+    insert_syntax_color(&mut syntax, "property", hex(syntax_property_roles.color));
     insert_syntax_color(&mut syntax, "punctuation", hex(scheme.on_surface_variant));
     insert_syntax_color(
         &mut syntax,
@@ -915,29 +913,45 @@ fn apply_material_highlight_tokens(scheme: &MaterializedScheme) -> HighlightThem
         "punctuation.list_marker",
         hex(scheme.on_surface_variant),
     );
-    insert_syntax_color(&mut syntax, "punctuation.special", hex(warning_roles.color));
-    insert_syntax_color(&mut syntax, "string", hex(success_roles.color));
-    insert_syntax_color(&mut syntax, "string.escape", hex(success_roles.color));
-    insert_syntax_color(&mut syntax, "string.regex", hex(success_roles.color));
-    insert_syntax_color(&mut syntax, "string.special", hex(warning_roles.color));
+    insert_syntax_color(
+        &mut syntax,
+        "punctuation.special",
+        hex(syntax_constant_roles.color),
+    );
+    insert_syntax_color(&mut syntax, "string", hex(syntax_string_roles.color));
+    insert_syntax_color(&mut syntax, "string.escape", hex(syntax_string_roles.color));
+    insert_syntax_color(&mut syntax, "string.regex", hex(syntax_string_roles.color));
+    insert_syntax_color(
+        &mut syntax,
+        "string.special",
+        hex(syntax_constant_roles.color),
+    );
     insert_syntax_color(
         &mut syntax,
         "string.special.symbol",
-        hex(warning_roles.color),
+        hex(syntax_constant_roles.color),
     );
-    insert_syntax_color(&mut syntax, "tag", hex(info_roles.color));
-    insert_syntax_color(&mut syntax, "text.literal", hex(warning_roles.color));
+    insert_syntax_color(&mut syntax, "tag", hex(syntax_tag_roles.color));
+    insert_syntax_color(
+        &mut syntax,
+        "text.literal",
+        hex(syntax_constant_roles.color),
+    );
     insert_syntax_text_style(
         &mut syntax,
         "title",
-        hex(function_roles.color),
+        hex(syntax_function_roles.color),
         None,
         Some(600),
     );
-    insert_syntax_color(&mut syntax, "type", hex(info_roles.color));
+    insert_syntax_color(&mut syntax, "type", hex(syntax_type_roles.color));
     insert_syntax_color(&mut syntax, "variable", editor_foreground);
-    insert_syntax_color(&mut syntax, "variable.special", hex(function_roles.color));
-    insert_syntax_color(&mut syntax, "variant", hex(info_roles.color));
+    insert_syntax_color(
+        &mut syntax,
+        "variable.special",
+        hex(syntax_function_roles.color),
+    );
+    insert_syntax_color(&mut syntax, "variant", hex(syntax_type_roles.color));
     root.insert("syntax".into(), Value::Object(syntax));
 
     serde_json::from_value(Value::Object(root))
@@ -1051,10 +1065,31 @@ struct MaterialSemanticRoles {
     on_container: Argb,
 }
 
-fn material_error_roles_for_palette(
+fn material_semantic_roles_for_seed(
     scheme: &MaterializedScheme,
-    error_palette: TonalPalette,
+    design_color: Argb,
 ) -> MaterialSemanticRoles {
+    material_semantic_roles_for_seed_and_chroma(scheme, design_color, SEMANTIC_CHROMA)
+}
+
+fn material_semantic_roles_for_seed_and_chroma(
+    scheme: &MaterializedScheme,
+    design_color: Argb,
+    chroma: f64,
+) -> MaterialSemanticRoles {
+    material_semantic_roles_for_palette(
+        scheme,
+        semantic_palette(scheme.source_color, design_color, chroma),
+    )
+}
+
+fn material_semantic_roles_for_palette(
+    scheme: &MaterializedScheme,
+    semantic_palette: TonalPalette,
+) -> MaterialSemanticRoles {
+    // material-color-utils exposes dynamic role contrast through MaterialDynamicColors.
+    // Replacing the DynamicScheme error palette lets app-specific semantic palettes
+    // reuse Material's error/on-error tone rules for status, chart, and syntax roles.
     let dynamic_scheme = DynamicScheme::new_with_platform_and_spec(
         Hct::from_argb(scheme.source_color),
         scheme.variant,
@@ -1067,7 +1102,7 @@ fn material_error_roles_for_palette(
         scheme.tertiary_palette.clone(),
         scheme.neutral_palette.clone(),
         scheme.neutral_variant_palette.clone(),
-        error_palette,
+        semantic_palette,
     );
     let dynamic_colors = MaterialDynamicColors::new_with_spec(scheme.spec_version);
     let color = dynamic_colors.error();

--- a/crates/app-theme/src/lib.rs
+++ b/crates/app-theme/src/lib.rs
@@ -53,6 +53,8 @@ pub struct SystemAccentThemeState {
     _task: Option<Task<()>>,
     #[cfg_attr(not(feature = "system-accent"), allow(dead_code))]
     color: Option<String>,
+    #[cfg_attr(not(feature = "system-accent"), allow(dead_code))]
+    text_highlight_color: Option<String>,
 }
 
 impl Global for SystemAccentThemeState {}
@@ -101,6 +103,18 @@ pub fn system_accent_color() -> Option<String> {
     #[cfg(feature = "system-accent")]
     {
         platform_ext::appearance::system_accent_color().map(|color| color.to_hex())
+    }
+
+    #[cfg(not(feature = "system-accent"))]
+    {
+        None
+    }
+}
+
+pub fn system_text_highlight_color() -> Option<String> {
+    #[cfg(feature = "system-accent")]
+    {
+        platform_ext::appearance::system_text_highlight_color().map(|color| color.to_hex())
     }
 
     #[cfg(not(feature = "system-accent"))]
@@ -194,17 +208,27 @@ pub fn init_system_accent_theme(cx: &mut App) {
             let _ = tx.try_send(());
         });
         let color = system_accent_color();
+        let text_highlight_color = system_text_highlight_color();
         let task = observer.as_ref().map(|_| {
             cx.spawn(async move |cx| {
                 while rx.recv().await.is_ok() {
                     let next_color = system_accent_color();
+                    let next_text_highlight_color = system_text_highlight_color();
                     cx.update(|cx| {
-                        if system_accent_color_changed(
-                            &cx.global::<SystemAccentThemeState>().color,
-                            &next_color,
-                        ) {
+                        let should_update = {
+                            let state = cx.global::<SystemAccentThemeState>();
+                            system_accent_theme_colors_changed(
+                                &state.color,
+                                &state.text_highlight_color,
+                                &next_color,
+                                &next_text_highlight_color,
+                            )
+                        };
+
+                        if should_update {
                             cx.update_global::<SystemAccentThemeState, _>(|state, _cx| {
                                 state.color = next_color;
+                                state.text_highlight_color = next_text_highlight_color;
                             });
                         }
                     });
@@ -216,6 +240,7 @@ pub fn init_system_accent_theme(cx: &mut App) {
             _observer: observer,
             _task: task,
             color,
+            text_highlight_color,
         });
     }
 
@@ -223,11 +248,22 @@ pub fn init_system_accent_theme(cx: &mut App) {
     cx.set_global(SystemAccentThemeState {
         _task: None,
         color: None,
+        text_highlight_color: None,
     });
 }
 
 pub fn system_accent_color_changed(current: &Option<String>, next: &Option<String>) -> bool {
     current != next
+}
+
+fn system_accent_theme_colors_changed(
+    current_accent: &Option<String>,
+    current_text_highlight: &Option<String>,
+    next_accent: &Option<String>,
+    next_text_highlight: &Option<String>,
+) -> bool {
+    system_accent_color_changed(current_accent, next_accent)
+        || current_text_highlight != next_text_highlight
 }
 
 pub fn generated_theme_choice(color: &str, mode: ComponentThemeMode) -> Option<ThemeChoice> {
@@ -252,11 +288,21 @@ pub fn system_accent_theme_choice(mode: ComponentThemeMode) -> Option<ThemeChoic
 pub fn system_accent_theme_config(mode: ComponentThemeMode) -> Option<ThemeConfig> {
     let color = system_accent_color()?;
     let mut config = generated_theme_config(&color, mode)?;
+    apply_system_text_highlight_selection(&mut config, system_text_highlight_color());
     config.name = SharedString::from(format!(
         "System Accent Material You {}",
         if mode.is_dark() { "Dark" } else { "Light" }
     ));
     Some(config)
+}
+
+fn apply_system_text_highlight_selection(
+    config: &mut ThemeConfig,
+    text_highlight_color: Option<String>,
+) {
+    if let Some(color) = text_highlight_color {
+        config.colors.selection = Some(color.into());
+    }
 }
 
 pub fn component_theme_mode_from_appearance(appearance: WindowAppearance) -> ComponentThemeMode {

--- a/crates/app-theme/src/tests.rs
+++ b/crates/app-theme/src/tests.rs
@@ -122,6 +122,28 @@ fn system_accent_color_changed_only_updates_on_real_changes() {
 }
 
 #[test]
+fn system_accent_theme_colors_changed_tracks_text_highlight() {
+    assert!(!system_accent_theme_colors_changed(
+        &Some("#123456".to_string()),
+        &Some("#ABCDEF".to_string()),
+        &Some("#123456".to_string()),
+        &Some("#ABCDEF".to_string()),
+    ));
+    assert!(system_accent_theme_colors_changed(
+        &Some("#123456".to_string()),
+        &Some("#ABCDEF".to_string()),
+        &Some("#123456".to_string()),
+        &Some("#FEDCBA".to_string()),
+    ));
+    assert!(system_accent_theme_colors_changed(
+        &Some("#123456".to_string()),
+        &Some("#ABCDEF".to_string()),
+        &Some("#654321".to_string()),
+        &Some("#ABCDEF".to_string()),
+    ));
+}
+
+#[test]
 fn normalize_theme_id_canonicalizes_material_you_color() {
     assert_eq!(
         normalize_theme_id("material-you:#aabbcc"),
@@ -598,4 +620,28 @@ fn generated_material_theme_uses_translucent_selection_tokens() {
     assert!(theme.list_active.a <= 0.2);
     assert!(theme.table_active.a <= 0.2);
     assert!(theme.selection.a <= 0.3);
+}
+
+#[test]
+fn system_text_highlight_overrides_material_selection() {
+    let mut config = generated_theme_config(TEST_THEME_COLOR, ComponentThemeMode::Dark)
+        .expect("dark material theme");
+
+    apply_system_text_highlight_selection(&mut config, Some("#B3D7FF".to_string()));
+
+    assert_eq!(config.colors.selection, Some("#B3D7FF".into()));
+}
+
+#[test]
+fn missing_system_text_highlight_keeps_generated_material_selection() {
+    let scheme = material_scheme(ComponentThemeMode::Dark);
+    let mut config = generated_theme_config(TEST_THEME_COLOR, ComponentThemeMode::Dark)
+        .expect("dark material theme");
+
+    apply_system_text_highlight_selection(&mut config, None);
+
+    assert_eq!(
+        config.colors.selection,
+        Some(hex_alpha(scheme.primary, 0x66))
+    );
 }

--- a/crates/app-theme/src/tests.rs
+++ b/crates/app-theme/src/tests.rs
@@ -41,6 +41,31 @@ fn syntax_color(highlight: &HighlightThemeStyle, name: &str) -> Argb {
     )
 }
 
+fn main_syntax_palette(highlight: &HighlightThemeStyle) -> Vec<(&'static str, Argb)> {
+    [
+        "keyword",
+        "function",
+        "type",
+        "property",
+        "attribute_link",
+        "tag",
+        "string",
+        "number",
+        "comment",
+        "variable",
+    ]
+    .into_iter()
+    .map(|name| {
+        let token = if name == "attribute_link" {
+            "attribute"
+        } else {
+            name
+        };
+        (name, syntax_color(highlight, token))
+    })
+    .collect()
+}
+
 fn collect_null_paths(prefix: &str, value: &serde_json::Value, paths: &mut Vec<String>) {
     match value {
         serde_json::Value::Null => paths.push(prefix.to_string()),
@@ -81,6 +106,96 @@ fn contrast_ratio(first: Argb, second: Argb) -> f64 {
     };
 
     (lighter + 0.05) / (darker + 0.05)
+}
+
+fn oklab_distance(first: Argb, second: Argb) -> f64 {
+    fn linear_channel(value: u8) -> f64 {
+        let value = f64::from(value) / 255.0;
+        if value <= 0.04045 {
+            value / 12.92
+        } else {
+            ((value + 0.055) / 1.055).powf(2.4)
+        }
+    }
+
+    fn oklab(color: Argb) -> [f64; 3] {
+        let red = linear_channel(color.red());
+        let green = linear_channel(color.green());
+        let blue = linear_channel(color.blue());
+
+        let l = 0.412_221_470_8 * red + 0.536_332_536_3 * green + 0.051_445_992_9 * blue;
+        let m = 0.211_903_498_2 * red + 0.680_699_545_1 * green + 0.107_396_956_6 * blue;
+        let s = 0.088_302_461_9 * red + 0.281_718_837_6 * green + 0.629_978_700_5 * blue;
+
+        let l = l.cbrt();
+        let m = m.cbrt();
+        let s = s.cbrt();
+
+        [
+            0.210_454_255_3 * l + 0.793_617_785 * m - 0.004_072_046_8 * s,
+            1.977_998_495_1 * l - 2.428_592_205 * m + 0.450_593_709_9 * s,
+            0.025_904_037_1 * l + 0.782_771_766_2 * m - 0.808_675_766 * s,
+        ]
+    }
+
+    let first = oklab(first);
+    let second = oklab(second);
+    ((first[0] - second[0]).powi(2)
+        + (first[1] - second[1]).powi(2)
+        + (first[2] - second[2]).powi(2))
+    .sqrt()
+}
+
+fn syntax_pair_minimum_oklab_distance(first: &str, second: &str) -> f64 {
+    let pair = [first, second];
+    if pair.contains(&"property") && pair.contains(&"string")
+        || pair.contains(&"property") && pair.contains(&"variable")
+        || pair.contains(&"property") && pair.contains(&"function")
+        || pair.contains(&"attribute_link") && pair.contains(&"type")
+        || pair.contains(&"attribute_link") && pair.contains(&"number")
+    {
+        0.10
+    } else {
+        0.08
+    }
+}
+
+fn assert_syntax_palette_pairwise_distances(
+    mode: ComponentThemeMode,
+    palette: &[(&'static str, Argb)],
+) {
+    let mut failures = Vec::new();
+    let mut nearest = Vec::new();
+
+    for (index, (first_name, first_color)) in palette.iter().enumerate() {
+        for (second_name, second_color) in palette.iter().skip(index + 1) {
+            let distance = oklab_distance(*first_color, *second_color);
+            let minimum = syntax_pair_minimum_oklab_distance(first_name, second_name);
+            let row = format!(
+                "{first_name} {} / {second_name} {}: {distance:.3} >= {minimum:.3}",
+                first_color.to_hex(),
+                second_color.to_hex()
+            );
+
+            if distance < minimum {
+                failures.push(row.clone());
+            }
+            nearest.push((distance, row));
+        }
+    }
+
+    nearest.sort_by(|first, second| first.0.partial_cmp(&second.0).unwrap());
+    assert!(
+        failures.is_empty(),
+        "Material You syntax palette should keep all main token pairs distinct for {mode:?}.\nFailures:\n{}\nNearest pairs:\n{}",
+        failures.join("\n"),
+        nearest
+            .iter()
+            .take(10)
+            .map(|(_, row)| row.as_str())
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
 }
 
 #[test]
@@ -281,7 +396,8 @@ fn generated_material_theme_uses_material_state_layers() {
     for mode in [ComponentThemeMode::Light, ComponentThemeMode::Dark] {
         let scheme = material_scheme(mode);
         let config = generated_theme_config(TEST_THEME_COLOR, mode).expect("material theme");
-        let danger_roles = material_error_roles_for_palette(&scheme, scheme.error_palette.clone());
+        let danger_roles =
+            material_semantic_roles_for_palette(&scheme, scheme.error_palette.clone());
 
         assert_eq!(
             config.colors.primary_hover,
@@ -343,10 +459,10 @@ fn generated_material_theme_uses_material_state_layers() {
 }
 
 #[test]
-fn material_error_roles_for_palette_matches_scheme_error_roles() {
+fn material_semantic_roles_for_palette_matches_scheme_error_roles() {
     for mode in [ComponentThemeMode::Light, ComponentThemeMode::Dark] {
         let scheme = material_scheme(mode);
-        let roles = material_error_roles_for_palette(&scheme, scheme.error_palette.clone());
+        let roles = material_semantic_roles_for_palette(&scheme, scheme.error_palette.clone());
 
         assert_eq!(roles.color, scheme.error);
         assert_eq!(roles.on_color, scheme.on_error);
@@ -498,6 +614,7 @@ fn generated_material_theme_fills_highlight_tokens() {
             "attribute",
             "boolean",
             "comment",
+            "comment.doc",
             "constant",
             "constructor",
             "embedded",
@@ -511,8 +628,13 @@ fn generated_material_theme_fills_highlight_tokens() {
             "punctuation",
             "punctuation.bracket",
             "punctuation.delimiter",
+            "punctuation.list_marker",
+            "punctuation.special",
             "string",
             "string.escape",
+            "string.regex",
+            "string.special",
+            "string.special.symbol",
             "tag",
             "text.literal",
             "title",
@@ -523,6 +645,39 @@ fn generated_material_theme_fills_highlight_tokens() {
         ] {
             _ = syntax_color(&highlight, name);
         }
+    }
+}
+
+#[test]
+fn generated_material_syntax_roles_do_not_collapse_to_repeated_colors() {
+    for mode in [ComponentThemeMode::Light, ComponentThemeMode::Dark] {
+        let config = generated_theme_config(TEST_THEME_COLOR, mode).expect("material theme");
+        let highlight = config.highlight.expect("highlight should be generated");
+        let palette = main_syntax_palette(&highlight);
+        let distinct = palette
+            .iter()
+            .map(|(_, color)| color.to_hex())
+            .collect::<HashSet<_>>();
+
+        assert!(
+            palette.len() >= 10,
+            "Material You syntax palette should include all main token roles for {mode:?}"
+        );
+        assert!(
+            distinct.len() >= 10,
+            "Material You syntax roles should stay visually distinct for {mode:?}: {distinct:?}"
+        );
+        assert_eq!(
+            syntax_color(&highlight, "attribute"),
+            syntax_color(&highlight, "link_text"),
+            "attribute and link_text should intentionally share the attribute_link color for {mode:?}"
+        );
+        assert_eq!(
+            syntax_color(&highlight, "attribute"),
+            syntax_color(&highlight, "link_uri"),
+            "attribute and link_uri should intentionally share the attribute_link color for {mode:?}"
+        );
+        assert_syntax_palette_pairwise_distances(mode, &palette);
     }
 }
 

--- a/crates/platform-ext/Cargo.toml
+++ b/crates/platform-ext/Cargo.toml
@@ -24,7 +24,11 @@ objc2-core-graphics = { version = "0.3.2", features = [
   "CGImage",
   "CGWindow",
 ] }
-objc2-foundation = { version = "0.3.2", features = ["block2"] }
+objc2-foundation = { version = "0.3.2", features = [
+  "block2",
+  "NSUserDefaults",
+  "NSString",
+] }
 
 [target.'cfg(target_os="windows")'.dependencies]
 windows = { version = "0.62.2", features = [

--- a/crates/platform-ext/src/appearance.rs
+++ b/crates/platform-ext/src/appearance.rs
@@ -48,7 +48,9 @@ mod macos {
         runtime::{AnyObject, NSObjectProtocol, ProtocolObject},
     };
     use objc2_app_kit::{NSColor, NSColorSpace, NSSystemColorsDidChangeNotification};
-    use objc2_foundation::{NSNotification, NSNotificationCenter, NSOperationQueue};
+    use objc2_foundation::{
+        NSNotification, NSNotificationCenter, NSOperationQueue, NSUserDefaults, ns_string,
+    };
     use std::{ptr::NonNull, sync::Arc};
 
     pub(super) struct MacObserver {
@@ -68,7 +70,16 @@ mod macos {
     }
 
     pub(super) fn system_accent_color() -> Option<SystemAccentColor> {
-        let color = NSColor::controlAccentColor();
+        ns_color_to_system_color(NSColor::controlAccentColor())
+    }
+
+    pub(super) fn system_text_highlight_color() -> Option<SystemAccentColor> {
+        let defaults = NSUserDefaults::standardUserDefaults();
+        defaults.objectForKey(ns_string!("AppleHighlightColor"))?;
+        ns_color_to_system_color(NSColor::selectedTextBackgroundColor())
+    }
+
+    fn ns_color_to_system_color(color: Retained<NSColor>) -> Option<SystemAccentColor> {
         let color_space = NSColorSpace::sRGBColorSpace();
         let color = color.colorUsingColorSpace(&color_space)?;
         Some(SystemAccentColor::new(
@@ -175,6 +186,18 @@ pub fn system_accent_color() -> Option<SystemAccentColor> {
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        None
+    }
+}
+
+pub fn system_text_highlight_color() -> Option<SystemAccentColor> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::system_text_highlight_color()
+    }
+
+    #[cfg(not(target_os = "macos"))]
     {
         None
     }


### PR DESCRIPTION
## Summary

- Split `ai-chat` tree-sitter language support into default basic and opt-in full feature sets.
- Make System Accent Material You use the explicit macOS text highlight color for selection.
- Rebalance `app-theme` Material You syntax colors with semantic groups and OKLab distance checks.
- Affected crates/apps: `ai-chat`, `app-theme`, `platform-ext`.

## Motivation

- Keep the default `ai-chat` binary smaller while still enabling common code fence highlighting.
- Respect macOS text highlight color in the system-accent Material You path.
- Avoid generated Material You syntax colors collapsing together in light and dark themes.

## Changes

- Added `tree-sitter-languages-basic` and `tree-sitter-languages-full` feature split for `ai-chat`.
- Added macOS system text highlight color plumbing and refreshed system-color change detection.
- Generated syntax colors now use semantic Material dynamic roles, merge attribute/link into one group, and validate group-level OKLab distances.
- Added focused unit coverage for feature/theme behavior and syntax palette distance constraints.

## Validation

- [ ] `cargo build`
- [x] `cargo test`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Manual verification completed for the affected app or flow

Validation details:

```text
cargo fmt
cargo test -p app-theme
cargo check -p ai-chat
CARGO_NET_OFFLINE=true cargo run --offline --manifest-path /private/tmp/app-theme-probe/Cargo.toml
```

`cargo build` and full clippy were not run; focused crate/app checks were used for the touched paths.

## Risks

- Default syntax highlighting language coverage changes through the new ai-chat feature split.
- Material You generated syntax colors change visually, but preset themes are not changed.

## Related Issues

- Closes #119
