### PR TITLE
workspace: refresh dependencies and lucide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -275,7 +275,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1275,7 +1275,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1296,7 +1296,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -2044,7 +2044,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "indexmap 2.14.0",
  "rustc-hash 2.1.2",
@@ -2881,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3030,7 +3030,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3079,7 +3079,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.8.9",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -3540,7 +3540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4588,7 +4588,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -4668,7 +4668,7 @@ dependencies = [
 [[package]]
 name = "gpui-component"
 version = "0.5.2"
-source = "git+https://github.com/longbridge/gpui-component#f2ae9cb3372551768716fa39667b59c9a3b787d0"
+source = "git+https://github.com/longbridge/gpui-component#e64411fcbcf4eb586334a4d543257218e009114b"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4744,7 +4744,7 @@ dependencies = [
 [[package]]
 name = "gpui-component-assets"
 version = "0.5.1"
-source = "git+https://github.com/longbridge/gpui-component#f2ae9cb3372551768716fa39667b59c9a3b787d0"
+source = "git+https://github.com/longbridge/gpui-component#e64411fcbcf4eb586334a4d543257218e009114b"
 dependencies = [
  "anyhow",
  "gpui",
@@ -4758,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "gpui-component-macros"
 version = "0.5.1"
-source = "git+https://github.com/longbridge/gpui-component#f2ae9cb3372551768716fa39667b59c9a3b787d0"
+source = "git+https://github.com/longbridge/gpui-component#e64411fcbcf4eb586334a4d543257218e009114b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4768,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "anyhow",
  "as-raw-xcb-connection",
@@ -4817,7 +4817,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "anyhow",
  "async-task",
@@ -4860,7 +4860,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4871,7 +4871,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -4884,7 +4884,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "schemars 1.2.1",
  "serde",
@@ -4894,7 +4894,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "anyhow",
  "log",
@@ -4903,7 +4903,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -4927,7 +4927,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -4945,6 +4945,7 @@ dependencies = [
  "raw-window-handle",
  "smallvec",
  "swash",
+ "unicode-segmentation",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -4955,7 +4956,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "anyhow",
  "collections",
@@ -5356,7 +5357,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -5489,12 +5490,12 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
+ "windows-registry 0.4.0",
 ]
 
 [[package]]
@@ -5871,7 +5872,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6716,7 +6717,7 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "anyhow",
  "bindgen 0.71.1",
@@ -6873,13 +6874,13 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "naga"
-version = "29.0.0"
-source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
+version = "29.0.3"
+source = "git+https://github.com/zed-industries/wgpu.git?rev=357a0c56e0070480ad9daea5d2eaa83150b79e88#357a0c56e0070480ad9daea5d2eaa83150b79e88"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -7073,7 +7074,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7242,7 +7243,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7730,7 +7731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -7967,7 +7968,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "collections",
  "serde",
@@ -8027,7 +8028,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitfield",
  "block-padding",
  "blowfish",
@@ -8670,7 +8671,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8708,7 +8709,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -9037,7 +9038,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "derive_refineable",
 ]
@@ -9525,7 +9526,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9538,7 +9539,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9666,7 +9667,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9687,7 +9688,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9800,7 +9801,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "async-task",
  "backtrace",
@@ -9993,7 +9994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10307,7 +10308,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 6.0.0",
+ "dirs 5.0.1",
 ]
 
 [[package]]
@@ -10486,7 +10487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10577,7 +10578,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10713,7 +10714,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "heapless",
  "log",
@@ -11063,9 +11064,9 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tauri-bundler"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab3b74b151e702edba8d2ea59dbdc98de5eedd7f613a04dc40c0657bf398980"
+checksum = "117b59d603583baca31472d9784a0f21bc5da543a4468af0a86ccfa031d67b41"
 dependencies = [
  "anyhow",
  "ar",
@@ -11144,9 +11145,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d57200389a2f82b4b0a40ae29ca19b6978116e8f4d4e974c3234ce40c0ffbdec"
+checksum = "092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95"
 dependencies = [
  "anyhow",
  "ctor 0.8.0",
@@ -11183,7 +11184,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11691,7 +11692,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12171,7 +12172,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12460,7 +12461,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "anyhow",
  "async-fs",
@@ -12499,7 +12500,7 @@ dependencies = [
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "perf",
  "quote",
@@ -12964,8 +12965,8 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wgpu"
-version = "29.0.0"
-source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
+version = "29.0.3"
+source = "git+https://github.com/zed-industries/wgpu.git?rev=357a0c56e0070480ad9daea5d2eaa83150b79e88#357a0c56e0070480ad9daea5d2eaa83150b79e88"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.1",
@@ -12993,8 +12994,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "29.0.0"
-source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
+version = "29.0.3"
+source = "git+https://github.com/zed-industries/wgpu.git?rev=357a0c56e0070480ad9daea5d2eaa83150b79e88#357a0c56e0070480ad9daea5d2eaa83150b79e88"
 dependencies = [
  "arrayvec",
  "bit-set",
@@ -13025,32 +13026,32 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "29.0.0"
-source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
+version = "29.0.3"
+source = "git+https://github.com/zed-industries/wgpu.git?rev=357a0c56e0070480ad9daea5d2eaa83150b79e88#357a0c56e0070480ad9daea5d2eaa83150b79e88"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "29.0.0"
-source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
+version = "29.0.3"
+source = "git+https://github.com/zed-industries/wgpu.git?rev=357a0c56e0070480ad9daea5d2eaa83150b79e88#357a0c56e0070480ad9daea5d2eaa83150b79e88"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "29.0.0"
-source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
+version = "29.0.3"
+source = "git+https://github.com/zed-industries/wgpu.git?rev=357a0c56e0070480ad9daea5d2eaa83150b79e88#357a0c56e0070480ad9daea5d2eaa83150b79e88"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "29.0.0"
-source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
+version = "29.0.3"
+source = "git+https://github.com/zed-industries/wgpu.git?rev=357a0c56e0070480ad9daea5d2eaa83150b79e88#357a0c56e0070480ad9daea5d2eaa83150b79e88"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -13097,12 +13098,13 @@ dependencies = [
  "wgpu-types",
  "windows 0.62.2",
  "windows-core 0.62.2",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
 name = "wgpu-naga-bridge"
-version = "29.0.0"
-source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
+version = "29.0.3"
+source = "git+https://github.com/zed-industries/wgpu.git?rev=357a0c56e0070480ad9daea5d2eaa83150b79e88#357a0c56e0070480ad9daea5d2eaa83150b79e88"
 dependencies = [
  "naga",
  "wgpu-types",
@@ -13110,8 +13112,8 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "29.0.0"
-source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
+version = "29.0.3"
+source = "git+https://github.com/zed-industries/wgpu.git?rev=357a0c56e0070480ad9daea5d2eaa83150b79e88#357a0c56e0070480ad9daea5d2eaa83150b79e88"
 dependencies = [
  "bitflags 2.11.1",
  "bytemuck",
@@ -13182,7 +13184,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -13446,17 +13448,6 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -14669,7 +14660,7 @@ checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -14726,7 +14717,7 @@ dependencies = [
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -14737,7 +14728,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#29db565437e39ed6f9a640d475c03e40f22d5641"
+source = "git+https://github.com/zed-industries/zed#da43bdb648202474bc7402590f0d6042a62c6ba2"
 
 [[package]]
 name = "zune-core"

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -11,8 +11,8 @@ plist = "1.9.0"
 serde = { version = "1.0.228", features = ["derive"] }
 thiserror = "2.0.18"
 toml = "1.1.2"
-tauri-bundler = "2.9.1"
-tauri-utils = "2.9.1"
+tauri-bundler = "2.9.2"
+tauri-utils = "2.9.2"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["local-time"] }
 walkdir = "2.5.0"


### PR DESCRIPTION
## Summary

- Refreshed workspace dependency pins and third-party assets.
- Affected scope: `workspace`, `xtask`, shared GPUI/gpui-component dependency graph, and Lucide assets.

## Motivation

- Closes #145 by moving package and third-party library references to current upstream revisions where the workspace can build and validate cleanly.

## Changes

- Updated `tauri-bundler` and `tauri-utils` from `2.9.1` to `2.9.2`.
- Updated `zed-industries/zed` git dependencies from `29db565` to `da43bdb`.
- Updated `longbridge/gpui-component` git dependencies from `f2ae9cb` to `e64411f`.
- Updated the zed-provided `wgpu` git dependency to `357a0c56`.
- Updated `third_party/lucide` from `2214caa` to `5b40f2c`.

## Validation

- [x] `cargo build`
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
cargo fmt
cargo fetch
cargo build
cargo test
cargo clippy --all-targets --all-features -- -D warnings

All commands completed successfully.
Manual app verification was not run because this is a dependency/submodule maintenance change with no app behavior changes.
```

## Risks

- Git dependency updates may include upstream GPUI/gpui-component behavior changes not covered by unit tests.
- Lucide update changes the available third-party icon catalog; declared app icons were covered by existing asset tests through `cargo test`.

## Related Issues

- Closes #145
