### PR TITLE
[tech] ai-chat: add provider-neutral model capability types

### DIFF
--- a/app/ai-chat/docs/dev/issue-137-llm-abstractions.md
+++ b/app/ai-chat/docs/dev/issue-137-llm-abstractions.md
@@ -17,7 +17,7 @@ Delete it before the final merge to `main`, unless the remaining content is prom
 | Issue | Branch | Purpose | Status |
 | --- | --- | --- | --- |
 | #137 | `codex/issue-137-llm-abstractions` | Parent integration work | Active |
-| #138 | `codex/issue-138-model-capabilities` | Provider-neutral model capability types | Pending |
+| #138 | `codex/issue-138-model-capabilities` | Provider-neutral model capability types | Implemented locally; PR pending |
 | #142 | `codex/issue-142-llm-items` | Typed input, content, and output items | Pending |
 | #139 | `codex/issue-139-provider-runtime` | Run-based provider trait and events | Pending |
 | #141 | `codex/issue-141-llm-persistence` | Run state, output items, tools, attachments persistence | Pending |
@@ -28,7 +28,10 @@ Delete it before the final merge to `main`, unless the remaining content is prom
 ## Current Architecture Facts
 
 - `llm::Message` is currently text-only: role plus `String` content.
-- `ProviderModelCapability` currently only differentiates streaming from non-streaming.
+- `ProviderModel` now holds provider-neutral `ModelCapabilities` instead of the old streaming-only `ProviderModelCapability`.
+- `ModelCapabilities` covers text input/output, streaming, image/file/audio input, image generation, tool calling, hosted web search, remote MCP, reasoning, structured output, stateful response continuation, and provider-specific typed extensions.
+- OpenAI model classification now emits typed capabilities for Responses API usage, reasoning effort options, hosted web search, structured output, and stateful response continuation.
+- Ollama `/api/show` metadata now maps into typed capabilities and an `OllamaModelCapabilities` extension for raw capabilities, family data, thinking mode, and local web tools.
 - `Provider` currently builds provider request JSON and fetches a single response stream.
 - `FetchUpdate` currently only covers thinking start, reasoning summary delta, text delta, and complete content.
 - `messages.content` stores rendered message content; `messages.send_content` stores the request body snapshot used for resend.
@@ -43,24 +46,22 @@ Delete it before the final merge to `main`, unless the remaining content is prom
 - The UI, templates, and shortcut flows should ask the generic capability model whether a feature is available.
 - Existing pure-text conversations, templates, shortcuts, resend behavior, OpenAI, and Ollama must keep working during the migration.
 
-## Planned Capability Vocabulary
+## Implemented Capability Vocabulary
 
-The first child issue should establish the exact Rust names, but the shared vocabulary is:
+Issue #138 established these Rust capability types:
 
-- Text input and text output
-- Streaming
-- Image input
-- File input
-- Audio input
-- Image generation
-- Tool calling
-- Hosted web search
-- Remote MCP
-- Reasoning
-- Structured output
-- Stateful response continuation
+- `ModelCapabilities`
+- `ReasoningCapability`
+- `ReasoningEffort`
+- `ImageInputCapability`
+- `FileInputCapability`
+- `ToolCallingCapability`
+- `ProviderCapabilityExtension`
+- `OpenAIModelCapabilities`
+- `OllamaModelCapabilities`
+- `OllamaThinkingCapability`
 
-Capability parameters should cover reasoning effort options, image limits, parallel tool calls, and stateful continuation support where applicable.
+The current implementation keeps request execution behavior unchanged: OpenAI and Ollama still produce the same provider request JSON shape, but capability gating inside provider/template code now reads typed model capabilities instead of ad hoc JSON metadata or streaming-only enum state.
 
 ## Provider Extension Rules
 
@@ -86,8 +87,25 @@ Capability parameters should cover reasoning effort options, image limits, paral
   - `cargo clippy --all-targets --all-features -- -D warnings`
 - UI or shortcut stages must include manual verification notes for old text chat, OpenAI, Ollama, resend, and shortcut flows.
 
+## Completed Child Issue Notes
+
+### #138 Provider-Neutral Model Capability Types
+
+- Replaced `ProviderModelCapability` with `ModelCapabilities`.
+- Re-exported the new capability vocabulary from `llm.rs` for downstream stages.
+- Migrated OpenAI reasoning/web-search capability checks to typed capabilities.
+- Migrated Ollama thinking/tool capability checks to typed `OllamaModelCapabilities`.
+- Preserved existing OpenAI Responses request body, Ollama chat request body, template replay, streaming, and ext-setting behavior.
+- Validation run:
+  - `cargo fmt`
+  - `cargo test -p ai-chat llm::provider`
+  - `cargo test -p ai-chat llm::preset`
+  - `cargo test -p ai-chat state::chat::models`
+  - `cargo test -p ai-chat components::chat_form::model_select`
+  - `cargo test -p ai-chat features::settings::shortcut_settings`
+
 ## Next Child Issue Constraints
 
-Start with #138.
-It should introduce provider-neutral capability types without changing request execution behavior yet.
-It should migrate existing OpenAI and Ollama model metadata enough for current ext settings to continue working.
+Next child issue is #142.
+It should introduce typed input, content, and output items on top of the `ModelCapabilities` foundation without forcing OpenAI Responses output items onto every provider.
+It must keep existing text-only conversations, templates, shortcuts, resend behavior, OpenAI, and Ollama working while the new item model is added.

--- a/app/ai-chat/src/components/chat_form/model_select/model_picker.rs
+++ b/app/ai-chat/src/components/chat_form/model_select/model_picker.rs
@@ -66,7 +66,7 @@ mod tests {
     use super::model_sections;
     use crate::{
         components::chat_form::picker::PickerListDelegate,
-        llm::{ProviderModel, ProviderModelCapability},
+        llm::{ModelCapabilities, ProviderModel},
     };
 
     #[test]
@@ -74,11 +74,11 @@ mod tests {
         let sections = model_sections(&[ProviderModel::new(
             "OpenAI",
             "gpt-4o",
-            ProviderModelCapability::Streaming,
+            ModelCapabilities::text_streaming(),
         )]);
 
         let missing_model =
-            ProviderModel::new("OpenAI", "gpt-5", ProviderModelCapability::Streaming);
+            ProviderModel::new("OpenAI", "gpt-5", ModelCapabilities::text_streaming());
         assert_eq!(
             PickerListDelegate::selected_index_for(&sections, Some(&missing_model)),
             None

--- a/app/ai-chat/src/features/settings/shortcut_settings/form.rs
+++ b/app/ai-chat/src/features/settings/shortcut_settings/form.rs
@@ -1102,14 +1102,59 @@ mod tests {
     use crate::database::{GlobalShortcutBinding, Mode, ShortcutInputSource};
     use crate::{
         features::settings::shortcut_settings::choices::ModelChoice,
-        llm::{ProviderModel, ProviderModelCapability, build_request_template},
+        llm::{
+            ModelCapabilities, OllamaModelCapabilities, OllamaThinkingCapability,
+            OpenAIModelCapabilities, ProviderModel, ReasoningCapability, ReasoningEffort,
+            build_request_template,
+        },
         state::ModelStoreStatus,
     };
     use serde_json::json;
     use time::OffsetDateTime;
 
     fn model(provider_name: &str, model_id: &str) -> ProviderModel {
-        ProviderModel::new(provider_name, model_id, ProviderModelCapability::Streaming)
+        ProviderModel::new(provider_name, model_id, ModelCapabilities::text_streaming())
+    }
+
+    fn openai_reasoning_model(model_id: &str) -> ProviderModel {
+        let mut capabilities = ModelCapabilities::text_streaming();
+        capabilities.reasoning = Some(ReasoningCapability {
+            default_effort: ReasoningEffort::Medium,
+            efforts: vec![
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+                ReasoningEffort::XHigh,
+            ],
+            summaries: true,
+        });
+        ProviderModel::new(
+            "OpenAI",
+            model_id,
+            capabilities.with_openai_extension(OpenAIModelCapabilities {
+                responses_api: true,
+                reasoning_summaries: true,
+                hosted_web_search: true,
+                stateful_response_continuation: true,
+            }),
+        )
+    }
+
+    fn ollama_gptoss_model(model_id: &str) -> ProviderModel {
+        ProviderModel::new(
+            "Ollama",
+            model_id,
+            ModelCapabilities::text_streaming().with_ollama_extension(OllamaModelCapabilities {
+                raw_capabilities: vec![
+                    "completion".to_string(),
+                    "thinking".to_string(),
+                    "tools".to_string(),
+                ],
+                family: "gptoss".to_string(),
+                families: vec!["gptoss".to_string()],
+                thinking: Some(OllamaThinkingCapability::Levels),
+                local_web_tools: true,
+            }),
+        )
     }
 
     fn shortcut_binding() -> GlobalShortcutBinding {
@@ -1247,7 +1292,7 @@ mod tests {
 
     #[test]
     fn saved_request_template_replays_ext_settings_for_same_model() -> anyhow::Result<()> {
-        let openai_model = model("OpenAI", "gpt-5.2-pro");
+        let openai_model = openai_reasoning_model("gpt-5.2-pro");
         let openai_template = build_request_template(
             &openai_model,
             Some(&json!({
@@ -1257,11 +1302,7 @@ mod tests {
         )?;
         assert_eq!(openai_template["reasoning"]["effort"], "xhigh");
 
-        let ollama_model = model("Ollama", "gpt-oss").with_metadata(json!({
-            "capabilities": ["completion", "thinking", "tools"],
-            "family": "gptoss",
-            "families": ["gptoss"]
-        }));
+        let ollama_model = ollama_gptoss_model("gpt-oss");
         let ollama_template = build_request_template(
             &ollama_model,
             Some(&json!({

--- a/app/ai-chat/src/llm.rs
+++ b/app/ai-chat/src/llm.rs
@@ -7,15 +7,15 @@ pub(crate) use preset::{
     apply_ext_setting, build_request_template, ext_settings as preset_ext_settings,
 };
 #[cfg(test)]
-pub(crate) use provider::ProviderModelCapability;
-#[cfg(test)]
 pub(crate) use provider::ProviderModelsSuccess;
 pub(crate) use provider::{
     AvailableModelsBatch, ExtSettingControl, ExtSettingItem, ExtSettingOption, FetchUpdate,
-    OllamaProvider, OllamaSettings, OpenAIProvider, OpenAISettings, Provider, ProviderModel,
-    ProviderModelsFailure, ProviderSettingsFieldKind, ProviderSettingsFieldSpec,
-    ProviderSettingsSpec, available_models, provider_by_name, provider_is_configured,
-    provider_names, provider_settings_specs,
+    ModelCapabilities, OllamaModelCapabilities, OllamaProvider, OllamaSettings,
+    OllamaThinkingCapability, OpenAIModelCapabilities, OpenAIProvider, OpenAISettings, Provider,
+    ProviderCapabilityExtension, ProviderModel, ProviderModelsFailure, ProviderSettingsFieldKind,
+    ProviderSettingsFieldSpec, ProviderSettingsSpec, ReasoningCapability, ReasoningEffort,
+    available_models, provider_by_name, provider_is_configured, provider_names,
+    provider_settings_specs,
 };
 pub(crate) use runner::FetchRunner;
 pub(crate) use types::Message;

--- a/app/ai-chat/src/llm/preset.rs
+++ b/app/ai-chat/src/llm/preset.rs
@@ -46,12 +46,78 @@ pub(crate) fn apply_ext_setting(
 #[cfg(test)]
 mod tests {
     use super::build_request_template;
-    use crate::llm::{ProviderModel, ProviderModelCapability};
+    use crate::llm::{
+        ModelCapabilities, OllamaModelCapabilities, OllamaThinkingCapability,
+        OpenAIModelCapabilities, ProviderModel, ReasoningCapability, ReasoningEffort,
+    };
     use serde_json::json;
+
+    fn openai_reasoning_model(id: &str) -> ProviderModel {
+        let mut capabilities = ModelCapabilities::text_streaming();
+        capabilities.reasoning = Some(ReasoningCapability {
+            default_effort: ReasoningEffort::Medium,
+            efforts: vec![
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+                ReasoningEffort::XHigh,
+            ],
+            summaries: true,
+        });
+        ProviderModel::new(
+            "OpenAI",
+            id,
+            capabilities.with_openai_extension(OpenAIModelCapabilities {
+                responses_api: true,
+                reasoning_summaries: true,
+                hosted_web_search: true,
+                stateful_response_continuation: true,
+            }),
+        )
+    }
+
+    fn ollama_model(
+        id: &str,
+        raw_capabilities: &[&str],
+        family: &str,
+        families: &[&str],
+    ) -> ProviderModel {
+        let raw_capabilities = raw_capabilities
+            .iter()
+            .map(|capability| (*capability).to_string())
+            .collect::<Vec<_>>();
+        let families = families
+            .iter()
+            .map(|family| (*family).to_string())
+            .collect::<Vec<_>>();
+        let thinking = raw_capabilities
+            .iter()
+            .any(|capability| capability == "thinking")
+            .then(|| {
+                if matches!(family, "gptoss" | "gpt-oss") {
+                    OllamaThinkingCapability::Levels
+                } else {
+                    OllamaThinkingCapability::Boolean
+                }
+            });
+        let local_web_tools = raw_capabilities
+            .iter()
+            .any(|capability| capability == "tools");
+        ProviderModel::new(
+            "Ollama",
+            id,
+            ModelCapabilities::text_streaming().with_ollama_extension(OllamaModelCapabilities {
+                raw_capabilities,
+                family: family.to_string(),
+                families,
+                thinking,
+                local_web_tools,
+            }),
+        )
+    }
 
     #[test]
     fn build_request_template_replays_openai_reasoning_settings() -> anyhow::Result<()> {
-        let model = ProviderModel::new("OpenAI", "gpt-5.2-pro", ProviderModelCapability::Streaming);
+        let model = openai_reasoning_model("gpt-5.2-pro");
         let template = build_request_template(
             &model,
             Some(&json!({
@@ -66,12 +132,12 @@ mod tests {
 
     #[test]
     fn build_request_template_replays_ollama_ext_settings() -> anyhow::Result<()> {
-        let model = ProviderModel::new("Ollama", "gpt-oss", ProviderModelCapability::Streaming)
-            .with_metadata(json!({
-                "capabilities": ["completion", "thinking", "tools"],
-                "family": "gptoss",
-                "families": ["gptoss"]
-            }));
+        let model = ollama_model(
+            "gpt-oss",
+            &["completion", "thinking", "tools"],
+            "gptoss",
+            &["gptoss"],
+        );
         let template = build_request_template(
             &model,
             Some(&json!({
@@ -87,12 +153,7 @@ mod tests {
 
     #[test]
     fn build_request_template_defaults_ollama_boolean_thinking_to_false() -> anyhow::Result<()> {
-        let model = ProviderModel::new("Ollama", "qwen3", ProviderModelCapability::Streaming)
-            .with_metadata(json!({
-                "capabilities": ["completion", "thinking"],
-                "family": "qwen3",
-                "families": ["qwen3"]
-            }));
+        let model = ollama_model("qwen3", &["completion", "thinking"], "qwen3", &["qwen3"]);
         let template = build_request_template(
             &model,
             Some(&json!({
@@ -107,7 +168,7 @@ mod tests {
 
     #[test]
     fn build_request_template_skips_invalid_saved_ext_settings() -> anyhow::Result<()> {
-        let model = ProviderModel::new("OpenAI", "gpt-5.2-pro", ProviderModelCapability::Streaming);
+        let model = openai_reasoning_model("gpt-5.2-pro");
         let template = build_request_template(
             &model,
             Some(&json!({

--- a/app/ai-chat/src/llm/provider.rs
+++ b/app/ai-chat/src/llm/provider.rs
@@ -15,14 +15,177 @@ mod ollama;
 mod openai;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ProviderModelCapability {
-    Streaming,
-    NonStreaming,
+pub(crate) enum ReasoningEffort {
+    None,
+    Minimal,
+    Low,
+    Medium,
+    High,
+    XHigh,
 }
 
-impl ProviderModelCapability {
-    pub(crate) fn stream_flag(self) -> bool {
-        matches!(self, Self::Streaming)
+impl ReasoningEffort {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Minimal => "minimal",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::XHigh => "xhigh",
+        }
+    }
+
+    pub(crate) fn from_str(value: &str) -> Option<Self> {
+        Some(match value {
+            "none" => Self::None,
+            "minimal" => Self::Minimal,
+            "low" => Self::Low,
+            "medium" => Self::Medium,
+            "high" => Self::High,
+            "xhigh" => Self::XHigh,
+            _ => return None,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReasoningCapability {
+    pub(crate) default_effort: ReasoningEffort,
+    pub(crate) efforts: Vec<ReasoningEffort>,
+    pub(crate) summaries: bool,
+}
+
+impl ReasoningCapability {
+    pub(crate) fn supports_effort(&self, effort: ReasoningEffort) -> bool {
+        self.efforts.contains(&effort)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ImageInputCapability {
+    pub(crate) max_images: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FileInputCapability {
+    pub(crate) max_files: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ToolCallingCapability {
+    pub(crate) parallel_tool_calls: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OpenAIModelCapabilities {
+    pub(crate) responses_api: bool,
+    pub(crate) reasoning_summaries: bool,
+    pub(crate) hosted_web_search: bool,
+    pub(crate) stateful_response_continuation: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OllamaThinkingCapability {
+    Boolean,
+    Levels,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OllamaModelCapabilities {
+    pub(crate) raw_capabilities: Vec<String>,
+    pub(crate) family: String,
+    pub(crate) families: Vec<String>,
+    pub(crate) thinking: Option<OllamaThinkingCapability>,
+    pub(crate) local_web_tools: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ProviderCapabilityExtension {
+    None,
+    OpenAI(OpenAIModelCapabilities),
+    Ollama(OllamaModelCapabilities),
+}
+
+impl Default for ProviderCapabilityExtension {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ModelCapabilities {
+    pub(crate) text_input: bool,
+    pub(crate) text_output: bool,
+    pub(crate) streaming: bool,
+    pub(crate) image_input: Option<ImageInputCapability>,
+    pub(crate) file_input: Option<FileInputCapability>,
+    pub(crate) audio_input: bool,
+    pub(crate) image_generation: bool,
+    pub(crate) tool_calling: Option<ToolCallingCapability>,
+    pub(crate) hosted_web_search: bool,
+    pub(crate) remote_mcp: bool,
+    pub(crate) reasoning: Option<ReasoningCapability>,
+    pub(crate) structured_output: bool,
+    pub(crate) stateful_response_continuation: bool,
+    pub(crate) extension: ProviderCapabilityExtension,
+}
+
+impl ModelCapabilities {
+    pub(crate) fn text_streaming() -> Self {
+        Self::text_with_streaming(true)
+    }
+
+    pub(crate) fn text_non_streaming() -> Self {
+        Self::text_with_streaming(false)
+    }
+
+    fn text_with_streaming(streaming: bool) -> Self {
+        Self {
+            text_input: true,
+            text_output: true,
+            streaming,
+            image_input: None,
+            file_input: None,
+            audio_input: false,
+            image_generation: false,
+            tool_calling: None,
+            hosted_web_search: false,
+            remote_mcp: false,
+            reasoning: None,
+            structured_output: false,
+            stateful_response_continuation: false,
+            extension: ProviderCapabilityExtension::None,
+        }
+    }
+
+    pub(crate) fn supports_streaming(&self) -> bool {
+        self.streaming
+    }
+
+    pub(crate) fn supports_reasoning(&self) -> bool {
+        self.reasoning.is_some()
+    }
+
+    pub(crate) fn supports_hosted_web_search(&self) -> bool {
+        self.hosted_web_search
+    }
+
+    pub(crate) fn with_openai_extension(mut self, extension: OpenAIModelCapabilities) -> Self {
+        self.hosted_web_search = extension.hosted_web_search;
+        self.stateful_response_continuation = extension.stateful_response_continuation;
+        self.extension = ProviderCapabilityExtension::OpenAI(extension);
+        self
+    }
+
+    pub(crate) fn with_ollama_extension(mut self, extension: OllamaModelCapabilities) -> Self {
+        if extension.local_web_tools {
+            self.tool_calling = Some(ToolCallingCapability {
+                parallel_tool_calls: false,
+            });
+        }
+        self.extension = ProviderCapabilityExtension::Ollama(extension);
+        self
     }
 }
 
@@ -30,7 +193,7 @@ impl ProviderModelCapability {
 pub(crate) struct ProviderModel {
     pub(crate) provider_name: String,
     pub(crate) id: String,
-    pub(crate) capability: ProviderModelCapability,
+    pub(crate) capabilities: ModelCapabilities,
     pub(crate) metadata: serde_json::Value,
 }
 
@@ -38,12 +201,12 @@ impl ProviderModel {
     pub(crate) fn new(
         provider_name: impl Into<String>,
         id: impl Into<String>,
-        capability: ProviderModelCapability,
+        capabilities: ModelCapabilities,
     ) -> Self {
         Self {
             provider_name: provider_name.into(),
             id: id.into(),
-            capability,
+            capabilities,
             metadata: serde_json::json!({}),
         }
     }
@@ -328,10 +491,10 @@ pub(crate) async fn available_models(config: AiChatConfig) -> AvailableModelsBat
 #[cfg(test)]
 mod tests {
     use super::{
-        AvailableModelsBatch, ExtSettingItem, FetchUpdate, Message, Provider, ProviderModel,
-        ProviderModelCapability, ProviderModelsFailure, ProviderSettingsFieldKind,
-        ProviderSettingsSpec, available_models_from_providers,
-        available_models_from_providers_with_timeout, provider_settings_specs,
+        AvailableModelsBatch, ExtSettingItem, FetchUpdate, Message, ModelCapabilities, Provider,
+        ProviderModel, ProviderModelsFailure, ProviderSettingsFieldKind, ProviderSettingsSpec,
+        available_models_from_providers, available_models_from_providers_with_timeout,
+        provider_settings_specs,
     };
     use crate::{
         errors::{AiChatError, AiChatResult},
@@ -431,7 +594,7 @@ mod tests {
     }
 
     fn model(provider: &str, id: &str) -> ProviderModel {
-        ProviderModel::new(provider, id, ProviderModelCapability::Streaming)
+        ProviderModel::new(provider, id, ModelCapabilities::text_streaming())
     }
 
     #[tokio::test]

--- a/app/ai-chat/src/llm/provider/ollama.rs
+++ b/app/ai-chat/src/llm/provider/ollama.rs
@@ -1,7 +1,8 @@
 use super::{
-    ExtSettingControl, ExtSettingItem, ExtSettingOption, FetchUpdate, Provider, ProviderModel,
-    ProviderModelCapability, ProviderSettingsFieldKind, ProviderSettingsFieldSpec,
-    ProviderSettingsSpec, normalized_or_default,
+    ExtSettingControl, ExtSettingItem, ExtSettingOption, FetchUpdate, ModelCapabilities,
+    OllamaModelCapabilities, OllamaThinkingCapability, Provider, ProviderCapabilityExtension,
+    ProviderModel, ProviderSettingsFieldKind, ProviderSettingsFieldSpec, ProviderSettingsSpec,
+    normalized_or_default,
 };
 use crate::{
     database::{Content, Role, UrlCitation},
@@ -343,61 +344,77 @@ struct RoundResult {
 }
 
 impl OllamaProvider {
-    fn metadata_capabilities(model: &ProviderModel) -> Vec<String> {
-        model
-            .metadata
-            .get("capabilities")
-            .and_then(serde_json::Value::as_array)
-            .into_iter()
-            .flatten()
-            .filter_map(serde_json::Value::as_str)
-            .map(ToOwned::to_owned)
-            .collect()
-    }
-
-    fn model_family(model: &ProviderModel) -> String {
-        model
-            .metadata
-            .get("family")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or_default()
-            .to_string()
-    }
-
-    fn model_families(model: &ProviderModel) -> Vec<String> {
-        model
-            .metadata
-            .get("families")
-            .and_then(serde_json::Value::as_array)
-            .into_iter()
-            .flatten()
-            .filter_map(serde_json::Value::as_str)
-            .map(ToOwned::to_owned)
-            .collect()
-    }
-
-    fn supports_capability(model: &ProviderModel, capability: &str) -> bool {
-        Self::metadata_capabilities(model)
-            .iter()
-            .any(|candidate| candidate == capability)
+    fn extension(model: &ProviderModel) -> Option<&OllamaModelCapabilities> {
+        match &model.capabilities.extension {
+            ProviderCapabilityExtension::Ollama(extension) => Some(extension),
+            _ => None,
+        }
     }
 
     fn supports_thinking(model: &ProviderModel) -> bool {
-        Self::supports_capability(model, "thinking")
+        Self::extension(model).is_some_and(|extension| extension.thinking.is_some())
     }
 
     fn supports_tools(model: &ProviderModel) -> bool {
-        Self::supports_capability(model, "tools")
+        Self::extension(model).is_some_and(|extension| extension.local_web_tools)
     }
 
     fn uses_thinking_levels(model: &ProviderModel) -> bool {
-        let family = Self::model_family(model);
-        if matches!(family.as_str(), "gptoss" | "gpt-oss") {
-            return true;
-        }
-        Self::model_families(model)
+        Self::extension(model)
+            .is_some_and(|extension| extension.thinking == Some(OllamaThinkingCapability::Levels))
+    }
+
+    fn thinking_capability(
+        capabilities: &[String],
+        family: &str,
+        families: &[String],
+    ) -> Option<OllamaThinkingCapability> {
+        if !capabilities
             .iter()
-            .any(|family| matches!(family.as_str(), "gptoss" | "gpt-oss"))
+            .any(|capability| capability == "thinking")
+        {
+            return None;
+        }
+        let uses_levels = matches!(family, "gptoss" | "gpt-oss")
+            || families
+                .iter()
+                .any(|family| matches!(family.as_str(), "gptoss" | "gpt-oss"));
+        Some(if uses_levels {
+            OllamaThinkingCapability::Levels
+        } else {
+            OllamaThinkingCapability::Boolean
+        })
+    }
+
+    fn capabilities_from_show(show: &OllamaShowResponse) -> ModelCapabilities {
+        let raw_capabilities = show.capabilities.clone();
+        let family = show.details.family.clone();
+        let families = show.details.families.clone();
+        let local_web_tools = raw_capabilities
+            .iter()
+            .any(|capability| capability == "tools");
+        let mut capabilities = ModelCapabilities::text_streaming();
+        capabilities.reasoning = Self::thinking_capability(&raw_capabilities, &family, &families)
+            .map(|_| super::ReasoningCapability {
+                default_effort: super::ReasoningEffort::Medium,
+                efforts: vec![
+                    super::ReasoningEffort::Low,
+                    super::ReasoningEffort::Medium,
+                    super::ReasoningEffort::High,
+                ],
+                summaries: true,
+            });
+        capabilities.with_ollama_extension(OllamaModelCapabilities {
+            raw_capabilities,
+            family,
+            families,
+            thinking: Self::thinking_capability(
+                &show.capabilities,
+                &show.details.family,
+                &show.details.families,
+            ),
+            local_web_tools,
+        })
     }
 
     fn default_think_for_model(model: &ProviderModel) -> Option<OllamaThinkValue> {
@@ -675,7 +692,7 @@ impl Provider for OllamaProvider {
     fn default_template_for_model(&self, model: &ProviderModel) -> AiChatResult<serde_json::Value> {
         Ok(serde_json::to_value(OllamaRequestTemplate {
             model: model.id.clone(),
-            stream: model.capability.stream_flag(),
+            stream: model.capabilities.supports_streaming(),
             think: Self::default_think_for_model(model),
             web_search: false,
         })?)
@@ -861,7 +878,7 @@ impl Provider for OllamaProvider {
                     ProviderModel::new(
                         OllamaProvider.name(),
                         model.name,
-                        ProviderModelCapability::Streaming,
+                        Self::capabilities_from_show(&show),
                     )
                     .with_metadata(json!({
                         "capabilities": show.capabilities,

--- a/app/ai-chat/src/llm/provider/ollama/tests.rs
+++ b/app/ai-chat/src/llm/provider/ollama/tests.rs
@@ -1,7 +1,8 @@
 use super::{
-    ExtSettingControl, OllamaChatMessage, OllamaProvider, OllamaStoredRequest, Provider,
-    ProviderModel, ProviderModelCapability, THINK_HIGH, THINK_KEY, THINK_LOW, THINK_MEDIUM,
-    WEB_SEARCH_KEY, WEB_SEARCH_TOOLTIP_KEY, should_bypass_proxy,
+    ExtSettingControl, ModelCapabilities, OllamaChatMessage, OllamaModelCapabilities,
+    OllamaProvider, OllamaStoredRequest, OllamaThinkingCapability, Provider, ProviderModel,
+    THINK_HIGH, THINK_KEY, THINK_LOW, THINK_MEDIUM, WEB_SEARCH_KEY, WEB_SEARCH_TOOLTIP_KEY,
+    should_bypass_proxy,
 };
 use crate::{database::Role, llm::ExtSettingItem};
 use serde_json::json;
@@ -12,7 +13,43 @@ fn model_with_metadata(
     family: &str,
     families: &[&str],
 ) -> ProviderModel {
-    ProviderModel::new("Ollama", id, ProviderModelCapability::Streaming).with_metadata(json!({
+    let capabilities = capabilities
+        .iter()
+        .map(|capability| (*capability).to_string())
+        .collect::<Vec<_>>();
+    let families = families
+        .iter()
+        .map(|family| (*family).to_string())
+        .collect::<Vec<_>>();
+    let thinking = if capabilities
+        .iter()
+        .any(|capability| capability == "thinking")
+    {
+        let uses_levels = matches!(family, "gptoss" | "gpt-oss")
+            || families
+                .iter()
+                .any(|family| matches!(family.as_str(), "gptoss" | "gpt-oss"));
+        Some(if uses_levels {
+            OllamaThinkingCapability::Levels
+        } else {
+            OllamaThinkingCapability::Boolean
+        })
+    } else {
+        None
+    };
+    let local_web_tools = capabilities.iter().any(|capability| capability == "tools");
+    ProviderModel::new(
+        "Ollama",
+        id,
+        ModelCapabilities::text_streaming().with_ollama_extension(OllamaModelCapabilities {
+            raw_capabilities: capabilities.clone(),
+            family: family.to_string(),
+            families: families.clone(),
+            thinking,
+            local_web_tools,
+        }),
+    )
+    .with_metadata(json!({
         "capabilities": capabilities,
         "family": family,
         "families": families,
@@ -62,6 +99,45 @@ fn ext_settings_use_select_for_gptoss_models() -> anyhow::Result<()> {
     assert_eq!(settings[1].key, WEB_SEARCH_KEY);
     assert_eq!(settings[1].tooltip, Some(WEB_SEARCH_TOOLTIP_KEY));
     assert_eq!(settings[1].control, ExtSettingControl::Boolean(true));
+    Ok(())
+}
+
+#[test]
+fn show_response_maps_to_typed_capabilities() -> anyhow::Result<()> {
+    let show = serde_json::from_value::<super::OllamaShowResponse>(json!({
+        "details": {
+            "family": "gptoss",
+            "families": ["gptoss"]
+        },
+        "capabilities": ["completion", "thinking", "tools"]
+    }))?;
+    let capabilities = OllamaProvider::capabilities_from_show(&show);
+
+    assert!(capabilities.supports_streaming());
+    assert!(capabilities.tool_calling.is_some());
+    let reasoning = capabilities.reasoning.expect("reasoning capability");
+    assert!(reasoning.summaries);
+    assert_eq!(
+        reasoning.efforts,
+        vec![
+            crate::llm::ReasoningEffort::Low,
+            crate::llm::ReasoningEffort::Medium,
+            crate::llm::ReasoningEffort::High,
+        ]
+    );
+    let crate::llm::ProviderCapabilityExtension::Ollama(extension) = capabilities.extension else {
+        panic!("expected Ollama extension");
+    };
+    assert_eq!(extension.thinking, Some(OllamaThinkingCapability::Levels));
+    assert!(extension.local_web_tools);
+    assert_eq!(
+        extension.raw_capabilities,
+        vec![
+            "completion".to_string(),
+            "thinking".to_string(),
+            "tools".to_string(),
+        ]
+    );
     Ok(())
 }
 

--- a/app/ai-chat/src/llm/provider/openai.rs
+++ b/app/ai-chat/src/llm/provider/openai.rs
@@ -1,7 +1,8 @@
 use super::{
-    ExtSettingControl, ExtSettingItem, ExtSettingOption, FetchUpdate, Provider, ProviderModel,
-    ProviderModelCapability, ProviderSettingsFieldKind, ProviderSettingsFieldSpec,
-    ProviderSettingsSpec, normalized_or_default, optional_setting_value,
+    ExtSettingControl, ExtSettingItem, ExtSettingOption, FetchUpdate, ModelCapabilities,
+    OpenAIModelCapabilities, Provider, ProviderModel, ProviderSettingsFieldKind,
+    ProviderSettingsFieldSpec, ProviderSettingsSpec, ReasoningCapability, ReasoningEffort,
+    normalized_or_default, optional_setting_value,
 };
 use crate::{
     database::{Content, UrlCitation},
@@ -339,41 +340,47 @@ enum OpenAIModelFamily {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ReasoningProfile {
-    default_effort: &'static str,
-    options: &'static [&'static str],
+    default_effort: ReasoningEffort,
+    options: &'static [ReasoningEffort],
 }
 
 const REASONING_EFFORT_KEY: &str = "reasoning.effort";
 const REASONING_SUMMARY_AUTO: &str = "auto";
 const REASONING_NONE: &str = "none";
-const REASONING_MINIMAL: &str = "minimal";
 const REASONING_LOW: &str = "low";
 const REASONING_MEDIUM: &str = "medium";
 const REASONING_HIGH: &str = "high";
 const REASONING_XHIGH: &str = "xhigh";
-const O_SERIES_REASONING_OPTIONS: &[&str] = &[REASONING_LOW, REASONING_MEDIUM, REASONING_HIGH];
-const GPT_5_REASONING_OPTIONS: &[&str] = &[
-    REASONING_MINIMAL,
-    REASONING_LOW,
-    REASONING_MEDIUM,
-    REASONING_HIGH,
+const O_SERIES_REASONING_OPTIONS: &[ReasoningEffort] = &[
+    ReasoningEffort::Low,
+    ReasoningEffort::Medium,
+    ReasoningEffort::High,
 ];
-const GPT_5_1_REASONING_OPTIONS: &[&str] = &[
-    REASONING_NONE,
-    REASONING_LOW,
-    REASONING_MEDIUM,
-    REASONING_HIGH,
+const GPT_5_REASONING_OPTIONS: &[ReasoningEffort] = &[
+    ReasoningEffort::Minimal,
+    ReasoningEffort::Low,
+    ReasoningEffort::Medium,
+    ReasoningEffort::High,
 ];
-const GPT_5_2_PLUS_REASONING_OPTIONS: &[&str] = &[
-    REASONING_NONE,
-    REASONING_LOW,
-    REASONING_MEDIUM,
-    REASONING_HIGH,
-    REASONING_XHIGH,
+const GPT_5_1_REASONING_OPTIONS: &[ReasoningEffort] = &[
+    ReasoningEffort::None,
+    ReasoningEffort::Low,
+    ReasoningEffort::Medium,
+    ReasoningEffort::High,
 ];
-const GPT_5_PRO_REASONING_OPTIONS: &[&str] = &[REASONING_HIGH];
-const GPT_5_2_PLUS_PRO_REASONING_OPTIONS: &[&str] =
-    &[REASONING_MEDIUM, REASONING_HIGH, REASONING_XHIGH];
+const GPT_5_2_PLUS_REASONING_OPTIONS: &[ReasoningEffort] = &[
+    ReasoningEffort::None,
+    ReasoningEffort::Low,
+    ReasoningEffort::Medium,
+    ReasoningEffort::High,
+    ReasoningEffort::XHigh,
+];
+const GPT_5_PRO_REASONING_OPTIONS: &[ReasoningEffort] = &[ReasoningEffort::High];
+const GPT_5_2_PLUS_PRO_REASONING_OPTIONS: &[ReasoningEffort] = &[
+    ReasoningEffort::Medium,
+    ReasoningEffort::High,
+    ReasoningEffort::XHigh,
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ParsedOpenAIModel<'a> {
@@ -433,7 +440,7 @@ fn parse_openai_model(input: &str) -> IResult<&str, ParsedOpenAIModel<'_>> {
     ))
 }
 
-fn classify_model(id: &str) -> Option<ProviderModelCapability> {
+fn classify_model(id: &str) -> Option<ModelCapabilities> {
     if id.strip_prefix("ft:").unwrap_or(id).starts_with("fp") {
         return None;
     }
@@ -449,10 +456,25 @@ fn classify_model(id: &str) -> Option<ProviderModelCapability> {
     if parsed.has_date_suffix || has_short_numeric_suffix || has_preview_suffix {
         return None;
     }
-    Some(match parsed.family {
-        OpenAIModelFamily::OSeries => ProviderModelCapability::NonStreaming,
-        OpenAIModelFamily::Gpt | OpenAIModelFamily::ChatGpt => ProviderModelCapability::Streaming,
-    })
+    let mut capabilities = match parsed.family {
+        OpenAIModelFamily::OSeries => ModelCapabilities::text_non_streaming(),
+        OpenAIModelFamily::Gpt | OpenAIModelFamily::ChatGpt => ModelCapabilities::text_streaming(),
+    };
+    capabilities.reasoning =
+        OpenAIProvider::reasoning_profile(id).map(|profile| ReasoningCapability {
+            default_effort: profile.default_effort,
+            efforts: profile.options.to_vec(),
+            summaries: true,
+        });
+    capabilities.structured_output = true;
+    let reasoning_summaries = capabilities.supports_reasoning();
+    capabilities = capabilities.with_openai_extension(OpenAIModelCapabilities {
+        responses_api: true,
+        reasoning_summaries,
+        hosted_web_search: OpenAIProvider::supports_web_search(id),
+        stateful_response_continuation: true,
+    });
+    Some(capabilities)
 }
 
 fn parse_response_stream_event(message: &str) -> AiChatResult<Option<FetchUpdate>> {
@@ -483,15 +505,14 @@ fn parse_response_stream_event(message: &str) -> AiChatResult<Option<FetchUpdate
 }
 
 impl OpenAIProvider {
-    fn reasoning_effort_label_key(effort: &str) -> &'static str {
+    fn reasoning_effort_label_key(effort: ReasoningEffort) -> &'static str {
         match effort {
-            REASONING_NONE => "reasoning-effort-none",
-            REASONING_MINIMAL => "reasoning-effort-minimal",
-            REASONING_LOW => "reasoning-effort-low",
-            REASONING_MEDIUM => "reasoning-effort-medium",
-            REASONING_HIGH => "reasoning-effort-high",
-            REASONING_XHIGH => "reasoning-effort-xhigh",
-            _ => "field-reasoning-effort",
+            ReasoningEffort::None => "reasoning-effort-none",
+            ReasoningEffort::Minimal => "reasoning-effort-minimal",
+            ReasoningEffort::Low => "reasoning-effort-low",
+            ReasoningEffort::Medium => "reasoning-effort-medium",
+            ReasoningEffort::High => "reasoning-effort-high",
+            ReasoningEffort::XHigh => "reasoning-effort-xhigh",
         }
     }
 
@@ -510,7 +531,7 @@ impl OpenAIProvider {
         let parsed = all_consuming(parse_openai_model).parse(model).ok()?.1;
         if parsed.family == OpenAIModelFamily::OSeries {
             return Some(ReasoningProfile {
-                default_effort: REASONING_MEDIUM,
+                default_effort: ReasoningEffort::Medium,
                 options: O_SERIES_REASONING_OPTIONS,
             });
         }
@@ -522,29 +543,29 @@ impl OpenAIProvider {
         if is_pro {
             return Some(if minor >= 2 {
                 ReasoningProfile {
-                    default_effort: REASONING_MEDIUM,
+                    default_effort: ReasoningEffort::Medium,
                     options: GPT_5_2_PLUS_PRO_REASONING_OPTIONS,
                 }
             } else {
                 ReasoningProfile {
-                    default_effort: REASONING_HIGH,
+                    default_effort: ReasoningEffort::High,
                     options: GPT_5_PRO_REASONING_OPTIONS,
                 }
             });
         }
         Some(if minor >= 2 {
             ReasoningProfile {
-                default_effort: REASONING_NONE,
+                default_effort: ReasoningEffort::None,
                 options: GPT_5_2_PLUS_REASONING_OPTIONS,
             }
         } else if minor == 1 {
             ReasoningProfile {
-                default_effort: REASONING_NONE,
+                default_effort: ReasoningEffort::None,
                 options: GPT_5_1_REASONING_OPTIONS,
             }
         } else {
             ReasoningProfile {
-                default_effort: REASONING_MEDIUM,
+                default_effort: ReasoningEffort::Medium,
                 options: GPT_5_REASONING_OPTIONS,
             }
         })
@@ -556,14 +577,12 @@ impl OpenAIProvider {
     ) -> Option<ReasoningConfig> {
         let profile = Self::reasoning_profile(model)?;
         let mut reasoning = reasoning.unwrap_or_else(|| ReasoningConfig {
-            effort: profile.default_effort.to_string(),
+            effort: profile.default_effort.as_str().to_string(),
             summary: None,
         });
-        profile
-            .options
-            .iter()
-            .any(|option| *option == reasoning.effort)
-            .then(|| {
+        ReasoningEffort::from_str(&reasoning.effort)
+            .filter(|effort| profile.options.contains(effort))
+            .map(|_| {
                 reasoning.summary = Some(REASONING_SUMMARY_AUTO.to_string());
                 reasoning
             })
@@ -597,8 +616,11 @@ impl OpenAIProvider {
         }
     }
 
-    fn default_tools(model: &str) -> Option<Vec<HostedTool>> {
-        Self::supports_web_search(model).then(|| vec![Self::web_search_tool()])
+    fn default_tools_for_model(model: &ProviderModel) -> Option<Vec<HostedTool>> {
+        model
+            .capabilities
+            .supports_hosted_web_search()
+            .then(|| vec![Self::web_search_tool()])
     }
 
     fn sanitize_tools(model: &str, tools: Vec<HostedTool>) -> Option<Vec<HostedTool>> {
@@ -659,8 +681,8 @@ impl Provider for OpenAIProvider {
     fn default_template_for_model(&self, model: &ProviderModel) -> AiChatResult<serde_json::Value> {
         Ok(serde_json::to_value(OpenAIRequestTemplate {
             model: model.id.clone(),
-            stream: model.capability.stream_flag(),
-            tools: Self::default_tools(&model.id),
+            stream: model.capabilities.supports_streaming(),
+            tools: Self::default_tools_for_model(model),
             reasoning: None,
         })?)
     }
@@ -748,8 +770,8 @@ impl Provider for OpenAIProvider {
                 .data
                 .into_iter()
                 .filter_map(|model| {
-                    let capability = classify_model(&model.id)?;
-                    ProviderModel::new(OpenAIProvider.name(), model.id.clone(), capability).into()
+                    let capabilities = classify_model(&model.id)?;
+                    ProviderModel::new(OpenAIProvider.name(), model.id.clone(), capabilities).into()
                 })
                 .collect::<Vec<_>>();
             models.sort_by(|left, right| left.id.cmp(&right.id));
@@ -805,12 +827,14 @@ impl Provider for OpenAIProvider {
         model: &ProviderModel,
         template: &serde_json::Value,
     ) -> AiChatResult<Vec<ExtSettingItem>> {
-        let Some(profile) = Self::reasoning_profile(&model.id) else {
+        let Some(reasoning) = model.capabilities.reasoning.as_ref() else {
             return Ok(Vec::new());
         };
         let value = Self::reasoning_effort_from_template(template)
-            .filter(|effort| profile.options.contains(effort))
-            .unwrap_or(profile.default_effort)
+            .and_then(ReasoningEffort::from_str)
+            .filter(|effort| reasoning.supports_effort(*effort))
+            .unwrap_or(reasoning.default_effort)
+            .as_str()
             .to_string();
         Ok(vec![ExtSettingItem {
             key: REASONING_EFFORT_KEY,
@@ -818,12 +842,12 @@ impl Provider for OpenAIProvider {
             tooltip: None,
             control: ExtSettingControl::Select {
                 value,
-                options: profile
-                    .options
+                options: reasoning
+                    .efforts
                     .iter()
                     .copied()
                     .map(|effort| ExtSettingOption {
-                        value: effort,
+                        value: effort.as_str(),
                         label_key: Self::reasoning_effort_label_key(effort),
                     })
                     .collect(),
@@ -848,11 +872,17 @@ impl Provider for OpenAIProvider {
                 "reasoning.effort must use select control".to_string(),
             ));
         };
-        let Some(profile) = Self::reasoning_profile(&model.id) else {
+        let Some(reasoning) = model.capabilities.reasoning.as_ref() else {
             Self::remove_reasoning(template);
             return Ok(());
         };
-        if !profile.options.contains(&value.as_str()) {
+        let Some(effort) = ReasoningEffort::from_str(value) else {
+            return Err(AiChatError::StreamError(format!(
+                "unsupported reasoning.effort '{value}' for model '{}'",
+                model.id
+            )));
+        };
+        if !reasoning.supports_effort(effort) {
             return Err(AiChatError::StreamError(format!(
                 "unsupported reasoning.effort '{value}' for model '{}'",
                 model.id
@@ -863,7 +893,7 @@ impl Provider for OpenAIProvider {
                 "request template must be a JSON object".to_string(),
             ));
         };
-        if value == profile.default_effort {
+        if effort == reasoning.default_effort {
             template_object.remove("reasoning");
             return Ok(());
         }

--- a/app/ai-chat/src/llm/provider/openai/tests.rs
+++ b/app/ai-chat/src/llm/provider/openai/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    ExtSettingControl, HostedTool, OpenAIProvider, OpenAIRequestTemplate, Provider, ProviderModel,
-    ProviderModelCapability, REASONING_EFFORT_KEY, REASONING_HIGH, REASONING_LOW, REASONING_MEDIUM,
-    REASONING_NONE, REASONING_SUMMARY_AUTO, REASONING_XHIGH, ReasoningConfig,
+    ExtSettingControl, HostedTool, ModelCapabilities, OpenAIProvider, OpenAIRequestTemplate,
+    Provider, ProviderModel, REASONING_EFFORT_KEY, REASONING_HIGH, REASONING_LOW, REASONING_MEDIUM,
+    REASONING_NONE, REASONING_SUMMARY_AUTO, REASONING_XHIGH, ReasoningConfig, ReasoningEffort,
     ResponsesCreateResponse, classify_model, normalize_base_url, parse_response_stream_event,
 };
 use crate::{
@@ -9,6 +9,14 @@ use crate::{
     llm::{ExtSettingOption, FetchUpdate},
 };
 use serde_json::json;
+
+fn openai_model(id: &str) -> ProviderModel {
+    ProviderModel::new(
+        "OpenAI",
+        id,
+        classify_model(id).unwrap_or_else(ModelCapabilities::text_streaming),
+    )
+}
 
 #[test]
 fn normalize_base_url_strips_terminal_api_paths() {
@@ -37,7 +45,7 @@ fn openai_provider_requires_non_empty_api_key() {
 
 #[test]
 fn default_template_uses_model_stream_capability() -> anyhow::Result<()> {
-    let model = ProviderModel::new("OpenAI", "gpt-5", ProviderModelCapability::Streaming);
+    let model = openai_model("gpt-5");
     let template = serde_json::from_value::<OpenAIRequestTemplate>(
         OpenAIProvider.default_template_for_model(&model)?,
     )?;
@@ -54,7 +62,7 @@ fn default_template_uses_model_stream_capability() -> anyhow::Result<()> {
 
 #[test]
 fn unsupported_models_default_to_no_tools() -> anyhow::Result<()> {
-    let model = ProviderModel::new("OpenAI", "gpt-4o", ProviderModelCapability::Streaming);
+    let model = openai_model("gpt-4o");
     let template = serde_json::from_value::<OpenAIRequestTemplate>(
         OpenAIProvider.default_template_for_model(&model)?,
     )?;
@@ -64,7 +72,7 @@ fn unsupported_models_default_to_no_tools() -> anyhow::Result<()> {
 
 #[test]
 fn default_template_contains_only_runtime_fields() -> anyhow::Result<()> {
-    let model = ProviderModel::new("OpenAI", "gpt-4o", ProviderModelCapability::Streaming);
+    let model = openai_model("gpt-4o");
     let template = OpenAIProvider.default_template_for_model(&model)?;
     let object = template.as_object().expect("template object");
     assert_eq!(object.len(), 2);
@@ -75,26 +83,39 @@ fn default_template_contains_only_runtime_fields() -> anyhow::Result<()> {
 
 #[test]
 fn classify_model_marks_o_series_as_non_streaming() {
-    assert_eq!(
-        classify_model("o3-mini"),
-        Some(ProviderModelCapability::NonStreaming)
-    );
-    assert_eq!(
-        classify_model("o4-mini"),
-        Some(ProviderModelCapability::NonStreaming)
-    );
+    assert!(!classify_model("o3-mini").unwrap().supports_streaming());
+    assert!(!classify_model("o4-mini").unwrap().supports_streaming());
 }
 
 #[test]
 fn classify_model_marks_gpt_series_as_streaming() {
-    assert_eq!(
-        classify_model("gpt-5"),
-        Some(ProviderModelCapability::Streaming)
+    assert!(classify_model("gpt-5").unwrap().supports_streaming());
+    assert!(
+        classify_model("chatgpt-4o-latest")
+            .unwrap()
+            .supports_streaming()
     );
+}
+
+#[test]
+fn classify_model_exposes_openai_typed_capabilities() {
+    let capabilities = classify_model("gpt-5.2-pro").expect("classified model");
+    assert!(capabilities.supports_streaming());
+    assert!(capabilities.supports_hosted_web_search());
+    assert!(capabilities.structured_output);
+    assert!(capabilities.stateful_response_continuation);
+
+    let reasoning = capabilities.reasoning.expect("reasoning capability");
+    assert_eq!(reasoning.default_effort, ReasoningEffort::Medium);
     assert_eq!(
-        classify_model("chatgpt-4o-latest"),
-        Some(ProviderModelCapability::Streaming)
+        reasoning.efforts,
+        vec![
+            ReasoningEffort::Medium,
+            ReasoningEffort::High,
+            ReasoningEffort::XHigh,
+        ]
     );
+    assert!(reasoning.summaries);
 }
 
 #[test]
@@ -135,7 +156,7 @@ fn request_body_omits_web_search_for_unsupported_models() -> anyhow::Result<()> 
 
 #[test]
 fn ext_settings_omit_reasoning_for_unsupported_models() -> anyhow::Result<()> {
-    let model = ProviderModel::new("OpenAI", "gpt-4o", ProviderModelCapability::Streaming);
+    let model = openai_model("gpt-4o");
     let settings = OpenAIProvider.ext_settings(&model, &json!({}))?;
     assert!(settings.is_empty());
     Ok(())
@@ -143,7 +164,7 @@ fn ext_settings_omit_reasoning_for_unsupported_models() -> anyhow::Result<()> {
 
 #[test]
 fn ext_settings_use_medium_default_for_gpt_5_2_pro() -> anyhow::Result<()> {
-    let model = ProviderModel::new("OpenAI", "gpt-5.2-pro", ProviderModelCapability::Streaming);
+    let model = openai_model("gpt-5.2-pro");
     let settings = OpenAIProvider.ext_settings(&model, &json!({}))?;
     assert_eq!(settings.len(), 1);
     assert_eq!(settings[0].key, REASONING_EFFORT_KEY);
@@ -172,7 +193,7 @@ fn ext_settings_use_medium_default_for_gpt_5_2_pro() -> anyhow::Result<()> {
 
 #[test]
 fn ext_settings_use_none_default_for_gpt_5_1() -> anyhow::Result<()> {
-    let model = ProviderModel::new("OpenAI", "gpt-5.1", ProviderModelCapability::Streaming);
+    let model = openai_model("gpt-5.1");
     let settings = OpenAIProvider.ext_settings(&model, &json!({}))?;
     assert_eq!(
         settings[0].control,
@@ -203,7 +224,7 @@ fn ext_settings_use_none_default_for_gpt_5_1() -> anyhow::Result<()> {
 
 #[test]
 fn ext_settings_use_high_only_for_gpt_5_pro() -> anyhow::Result<()> {
-    let model = ProviderModel::new("OpenAI", "gpt-5-pro", ProviderModelCapability::Streaming);
+    let model = openai_model("gpt-5-pro");
     let settings = OpenAIProvider.ext_settings(&model, &json!({}))?;
     assert_eq!(
         settings[0].control,
@@ -220,7 +241,7 @@ fn ext_settings_use_high_only_for_gpt_5_pro() -> anyhow::Result<()> {
 
 #[test]
 fn apply_ext_setting_removes_default_reasoning() -> anyhow::Result<()> {
-    let model = ProviderModel::new("OpenAI", "gpt-5.2-pro", ProviderModelCapability::Streaming);
+    let model = openai_model("gpt-5.2-pro");
     let mut template = OpenAIProvider.default_template_for_model(&model)?;
     OpenAIProvider.apply_ext_setting(
         &model,
@@ -241,7 +262,7 @@ fn apply_ext_setting_removes_default_reasoning() -> anyhow::Result<()> {
 
 #[test]
 fn apply_ext_setting_writes_non_default_reasoning() -> anyhow::Result<()> {
-    let model = ProviderModel::new("OpenAI", "gpt-5.2-pro", ProviderModelCapability::Streaming);
+    let model = openai_model("gpt-5.2-pro");
     let mut template = OpenAIProvider.default_template_for_model(&model)?;
     OpenAIProvider.apply_ext_setting(
         &model,
@@ -268,7 +289,7 @@ fn apply_ext_setting_writes_non_default_reasoning() -> anyhow::Result<()> {
 
 #[test]
 fn apply_ext_setting_rejects_unsupported_reasoning_values() {
-    let model = ProviderModel::new("OpenAI", "gpt-5.2-pro", ProviderModelCapability::Streaming);
+    let model = openai_model("gpt-5.2-pro");
     let mut template = json!({});
     let err = OpenAIProvider
         .apply_ext_setting(

--- a/app/ai-chat/src/state/chat/models.rs
+++ b/app/ai-chat/src/state/chat/models.rs
@@ -271,13 +271,13 @@ fn merge_models(previous: &[ProviderModel], batch: &AvailableModelsBatch) -> Vec
 mod tests {
     use super::{ModelStoreState, merge_models};
     use crate::llm::{
-        AvailableModelsBatch, ProviderModel, ProviderModelCapability, ProviderModelsFailure,
+        AvailableModelsBatch, ModelCapabilities, ProviderModel, ProviderModelsFailure,
         ProviderModelsSuccess,
     };
     use gpui::Task;
 
     fn model(provider: &str, id: &str) -> ProviderModel {
-        ProviderModel::new(provider, id, ProviderModelCapability::Streaming)
+        ProviderModel::new(provider, id, ModelCapabilities::text_streaming())
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Added provider-neutral typed model capabilities for `ai-chat`.
- Affected app: `ai-chat`.

## Motivation

- Addresses #138 as the first child issue under #137.
- Replaces the streaming-only model capability enum with Rust types that can represent provider/model feature differences without making OpenAI Responses the core abstraction.

## Changes

- Replaced `ProviderModelCapability` with `ModelCapabilities` and re-exported the new capability vocabulary for later LLM abstraction stages.
- Added typed reasoning, tool-calling, input modality, stateful continuation, and provider extension capability structures.
- Migrated OpenAI model classification to populate typed capabilities for reasoning efforts, hosted web search, structured output, and stateful Responses support.
- Migrated Ollama `/api/show` metadata into typed `OllamaModelCapabilities` for raw capabilities, family data, thinking mode, and local web tools.
- Updated provider ext-setting/template replay tests and the issue #137 coordination document.
- No database schema, message item, provider runtime, or request execution changes are included.

## Validation

- [ ] `cargo build`
- [ ] `cargo test`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
cargo fmt
cargo test -p ai-chat llm::provider
cargo test -p ai-chat llm::preset
cargo test -p ai-chat state::chat::models
cargo test -p ai-chat components::chat_form::model_select
cargo test -p ai-chat features::settings::shortcut_settings

All focused checks passed.

Full cargo build, full cargo test, clippy, and manual UI verification were not run for this typed model capability refactor.
```

## Risks

- OpenAI and Ollama request execution should remain unchanged, but capability metadata now flows through typed model structures instead of the old enum and ad hoc metadata checks.
- Later child issues still need to add typed message/items, provider runtime events, persistence, provider migrations, and UI capability gating.

## Related Issues

- Closes #138
- Related to #137
