### PR TITLE
[tech] ai-chat: add provider run events

### DIFF
--- a/app/ai-chat/docs/dev/issue-137-llm-abstractions.md
+++ b/app/ai-chat/docs/dev/issue-137-llm-abstractions.md
@@ -19,7 +19,7 @@ Delete it before the final merge to `main`, unless the remaining content is prom
 | #137 | `codex/issue-137-llm-abstractions` | Parent integration work | Active |
 | #138 | `codex/issue-138-model-capabilities` | Provider-neutral model capability types | Merged to integration via PR #147; GitHub issue still open |
 | #142 | `codex/issue-142-llm-items` | Typed input, content, and output items | Merged to integration via PR #148; GitHub issue still open |
-| #139 | `codex/issue-139-provider-runtime` | Run-based provider trait and events | Pending |
+| #139 | `codex/issue-139-provider-runtime` | Run-based provider trait and events | Implemented on child branch; not merged to integration |
 | #141 | `codex/issue-141-llm-persistence` | Run state, output items, tools, attachments persistence | Pending |
 | #143 | `codex/issue-143-openai-responses-abstraction` | OpenAI Responses migration on shared abstraction | Pending |
 | #144 | `codex/issue-144-ollama-shared-abstraction` | Ollama migration on shared abstraction | Pending |
@@ -32,7 +32,8 @@ Last synchronized: 2026-05-20.
 - #137 remains open and is the parent tracking issue. Its comments record the child issue list and the integration branch/document workflow.
 - #138 remains open on GitHub, but PR #147 merged `codex/issue-138-model-capabilities` into `codex/issue-137-llm-abstractions`.
 - #142 remains open on GitHub, but PR #148 merged `codex/issue-142-llm-items` into `codex/issue-137-llm-abstractions`.
-- #139, #141, #143, #144, and #140 remain open and pending behind the typed item model.
+- #139 remains open on GitHub. The local child branch `codex/issue-139-provider-runtime` has implemented the first-stage runtime abstraction and still needs review/merge into the integration branch.
+- #141, #143, #144, and #140 remain open and pending behind the typed item and run/event model.
 
 ## Current Architecture Facts
 
@@ -44,8 +45,10 @@ Last synchronized: 2026-05-20.
 - `ModelCapabilities` covers text input/output, streaming, image/file/audio input, image generation, tool calling, hosted web search, remote MCP, reasoning, structured output, stateful response continuation, and provider-specific typed extensions.
 - OpenAI model classification now emits typed capabilities for Responses API usage, reasoning effort options, hosted web search, structured output, and stateful response continuation.
 - Ollama `/api/show` metadata now maps into typed capabilities and an `OllamaModelCapabilities` extension for raw capabilities, family data, thinking mode, and local web tools.
-- `Provider` currently builds provider request JSON from typed input items and fetches a single response stream.
-- `FetchUpdate` currently only covers thinking start, reasoning summary delta, text delta, and complete content.
+- `Provider` now builds `ProviderRunRequest` values from typed input items and streams provider-neutral `ProviderRunEvent` values.
+- `ProviderRunRequest` keeps the provider request JSON snapshot so existing `messages.send_content` resend behavior remains compatible.
+- `ProviderRunEvent` replaces `FetchUpdate` and covers thinking start, reasoning summary delta, text delta, output item added/done, tool call/result, MCP approval request, usage update, completed, and failed states.
+- `ProviderRunState` and `ProviderUsage` are available for provider response/run metadata, output item ids, continuation metadata, and token usage, but database persistence remains a follow-up.
 - `messages.content` stores rendered message content; `messages.send_content` stores the request body snapshot used for resend.
 - OpenAI already uses `/v1/responses`, reasoning effort, reasoning summaries, and hosted web search citations.
 - Ollama has provider-specific thinking and experimental web search/fetch behavior that must not be forced into OpenAI-shaped types.
@@ -74,6 +77,17 @@ Issue #138 established these Rust capability types:
 - `OllamaThinkingCapability`
 
 The current implementation keeps request execution behavior unchanged: OpenAI and Ollama still produce the same provider request JSON shape, but capability gating inside provider/template code now reads typed model capabilities instead of ad hoc JSON metadata or streaming-only enum state.
+
+## Implemented Runtime Vocabulary
+
+Issue #139 established these Rust runtime types:
+
+- `ProviderRunRequest`
+- `ProviderRunEvent`
+- `ProviderRunState`
+- `ProviderUsage`
+
+The current implementation keeps request persistence additive: existing provider request JSON remains the compatibility snapshot for `messages.send_content`, while new runtime code uses `ProviderRunRequest` and `ProviderRunEvent` internally. OpenAI and Ollama still own their own wire/request conversion inside provider adapters.
 
 ## Provider Extension Rules
 
@@ -132,8 +146,29 @@ The current implementation keeps request execution behavior unchanged: OpenAI an
   - `cargo test -p ai-chat features::home::tabs::conversation_panel`
   - `cargo test -p ai-chat features::temporary::detail`
 
+### #139 Run-Based Provider Trait And Events
+
+- Replaced the old `FetchUpdate` stream path with provider-neutral `ProviderRunEvent`.
+- Added `ProviderRunRequest`, `ProviderRunState`, and `ProviderUsage` as the first-stage runtime abstraction.
+- Changed the `Provider` trait to build run requests with `build_run_request` and execute them with `run`.
+- Kept `Provider::request_body` as a compatibility helper for persisted `messages.send_content` snapshots.
+- Migrated conversation panel and temporary detail streaming consumers to `ProviderRunRunner`.
+- Migrated OpenAI Responses stream parsing into provider-neutral events without exposing OpenAI event names in the core runtime.
+- Added OpenAI parser coverage for completed, failed, incomplete, and top-level error events.
+- Migrated Ollama chat streaming to the same run event vocabulary while keeping its experimental web search/fetch loop provider-local.
+- Left generic app-level tool execution, MCP approval UI, and run-state database persistence to #141, #143, #144, and #140.
+- Validation run:
+  - `cargo fmt`
+  - `cargo test -p ai-chat llm::types`
+  - `cargo test -p ai-chat llm::provider`
+  - `cargo test -p ai-chat llm::provider::openai`
+  - `cargo test -p ai-chat llm::provider::ollama`
+  - `cargo test -p ai-chat features::home::tabs::conversation_panel`
+  - `cargo test -p ai-chat features::temporary::detail`
+  - `cargo clippy -p ai-chat --all-targets --all-features -- -D warnings`
+
 ## Next Child Issue Constraints
 
-Next child issue is #139.
+Next child issue after #139 is merged is #141.
 
-#139 should build on the typed item model and introduce run-based provider events without pushing OpenAI Responses event names into the core runtime. It should preserve the #142 adapter boundary: generic code owns provider-neutral input/output items, while OpenAI and Ollama keep their own wire/event conversion.
+#141 should persist the runtime state introduced by #139 without breaking old conversations. It should preserve `messages.content` and `messages.send_content` compatibility, add storage for provider run state/output items/tool calls/attachments as additive data, and avoid storing binary attachment data directly inside message text.

--- a/app/ai-chat/src/components/chat_form/model_select.rs
+++ b/app/ai-chat/src/components/chat_form/model_select.rs
@@ -22,6 +22,7 @@ use model_picker::{ModelOption, model_sections};
 use std::ops::Deref;
 
 #[derive(Clone)]
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum ModelSelectEvent {
     Change(Option<ProviderModel>),
     ModelsChanged,

--- a/app/ai-chat/src/features/home/tabs/conversation_panel.rs
+++ b/app/ai-chat/src/features/home/tabs/conversation_panel.rs
@@ -12,7 +12,10 @@ use crate::{
     features::home::conversation_export_menu,
     foundation::assets::IconName,
     foundation::i18n::I18n,
-    llm::{FetchRunner, FetchUpdate, LlmHistoryMessage, build_input_items, provider_by_name},
+    llm::{
+        LlmHistoryMessage, ProviderRunEvent, ProviderRunRequest, ProviderRunRunner,
+        build_input_items, provider_by_name,
+    },
     platform::gpui_ext::{AsyncWindowContextResultExt, EntityResultExt, WeakEntityResultExt},
     state::{
         AiChatConfig, ChatData, ChatDataEvent, ChatDataInner, ConversationDraft, WorkspaceStore,
@@ -544,12 +547,13 @@ impl ConversationPanelView {
                 provider.name().to_string(),
             ))?
             .clone();
-        let stream =
-            provider.fetch_by_request_body(context.config, settings, &context.request_body);
+        let request =
+            ProviderRunRequest::from_request_body(provider.name(), context.request_body.clone());
+        let stream = provider.run(context.config, settings, &request);
         pin_mut!(stream);
         while let Some(message) = stream.next().await {
             match message {
-                Ok(FetchUpdate::ThinkingStarted) => {
+                Ok(ProviderRunEvent::ThinkingStarted) => {
                     Self::set_assistant_message_status_by_id(
                         &context.chat_data,
                         context.conversation_id,
@@ -558,7 +562,7 @@ impl ConversationPanelView {
                         cx,
                     )?;
                 }
-                Ok(FetchUpdate::ReasoningSummaryDelta(delta)) => {
+                Ok(ProviderRunEvent::ReasoningSummaryDelta(delta)) => {
                     Self::append_assistant_reasoning_summary_by_id(
                         &context.chat_data,
                         context.conversation_id,
@@ -567,7 +571,7 @@ impl ConversationPanelView {
                         cx,
                     )?;
                 }
-                Ok(FetchUpdate::TextDelta(delta)) => {
+                Ok(ProviderRunEvent::TextDelta(delta)) => {
                     Self::append_assistant_message_by_id(
                         &context.chat_data,
                         context.conversation_id,
@@ -576,7 +580,7 @@ impl ConversationPanelView {
                         cx,
                     )?;
                 }
-                Ok(FetchUpdate::Complete(content)) => {
+                Ok(ProviderRunEvent::Completed { content, .. }) => {
                     Self::replace_assistant_message_content_by_id(
                         &context.chat_data,
                         context.conversation_id,
@@ -584,6 +588,25 @@ impl ConversationPanelView {
                         content,
                         cx,
                     )?;
+                }
+                Ok(
+                    ProviderRunEvent::OutputItemAdded(_)
+                    | ProviderRunEvent::OutputItemDone(_)
+                    | ProviderRunEvent::ToolCallRequested(_)
+                    | ProviderRunEvent::ToolResultReceived(_)
+                    | ProviderRunEvent::McpApprovalRequested(_)
+                    | ProviderRunEvent::UsageUpdated(_),
+                ) => {}
+                Ok(ProviderRunEvent::Failed { message }) => {
+                    Self::record_stream_error(
+                        state,
+                        &context.chat_data,
+                        context.conversation_id,
+                        assistant_message_id,
+                        message,
+                        cx,
+                    )?;
+                    return Ok(());
                 }
                 Err(error) => {
                     event!(Level::ERROR, "Connection Error: {}", error);
@@ -687,7 +710,7 @@ impl ConversationPanelView {
         let template = context.composer_snapshot.request_template.clone();
         let prompts = context.composer_snapshot.prompts.clone();
         let mode = context.composer_snapshot.mode;
-        let request_body = build_request_body(
+        let run_request = build_run_request(
             &provider_name,
             &template,
             prompts,
@@ -699,7 +722,7 @@ impl ConversationPanelView {
         Ok(Runner {
             config: context.config.clone(),
             provider_name,
-            request_body,
+            run_request,
         })
     }
 
@@ -732,11 +755,11 @@ impl ConversationPanelView {
         assistant_message_id: i32,
         cx: &mut AsyncWindowContext,
     ) -> AiChatResult<()> {
-        let stream = runner.fetch();
+        let stream = runner.run();
         pin_mut!(stream);
         while let Some(message) = stream.next().await {
             match message {
-                Ok(FetchUpdate::ThinkingStarted) => {
+                Ok(ProviderRunEvent::ThinkingStarted) => {
                     Self::set_assistant_message_status(
                         context,
                         assistant_message_id,
@@ -744,7 +767,7 @@ impl ConversationPanelView {
                         cx,
                     )?;
                 }
-                Ok(FetchUpdate::ReasoningSummaryDelta(delta)) => {
+                Ok(ProviderRunEvent::ReasoningSummaryDelta(delta)) => {
                     Self::append_assistant_reasoning_summary(
                         context,
                         assistant_message_id,
@@ -752,16 +775,35 @@ impl ConversationPanelView {
                         cx,
                     )?;
                 }
-                Ok(FetchUpdate::TextDelta(delta)) => {
+                Ok(ProviderRunEvent::TextDelta(delta)) => {
                     Self::append_assistant_message(context, assistant_message_id, delta, cx)?;
                 }
-                Ok(FetchUpdate::Complete(content)) => {
+                Ok(ProviderRunEvent::Completed { content, .. }) => {
                     Self::replace_assistant_message_content(
                         context,
                         assistant_message_id,
                         content,
                         cx,
                     )?;
+                }
+                Ok(
+                    ProviderRunEvent::OutputItemAdded(_)
+                    | ProviderRunEvent::OutputItemDone(_)
+                    | ProviderRunEvent::ToolCallRequested(_)
+                    | ProviderRunEvent::ToolResultReceived(_)
+                    | ProviderRunEvent::McpApprovalRequested(_)
+                    | ProviderRunEvent::UsageUpdated(_),
+                ) => {}
+                Ok(ProviderRunEvent::Failed { message }) => {
+                    Self::record_stream_error(
+                        state,
+                        &context.chat_data,
+                        context.conversation_id,
+                        assistant_message_id,
+                        message,
+                        cx,
+                    )?;
+                    return Ok(());
                 }
                 Err(error) => {
                     event!(Level::ERROR, "Connection Error: {}", error);
@@ -1094,10 +1136,10 @@ struct ExistingMessageFetchContext {
 struct Runner {
     config: AiChatConfig,
     provider_name: String,
-    request_body: serde_json::Value,
+    run_request: ProviderRunRequest,
 }
 
-impl FetchRunner for Runner {
+impl ProviderRunRunner for Runner {
     fn get_provider(&self) -> &str {
         &self.provider_name
     }
@@ -1106,8 +1148,8 @@ impl FetchRunner for Runner {
         &self.config
     }
 
-    fn request_body(&self) -> &serde_json::Value {
-        &self.request_body
+    fn run_request(&self) -> &ProviderRunRequest {
+        &self.run_request
     }
 }
 
@@ -1130,6 +1172,26 @@ fn build_history_messages(
     )
 }
 
+fn build_run_request(
+    provider_name: &str,
+    template: &serde_json::Value,
+    prompts: Vec<crate::database::ConversationTemplatePrompt>,
+    mode: Mode,
+    history_messages: &[Message],
+    user_message_role: Role,
+    user_message_content: &str,
+) -> AiChatResult<ProviderRunRequest> {
+    let history = build_history_messages(
+        prompts,
+        mode,
+        history_messages,
+        user_message_role,
+        user_message_content,
+    );
+    provider_by_name(provider_name)?.build_run_request(template, history)
+}
+
+#[cfg(test)]
 fn build_request_body(
     provider_name: &str,
     template: &serde_json::Value,
@@ -1139,14 +1201,16 @@ fn build_request_body(
     user_message_role: Role,
     user_message_content: &str,
 ) -> AiChatResult<serde_json::Value> {
-    let history = build_history_messages(
+    Ok(build_run_request(
+        provider_name,
+        template,
         prompts,
         mode,
         history_messages,
         user_message_role,
         user_message_content,
-    );
-    provider_by_name(provider_name)?.request_body(template, history)
+    )?
+    .request_body)
 }
 
 #[cfg(test)]

--- a/app/ai-chat/src/features/temporary/detail.rs
+++ b/app/ai-chat/src/features/temporary/detail.rs
@@ -21,7 +21,10 @@ use crate::{
         temporary::TemporaryView,
     },
     foundation::i18n::I18n,
-    llm::{FetchRunner, FetchUpdate, LlmHistoryMessage, build_input_items, provider_by_name},
+    llm::{
+        LlmHistoryMessage, ProviderRunEvent, ProviderRunRequest, ProviderRunRunner,
+        build_input_items, provider_by_name,
+    },
     platform::gpui_ext::WeakEntityResultExt,
     state::{AddConversationMessage, AiChatConfig, ChatData},
 };
@@ -835,7 +838,7 @@ impl TemplateDetailView {
             content.send_content().to_string(),
             cx,
         )?;
-        let send_content = runner.request_body.clone();
+        let send_content = Rc::new(runner.request_body().clone());
         let assistant_message_id = state.update_in_result(cx, |this, window, cx| {
             this.chat_form
                 .update(cx, |chat_form, cx| chat_form.clear_input(window, cx));
@@ -879,7 +882,7 @@ impl TemplateDetailView {
         cx: &mut AsyncWindowContext,
     ) -> AiChatResult<Runner> {
         state.read_with_result(cx, |this, _cx| {
-            let request_body = build_request_body(
+            let run_request = build_run_request(
                 &composer_snapshot.provider_name,
                 &composer_snapshot.request_template,
                 &composer_snapshot.prompts,
@@ -891,7 +894,7 @@ impl TemplateDetailView {
             Ok(Runner {
                 config,
                 provider_name: composer_snapshot.provider_name.clone(),
-                request_body: Rc::new(request_body),
+                run_request: Rc::new(run_request),
             })
         })?
     }
@@ -905,29 +908,43 @@ impl TemplateDetailView {
         assistant_message_id: usize,
         cx: &mut AsyncWindowContext,
     ) -> AiChatResult<()> {
-        let stream = runner.fetch();
+        let stream = runner.run();
         pin_mut!(stream);
         while let Some(message) = stream.next().await {
             match message {
-                Ok(FetchUpdate::ThinkingStarted) => {
+                Ok(ProviderRunEvent::ThinkingStarted) => {
                     state.update_result(cx, |this, _cx| {
                         this.on_thinking(assistant_message_id);
                     })?;
                 }
-                Ok(FetchUpdate::ReasoningSummaryDelta(delta)) => {
+                Ok(ProviderRunEvent::ReasoningSummaryDelta(delta)) => {
                     state.update_result(cx, |this, _cx| {
                         this.on_reasoning_summary(&delta, assistant_message_id);
                     })?;
                 }
-                Ok(FetchUpdate::TextDelta(message)) => {
+                Ok(ProviderRunEvent::TextDelta(message)) => {
                     state.update_result(cx, |this, _cx| {
                         this.on_message(&message, assistant_message_id);
                     })?;
                 }
-                Ok(FetchUpdate::Complete(content)) => {
+                Ok(ProviderRunEvent::Completed { content, .. }) => {
                     state.update_result(cx, |this, _cx| {
                         this.on_complete_content(content, assistant_message_id);
                     })?;
+                }
+                Ok(
+                    ProviderRunEvent::OutputItemAdded(_)
+                    | ProviderRunEvent::OutputItemDone(_)
+                    | ProviderRunEvent::ToolCallRequested(_)
+                    | ProviderRunEvent::ToolResultReceived(_)
+                    | ProviderRunEvent::McpApprovalRequested(_)
+                    | ProviderRunEvent::UsageUpdated(_),
+                ) => {}
+                Ok(ProviderRunEvent::Failed { message }) => {
+                    state.update_result(cx, |this, cx| {
+                        this.on_error(assistant_message_id, message, cx);
+                    })?;
+                    return Ok(());
                 }
                 Err(error) => {
                     event!(Level::ERROR, "Connection Error: {}", error);
@@ -959,29 +976,45 @@ impl TemplateDetailView {
                 provider.name().to_string(),
             ))?
             .clone();
-        let stream = provider.fetch_by_request_body(config, settings, request_body.as_ref());
+        let request =
+            ProviderRunRequest::from_request_body(provider.name(), request_body.as_ref().clone());
+        let stream = provider.run(config, settings, &request);
         pin_mut!(stream);
         while let Some(message) = stream.next().await {
             match message {
-                Ok(FetchUpdate::ThinkingStarted) => {
+                Ok(ProviderRunEvent::ThinkingStarted) => {
                     state.update_result(cx, |this, _cx| {
                         this.on_thinking(assistant_message_id);
                     })?;
                 }
-                Ok(FetchUpdate::ReasoningSummaryDelta(delta)) => {
+                Ok(ProviderRunEvent::ReasoningSummaryDelta(delta)) => {
                     state.update_result(cx, |this, _cx| {
                         this.on_reasoning_summary(&delta, assistant_message_id);
                     })?;
                 }
-                Ok(FetchUpdate::TextDelta(message)) => {
+                Ok(ProviderRunEvent::TextDelta(message)) => {
                     state.update_result(cx, |this, _cx| {
                         this.on_message(&message, assistant_message_id);
                     })?;
                 }
-                Ok(FetchUpdate::Complete(content)) => {
+                Ok(ProviderRunEvent::Completed { content, .. }) => {
                     state.update_result(cx, |this, _cx| {
                         this.on_complete_content(content, assistant_message_id);
                     })?;
+                }
+                Ok(
+                    ProviderRunEvent::OutputItemAdded(_)
+                    | ProviderRunEvent::OutputItemDone(_)
+                    | ProviderRunEvent::ToolCallRequested(_)
+                    | ProviderRunEvent::ToolResultReceived(_)
+                    | ProviderRunEvent::McpApprovalRequested(_)
+                    | ProviderRunEvent::UsageUpdated(_),
+                ) => {}
+                Ok(ProviderRunEvent::Failed { message }) => {
+                    state.update_result(cx, |this, cx| {
+                        this.on_error(assistant_message_id, message, cx);
+                    })?;
+                    return Ok(());
                 }
                 Err(error) => {
                     event!(Level::ERROR, "Connection Error: {}", error);
@@ -1013,10 +1046,10 @@ struct TemporaryFetchContext {
 struct Runner {
     config: AiChatConfig,
     provider_name: String,
-    request_body: Rc<serde_json::Value>,
+    run_request: Rc<ProviderRunRequest>,
 }
 
-impl FetchRunner for Runner {
+impl ProviderRunRunner for Runner {
     fn get_provider(&self) -> &str {
         &self.provider_name
     }
@@ -1025,8 +1058,8 @@ impl FetchRunner for Runner {
         &self.config
     }
 
-    fn request_body(&self) -> &serde_json::Value {
-        self.request_body.as_ref()
+    fn run_request(&self) -> &ProviderRunRequest {
+        self.run_request.as_ref()
     }
 }
 
@@ -1049,6 +1082,26 @@ fn build_history_messages(
     )
 }
 
+fn build_run_request(
+    provider_name: &str,
+    template: &serde_json::Value,
+    prompts: &[crate::database::ConversationTemplatePrompt],
+    mode: Mode,
+    messages: &[TemporaryMessage],
+    user_message_role: Role,
+    user_message_content: &str,
+) -> AiChatResult<ProviderRunRequest> {
+    let history = build_history_messages(
+        prompts,
+        mode,
+        messages,
+        user_message_role,
+        user_message_content,
+    );
+    provider_by_name(provider_name)?.build_run_request(template, history)
+}
+
+#[cfg(test)]
 fn build_request_body(
     provider_name: &str,
     template: &serde_json::Value,
@@ -1058,14 +1111,16 @@ fn build_request_body(
     user_message_role: Role,
     user_message_content: &str,
 ) -> AiChatResult<serde_json::Value> {
-    let history = build_history_messages(
+    Ok(build_run_request(
+        provider_name,
+        template,
         prompts,
         mode,
         messages,
         user_message_role,
         user_message_content,
-    );
-    provider_by_name(provider_name)?.request_body(template, history)
+    )?
+    .request_body)
 }
 
 #[cfg(test)]

--- a/app/ai-chat/src/llm.rs
+++ b/app/ai-chat/src/llm.rs
@@ -8,19 +8,20 @@ pub(crate) use preset::{
 };
 #[cfg(test)]
 pub(crate) use provider::ProviderModelsSuccess;
+#[allow(unused_imports)]
 pub(crate) use provider::{
-    AvailableModelsBatch, ExtSettingControl, ExtSettingItem, ExtSettingOption, FetchUpdate,
-    ModelCapabilities, OllamaModelCapabilities, OllamaProvider, OllamaSettings,
-    OllamaThinkingCapability, OpenAIModelCapabilities, OpenAIProvider, OpenAISettings, Provider,
-    ProviderCapabilityExtension, ProviderModel, ProviderModelsFailure, ProviderSettingsFieldKind,
-    ProviderSettingsFieldSpec, ProviderSettingsSpec, ReasoningCapability, ReasoningEffort,
-    available_models, provider_by_name, provider_is_configured, provider_names,
-    provider_settings_specs,
+    AvailableModelsBatch, ExtSettingControl, ExtSettingItem, ExtSettingOption, ModelCapabilities,
+    OllamaModelCapabilities, OllamaProvider, OllamaSettings, OllamaThinkingCapability,
+    OpenAIModelCapabilities, OpenAIProvider, OpenAISettings, Provider, ProviderCapabilityExtension,
+    ProviderModel, ProviderModelsFailure, ProviderSettingsFieldKind, ProviderSettingsFieldSpec,
+    ProviderSettingsSpec, ReasoningCapability, ReasoningEffort, available_models, provider_by_name,
+    provider_is_configured, provider_names, provider_settings_specs,
 };
-pub(crate) use runner::FetchRunner;
+pub(crate) use runner::ProviderRunRunner;
 // Re-export the full provider-neutral item vocabulary for staged follow-up issues.
 #[allow(unused_imports)]
 pub(crate) use types::{
     LlmAttachmentRef, LlmContentPart, LlmHistoryMessage, LlmHostedToolCall, LlmInputItem,
-    LlmMcpApprovalRequest, LlmOutputItem, LlmToolCall, LlmToolResult, build_input_items,
+    LlmMcpApprovalRequest, LlmOutputItem, LlmToolCall, LlmToolResult, ProviderRunEvent,
+    ProviderRunRequest, ProviderRunState, ProviderUsage, build_input_items,
 };

--- a/app/ai-chat/src/llm/preset.rs
+++ b/app/ai-chat/src/llm/preset.rs
@@ -92,7 +92,7 @@ mod tests {
         let thinking = raw_capabilities
             .iter()
             .any(|capability| capability == "thinking")
-            .then(|| {
+            .then_some({
                 if matches!(family, "gptoss" | "gpt-oss") {
                     OllamaThinkingCapability::Levels
                 } else {

--- a/app/ai-chat/src/llm/provider.rs
+++ b/app/ai-chat/src/llm/provider.rs
@@ -1,6 +1,5 @@
-use super::LlmInputItem;
+use super::{LlmInputItem, ProviderRunEvent, ProviderRunRequest};
 use crate::{
-    database::Content,
     errors::{AiChatError, AiChatResult},
     state::AiChatConfig,
 };
@@ -100,17 +99,12 @@ pub(crate) struct OllamaModelCapabilities {
     pub(crate) local_web_tools: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) enum ProviderCapabilityExtension {
+    #[default]
     None,
     OpenAI(OpenAIModelCapabilities),
     Ollama(OllamaModelCapabilities),
-}
-
-impl Default for ProviderCapabilityExtension {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -265,17 +259,24 @@ pub(crate) trait Provider: Sync {
     fn name(&self) -> &'static str;
     fn is_configured(&self, settings: &serde_json::Value) -> bool;
     fn default_template_for_model(&self, model: &ProviderModel) -> AiChatResult<serde_json::Value>;
+    fn build_run_request(
+        &self,
+        template: &serde_json::Value,
+        input_items: Vec<LlmInputItem>,
+    ) -> AiChatResult<ProviderRunRequest>;
+    fn run<'a>(
+        &'a self,
+        config: AiChatConfig,
+        settings: toml::Value,
+        request: &'a ProviderRunRequest,
+    ) -> BoxStream<'a, AiChatResult<ProviderRunEvent>>;
     fn request_body(
         &self,
         template: &serde_json::Value,
         input_items: Vec<LlmInputItem>,
-    ) -> AiChatResult<serde_json::Value>;
-    fn fetch_by_request_body<'a>(
-        &self,
-        config: AiChatConfig,
-        settings: toml::Value,
-        request_body: &'a serde_json::Value,
-    ) -> BoxStream<'a, AiChatResult<FetchUpdate>>;
+    ) -> AiChatResult<serde_json::Value> {
+        Ok(self.build_run_request(template, input_items)?.request_body)
+    }
     fn list_models(
         &self,
         config: AiChatConfig,
@@ -322,14 +323,6 @@ pub(crate) fn normalized_or_default(
 
 pub(crate) use ollama::{OllamaProvider, OllamaSettings};
 pub(crate) use openai::{OpenAIProvider, OpenAISettings};
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum FetchUpdate {
-    ThinkingStarted,
-    ReasoningSummaryDelta(String),
-    TextDelta(String),
-    Complete(Content),
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ProviderModelsSuccess {
@@ -491,9 +484,9 @@ pub(crate) async fn available_models(config: AiChatConfig) -> AvailableModelsBat
 #[cfg(test)]
 mod tests {
     use super::{
-        AvailableModelsBatch, ExtSettingItem, FetchUpdate, LlmInputItem, ModelCapabilities,
-        Provider, ProviderModel, ProviderModelsFailure, ProviderSettingsFieldKind,
-        ProviderSettingsSpec, available_models_from_providers,
+        AvailableModelsBatch, ExtSettingItem, LlmInputItem, ModelCapabilities, Provider,
+        ProviderModel, ProviderModelsFailure, ProviderRunEvent, ProviderRunRequest,
+        ProviderSettingsFieldKind, ProviderSettingsSpec, available_models_from_providers,
         available_models_from_providers_with_timeout, provider_settings_specs,
     };
     use crate::{
@@ -527,20 +520,24 @@ mod tests {
             unreachable!()
         }
 
-        fn request_body(
+        fn build_run_request(
             &self,
             _template: &serde_json::Value,
-            _input_items: Vec<LlmInputItem>,
-        ) -> crate::errors::AiChatResult<serde_json::Value> {
-            unreachable!()
+            input_items: Vec<LlmInputItem>,
+        ) -> crate::errors::AiChatResult<ProviderRunRequest> {
+            Ok(ProviderRunRequest::new(
+                self.name(),
+                serde_json::json!({}),
+                input_items,
+            ))
         }
 
-        fn fetch_by_request_body<'a>(
-            &self,
+        fn run<'a>(
+            &'a self,
             _config: AiChatConfig,
             _settings: toml::Value,
-            _request_body: &'a serde_json::Value,
-        ) -> BoxStream<'a, crate::errors::AiChatResult<FetchUpdate>> {
+            _request: &'a ProviderRunRequest,
+        ) -> BoxStream<'a, crate::errors::AiChatResult<ProviderRunEvent>> {
             futures::stream::empty().boxed()
         }
 

--- a/app/ai-chat/src/llm/provider/ollama.rs
+++ b/app/ai-chat/src/llm/provider/ollama.rs
@@ -1,5 +1,5 @@
 use super::{
-    ExtSettingControl, ExtSettingItem, ExtSettingOption, FetchUpdate, ModelCapabilities,
+    ExtSettingControl, ExtSettingItem, ExtSettingOption, ModelCapabilities,
     OllamaModelCapabilities, OllamaThinkingCapability, Provider, ProviderCapabilityExtension,
     ProviderModel, ProviderSettingsFieldKind, ProviderSettingsFieldSpec, ProviderSettingsSpec,
     normalized_or_default,
@@ -7,7 +7,10 @@ use super::{
 use crate::{
     database::{Content, UrlCitation},
     errors::{AiChatError, AiChatResult},
-    llm::LlmInputItem,
+    llm::{
+        LlmContentPart, LlmInputItem, LlmToolCall, LlmToolResult, ProviderRunEvent,
+        ProviderRunRequest, ProviderRunState,
+    },
     state::AiChatConfig,
 };
 use futures::{FutureExt, StreamExt, future::BoxFuture, stream::BoxStream};
@@ -344,6 +347,14 @@ struct RoundResult {
 }
 
 impl OllamaProvider {
+    fn provider_tool_call(tool_call: &OllamaToolCall) -> LlmToolCall {
+        LlmToolCall {
+            call_id: tool_call.id.clone(),
+            name: tool_call.function.name.clone(),
+            arguments: tool_call.function.arguments.clone(),
+        }
+    }
+
     fn extension(model: &ProviderModel) -> Option<&OllamaModelCapabilities> {
         match &model.capabilities.extension {
             ProviderCapabilityExtension::Ollama(extension) => Some(extension),
@@ -700,15 +711,16 @@ impl Provider for OllamaProvider {
         })?)
     }
 
-    fn request_body(
+    fn build_run_request(
         &self,
         template: &serde_json::Value,
         input_items: Vec<LlmInputItem>,
-    ) -> AiChatResult<serde_json::Value> {
+    ) -> AiChatResult<ProviderRunRequest> {
         let template = OllamaRequestTemplate::deserialize(template)?;
         let request = OllamaStoredRequest {
             model: template.model,
             messages: input_items
+                .clone()
                 .into_iter()
                 .map(Self::to_ollama_message)
                 .collect::<AiChatResult<_>>()?,
@@ -716,20 +728,25 @@ impl Provider for OllamaProvider {
             think: template.think,
             web_search: template.web_search,
         };
-        Ok(serde_json::to_value(request)?)
+        Ok(ProviderRunRequest::new(
+            self.name(),
+            serde_json::to_value(request)?,
+            input_items,
+        ))
     }
 
-    fn fetch_by_request_body<'a>(
-        &self,
+    fn run<'a>(
+        &'a self,
         config: AiChatConfig,
         settings: toml::Value,
-        request_body: &'a serde_json::Value,
-    ) -> BoxStream<'a, AiChatResult<FetchUpdate>> {
+        request: &'a ProviderRunRequest,
+    ) -> BoxStream<'a, AiChatResult<ProviderRunEvent>> {
         async_stream::try_stream! {
             let settings: OllamaSettings = settings.try_into()?;
             let settings = settings.normalized();
             let client = Self::client(&config, &settings.base_url)?;
-            let mut request = OllamaStoredRequest::deserialize(request_body)?;
+            let request_body = request.request_body.clone();
+            let mut request = OllamaStoredRequest::deserialize(&request.request_body)?;
             let mut final_citations = Vec::new();
             let mut accumulated_reasoning = String::new();
 
@@ -781,19 +798,22 @@ impl Provider for OllamaProvider {
                             let event = serde_json::from_str::<OllamaChatResponse>(line)?;
                             if !event.message.thinking.is_empty() {
                                 if !emitted_thinking_started {
-                                    yield FetchUpdate::ThinkingStarted;
+                                    yield ProviderRunEvent::ThinkingStarted;
                                     emitted_thinking_started = true;
                                 }
                                 accumulated_reasoning.push_str(&event.message.thinking);
-                                yield FetchUpdate::ReasoningSummaryDelta(event.message.thinking.clone());
+                                yield ProviderRunEvent::ReasoningSummaryDelta(event.message.thinking.clone());
                                 round_message.thinking.push_str(&event.message.thinking);
                             }
                             if !event.message.content.is_empty() {
-                                yield FetchUpdate::TextDelta(event.message.content.clone());
+                                yield ProviderRunEvent::TextDelta(event.message.content.clone());
                                 round_message.content.push_str(&event.message.content);
                             }
                             if !event.message.tool_calls.is_empty() {
                                 round_message.tool_calls = event.message.tool_calls.clone();
+                                for tool_call in &round_message.tool_calls {
+                                    yield ProviderRunEvent::ToolCallRequested(Self::provider_tool_call(tool_call));
+                                }
                             }
                             if !event.message.role.is_empty() {
                                 round_message.role = event.message.role;
@@ -812,9 +832,20 @@ impl Provider for OllamaProvider {
 
                 if request.web_search && !round.message.tool_calls.is_empty() {
                     let mut tool_calls = round.message.tool_calls.clone();
+                    if !request.stream {
+                        for tool_call in &tool_calls {
+                            yield ProviderRunEvent::ToolCallRequested(Self::provider_tool_call(tool_call));
+                        }
+                    }
                     let (tool_messages, citations) =
                         Self::execute_tools(&client, &settings.base_url, &mut tool_calls).await?;
                     final_citations.extend(citations);
+                    for message in &tool_messages {
+                        yield ProviderRunEvent::ToolResultReceived(LlmToolResult {
+                            call_id: message.tool_call_id.clone(),
+                            content: vec![LlmContentPart::text(message.content.clone())],
+                        });
+                    }
                     request.messages.push(OllamaChatMessage {
                         role: "assistant".to_string(),
                         content: round.message.content.clone(),
@@ -831,7 +862,11 @@ impl Provider for OllamaProvider {
                     final_citations,
                     (!accumulated_reasoning.is_empty()).then_some(accumulated_reasoning),
                 );
-                yield FetchUpdate::Complete(content);
+                yield ProviderRunEvent::Completed {
+                    content,
+                    state: Some(ProviderRunState::new(self.name(), None, Vec::new(), request_body.clone())),
+                    usage: None,
+                };
                 break;
             }
         }

--- a/app/ai-chat/src/llm/provider/openai.rs
+++ b/app/ai-chat/src/llm/provider/openai.rs
@@ -1,5 +1,5 @@
 use super::{
-    ExtSettingControl, ExtSettingItem, ExtSettingOption, FetchUpdate, ModelCapabilities,
+    ExtSettingControl, ExtSettingItem, ExtSettingOption, ModelCapabilities,
     OpenAIModelCapabilities, Provider, ProviderModel, ProviderSettingsFieldKind,
     ProviderSettingsFieldSpec, ProviderSettingsSpec, ReasoningCapability, ReasoningEffort,
     normalized_or_default, optional_setting_value,
@@ -7,7 +7,10 @@ use super::{
 use crate::{
     database::{Content, UrlCitation},
     errors::{AiChatError, AiChatResult},
-    llm::LlmInputItem,
+    llm::{
+        LlmHostedToolCall, LlmInputItem, LlmOutputItem, ProviderRunEvent, ProviderRunRequest,
+        ProviderRunState, ProviderUsage,
+    },
     state::AiChatConfig,
 };
 use eventsource_stream::Eventsource;
@@ -165,14 +168,22 @@ struct OpenAIInputMessage {
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type")]
 enum OpenAIResponseStreamEvent {
+    #[serde(rename = "response.created")]
+    ResponseCreated { response: OpenAIResponseSnapshot },
+    #[serde(rename = "response.in_progress")]
+    ResponseInProgress { response: OpenAIResponseSnapshot },
     #[serde(rename = "response.output_item.added")]
     ResponseOutputItemAdded { item: OpenAIOutputItemEvent },
+    #[serde(rename = "response.output_item.done")]
+    ResponseOutputItemDone { item: OpenAIOutputItemEvent },
     #[serde(rename = "response.reasoning_summary_text.delta")]
     ResponseReasoningSummaryTextDelta { delta: String },
     #[serde(rename = "response.output_text.delta")]
     ResponseOutputTextDelta { delta: String },
     #[serde(rename = "response.completed")]
-    ResponseCompleted { response: serde_json::Value },
+    ResponseCompleted { response: ResponsesCreateResponse },
+    #[serde(rename = "response.incomplete")]
+    ResponseIncomplete { response: OpenAIResponse },
     #[serde(rename = "error")]
     Error { message: String },
     #[serde(rename = "response.failed")]
@@ -183,7 +194,9 @@ enum OpenAIResponseStreamEvent {
 
 #[derive(Debug, Deserialize)]
 struct OpenAIResponse {
-    error: OpenAIResponseError,
+    id: Option<String>,
+    error: Option<OpenAIResponseError>,
+    incomplete_details: Option<OpenAIIncompleteDetails>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -192,9 +205,24 @@ struct OpenAIResponseError {
 }
 
 #[derive(Debug, Deserialize)]
+struct OpenAIIncompleteDetails {
+    reason: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct OpenAIOutputItemEvent {
+    id: Option<String>,
     #[serde(rename = "type")]
     item_type: String,
+    status: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAIResponseSnapshot {
+    id: Option<String>,
+    #[serde(default)]
+    output: Vec<OpenAIOutputItemEvent>,
+    usage: Option<OpenAIUsage>,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -230,11 +258,14 @@ struct ModelListItem {
 
 #[derive(Debug, Deserialize)]
 struct ResponsesCreateResponse {
+    id: Option<String>,
     output: Vec<OutputItem>,
+    usage: Option<OpenAIUsage>,
 }
 
 #[derive(Debug, Deserialize)]
 struct OutputItem {
+    id: Option<String>,
     #[serde(rename = "type")]
     item_type: Option<String>,
     content: Option<Vec<OutputContent>>,
@@ -268,6 +299,13 @@ struct ReasoningSummaryPart {
     text: Option<String>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+struct OpenAIUsage {
+    input_tokens: Option<u64>,
+    output_tokens: Option<u64>,
+    total_tokens: Option<u64>,
+}
+
 impl OutputAnnotation {
     fn into_citation(self) -> Option<UrlCitation> {
         if self.annotation_type != "url_citation" {
@@ -282,7 +320,40 @@ impl OutputAnnotation {
     }
 }
 
+impl OpenAIOutputItemEvent {
+    fn output_item(&self) -> Option<LlmOutputItem> {
+        match self.item_type.as_str() {
+            "reasoning" => Some(LlmOutputItem::Reasoning { summary: None }),
+            "web_search_call" | "file_search_call" | "image_generation_call" => {
+                Some(LlmOutputItem::HostedToolCall(LlmHostedToolCall {
+                    call_id: self.id.clone().unwrap_or_default(),
+                    tool_type: self.item_type.clone(),
+                    status: self.status.clone(),
+                }))
+            }
+            _ => None,
+        }
+    }
+}
+
+impl OpenAIUsage {
+    fn provider_usage(&self) -> ProviderUsage {
+        ProviderUsage::new(self.input_tokens, self.output_tokens, self.total_tokens)
+    }
+}
+
 impl ResponsesCreateResponse {
+    fn output_item_ids(&self) -> Vec<String> {
+        self.output
+            .iter()
+            .filter_map(|item| item.id.clone())
+            .collect()
+    }
+
+    fn usage(&self) -> Option<ProviderUsage> {
+        self.usage.as_ref().map(OpenAIUsage::provider_usage)
+    }
+
     fn into_content(self) -> Content {
         let mut content = Content::default();
         let mut citations = Vec::new();
@@ -352,10 +423,15 @@ struct ReasoningProfile {
 
 const REASONING_EFFORT_KEY: &str = "reasoning.effort";
 const REASONING_SUMMARY_AUTO: &str = "auto";
+#[cfg(test)]
 const REASONING_NONE: &str = "none";
+#[cfg(test)]
 const REASONING_LOW: &str = "low";
+#[cfg(test)]
 const REASONING_MEDIUM: &str = "medium";
+#[cfg(test)]
 const REASONING_HIGH: &str = "high";
+#[cfg(test)]
 const REASONING_XHIGH: &str = "xhigh";
 const O_SERIES_REASONING_OPTIONS: &[ReasoningEffort] = &[
     ReasoningEffort::Low,
@@ -483,28 +559,64 @@ fn classify_model(id: &str) -> Option<ModelCapabilities> {
     Some(capabilities)
 }
 
-fn parse_response_stream_event(message: &str) -> AiChatResult<Option<FetchUpdate>> {
+fn parse_response_stream_event(message: &str) -> AiChatResult<Option<ProviderRunEvent>> {
     let event = serde_json::from_str::<OpenAIResponseStreamEvent>(message)?;
     match event {
+        OpenAIResponseStreamEvent::ResponseCreated { response }
+        | OpenAIResponseStreamEvent::ResponseInProgress { response } => {
+            let _ = response.id;
+            let _ = response.output;
+            Ok(response
+                .usage
+                .map(|usage| ProviderRunEvent::UsageUpdated(usage.provider_usage())))
+        }
         OpenAIResponseStreamEvent::ResponseOutputItemAdded { item }
             if item.item_type == "reasoning" =>
         {
-            Ok(Some(FetchUpdate::ThinkingStarted))
+            Ok(Some(ProviderRunEvent::ThinkingStarted))
         }
-        OpenAIResponseStreamEvent::ResponseOutputItemAdded { .. } => Ok(None),
+        OpenAIResponseStreamEvent::ResponseOutputItemAdded { item } => {
+            Ok(item.output_item().map(ProviderRunEvent::OutputItemAdded))
+        }
+        OpenAIResponseStreamEvent::ResponseOutputItemDone { item } => {
+            Ok(item.output_item().map(ProviderRunEvent::OutputItemDone))
+        }
         OpenAIResponseStreamEvent::ResponseReasoningSummaryTextDelta { delta } => {
-            Ok(Some(FetchUpdate::ReasoningSummaryDelta(delta)))
+            Ok(Some(ProviderRunEvent::ReasoningSummaryDelta(delta)))
         }
         OpenAIResponseStreamEvent::ResponseOutputTextDelta { delta } => {
-            Ok(Some(FetchUpdate::TextDelta(delta)))
+            Ok(Some(ProviderRunEvent::TextDelta(delta)))
         }
         OpenAIResponseStreamEvent::ResponseCompleted { response } => {
-            let response = serde_json::from_value::<ResponsesCreateResponse>(response)?;
-            Ok(Some(FetchUpdate::Complete(response.into_content())))
+            let state = ProviderRunState::new(
+                OpenAIProvider.name(),
+                response.id.clone(),
+                response.output_item_ids(),
+                serde_json::Value::Null,
+            );
+            let usage = response.usage();
+            Ok(Some(ProviderRunEvent::Completed {
+                content: response.into_content(),
+                state: Some(state),
+                usage,
+            }))
         }
         OpenAIResponseStreamEvent::Error { message, .. } => Err(AiChatError::StreamError(message)),
         OpenAIResponseStreamEvent::ResponseFailed { response } => {
-            Err(AiChatError::StreamError(response.error.message))
+            let message = response
+                .error
+                .map(|error| error.message)
+                .unwrap_or_else(|| "OpenAI response failed".to_string());
+            Err(AiChatError::StreamError(message))
+        }
+        OpenAIResponseStreamEvent::ResponseIncomplete { response } => {
+            let message = response
+                .incomplete_details
+                .map(|details| format!("OpenAI response incomplete: {}", details.reason))
+                .or_else(|| response.error.map(|error| error.message))
+                .unwrap_or_else(|| "OpenAI response incomplete".to_string());
+            let _ = response.id;
+            Ok(Some(ProviderRunEvent::Failed { message }))
         }
         OpenAIResponseStreamEvent::Other => Ok(None),
     }
@@ -704,36 +816,38 @@ impl Provider for OpenAIProvider {
         })?)
     }
 
-    fn request_body(
+    fn build_run_request(
         &self,
         template: &serde_json::Value,
         input_items: Vec<LlmInputItem>,
-    ) -> AiChatResult<serde_json::Value> {
+    ) -> AiChatResult<ProviderRunRequest> {
         let template = OpenAIRequestTemplate::deserialize(template)?;
-        Ok(serde_json::to_value(Self::get_body(
-            &template,
+        let request_body = serde_json::to_value(Self::get_body(&template, input_items.clone())?)?;
+        Ok(ProviderRunRequest::new(
+            self.name(),
+            request_body,
             input_items,
-        )?)?)
+        ))
     }
 
-    fn fetch_by_request_body<'a>(
-        &self,
+    fn run<'a>(
+        &'a self,
         config: AiChatConfig,
         settings: toml::Value,
-        request_body: &'a serde_json::Value,
-    ) -> BoxStream<'a, AiChatResult<FetchUpdate>> {
+        request: &'a ProviderRunRequest,
+    ) -> BoxStream<'a, AiChatResult<ProviderRunEvent>> {
         async_stream::try_stream! {
             let settings: OpenAISettings = settings.try_into()?;
             let settings = settings.normalized();
             let client = Self::get_reqwest_client(&config, &settings)?;
-            let stream = request_body
+            let stream = request.request_body
                 .get("stream")
                 .and_then(serde_json::Value::as_bool)
                 .unwrap_or(false);
             if stream {
                 let response = client
                     .post(responses_url(&settings.base_url))
-                    .json(&request_body)
+                    .json(&request.request_body)
                     .send()
                     .await?;
                 let response = response.error_for_status()?;
@@ -744,8 +858,11 @@ impl Provider for OpenAIProvider {
                             let message = message.data;
                             if message == "[DONE]" {
                                 break;
-                            } else if let Some(content) = parse_response_stream_event(&message)? {
-                                yield content;
+                            } else if let Some(mut event) = parse_response_stream_event(&message)? {
+                                if let ProviderRunEvent::Completed { state: Some(state), .. } = &mut event {
+                                    state.request_body = request.request_body.clone();
+                                }
+                                yield event;
                             }
                         }
                         Err(err) => {
@@ -756,13 +873,24 @@ impl Provider for OpenAIProvider {
             } else {
                 let response = client
                     .post(responses_url(&settings.base_url))
-                    .json(&request_body)
+                    .json(&request.request_body)
                     .send()
                     .await?;
                 let response = response
                     .json::<ResponsesCreateResponse>()
                     .await?;
-                yield FetchUpdate::Complete(response.into_content());
+                let state = ProviderRunState::new(
+                    self.name(),
+                    response.id.clone(),
+                    response.output_item_ids(),
+                    request.request_body.clone(),
+                );
+                let usage = response.usage();
+                yield ProviderRunEvent::Completed {
+                    content: response.into_content(),
+                    state: Some(state),
+                    usage,
+                };
             }
         }
         .boxed()

--- a/app/ai-chat/src/llm/provider/openai/tests.rs
+++ b/app/ai-chat/src/llm/provider/openai/tests.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{
     database::{Content, Role},
-    llm::{ExtSettingOption, FetchUpdate, LlmAttachmentRef, LlmContentPart, LlmInputItem},
+    llm::{ExtSettingOption, LlmAttachmentRef, LlmContentPart, LlmInputItem, ProviderRunEvent},
 };
 use serde_json::json;
 
@@ -16,6 +16,13 @@ fn openai_model(id: &str) -> ProviderModel {
         id,
         classify_model(id).unwrap_or_else(ModelCapabilities::text_streaming),
     )
+}
+
+fn completed_content(update: Option<ProviderRunEvent>) -> Option<Content> {
+    match update {
+        Some(ProviderRunEvent::Completed { content, .. }) => Some(content),
+        _ => None,
+    }
 }
 
 #[test]
@@ -446,8 +453,8 @@ fn response_completed_event_yields_complete_update() -> anyhow::Result<()> {
         r#"{"type":"response.completed","response":{"output":[{"type":"message","content":[{"type":"output_text","text":"done","annotations":[{"type":"url_citation","title":"Example","url":"https://example.com","start_index":0,"end_index":4}]}]}]}}"#,
     )?;
     assert_eq!(
-        update,
-        Some(FetchUpdate::Complete(Content {
+        completed_content(update),
+        Some(Content {
             text: "done".to_string(),
             reasoning_summary: None,
             citations: vec![crate::database::UrlCitation {
@@ -455,8 +462,8 @@ fn response_completed_event_yields_complete_update() -> anyhow::Result<()> {
                 url: "https://example.com".to_string(),
                 start_index: Some(0),
                 end_index: Some(4),
-            }]
-        }))
+            }],
+        })
     );
     Ok(())
 }
@@ -466,7 +473,7 @@ fn reasoning_output_item_added_starts_thinking() -> anyhow::Result<()> {
     let update = parse_response_stream_event(
         r#"{"type":"response.output_item.added","item":{"type":"reasoning","summary":[]}}"#,
     )?;
-    assert_eq!(update, Some(FetchUpdate::ThinkingStarted));
+    assert_eq!(update, Some(ProviderRunEvent::ThinkingStarted));
     Ok(())
 }
 
@@ -477,7 +484,41 @@ fn reasoning_summary_text_delta_yields_update() -> anyhow::Result<()> {
     )?;
     assert_eq!(
         update,
-        Some(FetchUpdate::ReasoningSummaryDelta("thinking".to_string()))
+        Some(ProviderRunEvent::ReasoningSummaryDelta(
+            "thinking".to_string()
+        ))
+    );
+    Ok(())
+}
+
+#[test]
+fn top_level_error_event_returns_stream_error() {
+    let error = parse_response_stream_event(
+        r#"{"type":"error","message":"request failed","sequence_number":1}"#,
+    )
+    .expect_err("error event should fail");
+    assert!(error.to_string().contains("request failed"));
+}
+
+#[test]
+fn response_failed_event_returns_stream_error() {
+    let error = parse_response_stream_event(
+        r#"{"type":"response.failed","response":{"id":"resp_1","error":{"message":"model failed"}}}"#,
+    )
+    .expect_err("failed event should fail");
+    assert!(error.to_string().contains("model failed"));
+}
+
+#[test]
+fn response_incomplete_event_yields_failed_run_event() -> anyhow::Result<()> {
+    let update = parse_response_stream_event(
+        r#"{"type":"response.incomplete","response":{"id":"resp_1","incomplete_details":{"reason":"max_output_tokens"}}}"#,
+    )?;
+    assert_eq!(
+        update,
+        Some(ProviderRunEvent::Failed {
+            message: "OpenAI response incomplete: max_output_tokens".to_string()
+        })
     );
     Ok(())
 }
@@ -488,12 +529,12 @@ fn response_completed_event_extracts_reasoning_summary() -> anyhow::Result<()> {
         r#"{"type":"response.completed","response":{"output":[{"type":"reasoning","summary":[{"type":"summary_text","text":"summarized"}]},{"type":"message","content":[{"type":"output_text","text":"done","annotations":[]}]}]}}"#,
     )?;
     assert_eq!(
-        update,
-        Some(FetchUpdate::Complete(Content {
+        completed_content(update),
+        Some(Content {
             text: "done".to_string(),
             reasoning_summary: Some("summarized".to_string()),
             citations: vec![],
-        }))
+        })
     );
     Ok(())
 }
@@ -504,12 +545,12 @@ fn response_completed_event_accumulates_reasoning_summaries() -> anyhow::Result<
         r#"{"type":"response.completed","response":{"output":[{"type":"reasoning","summary":[{"type":"summary_text","text":"first"}]},{"type":"reasoning","summary":[{"type":"summary_text","text":"second"}]},{"type":"message","content":[{"type":"output_text","text":"done","annotations":[]}]}]}}"#,
     )?;
     assert_eq!(
-        update,
-        Some(FetchUpdate::Complete(Content {
+        completed_content(update),
+        Some(Content {
             text: "done".to_string(),
             reasoning_summary: Some("first\n\nsecond".to_string()),
             citations: vec![],
-        }))
+        })
     );
     Ok(())
 }

--- a/app/ai-chat/src/llm/runner.rs
+++ b/app/ai-chat/src/llm/runner.rs
@@ -1,19 +1,22 @@
 use super::{Provider, provider_by_name};
 use crate::{
     errors::{AiChatError, AiChatResult},
-    llm::FetchUpdate,
+    llm::{ProviderRunEvent, ProviderRunRequest},
     state::AiChatConfig,
 };
 use futures::pin_mut;
 
-pub trait FetchRunner {
+pub trait ProviderRunRunner {
     fn get_provider(&self) -> &str;
     fn get_config(&self) -> &AiChatConfig;
-    fn request_body(&self) -> &serde_json::Value;
+    fn run_request(&self) -> &ProviderRunRequest;
+    fn request_body(&self) -> &serde_json::Value {
+        &self.run_request().request_body
+    }
     fn provider(&self) -> AiChatResult<&'static dyn Provider> {
         provider_by_name(self.get_provider())
     }
-    fn fetch(&self) -> impl futures::Stream<Item = AiChatResult<FetchUpdate>> {
+    fn run(&self) -> impl futures::Stream<Item = AiChatResult<ProviderRunEvent>> {
         async_stream::try_stream! {
             let provider = self.provider()?;
             let config = self.get_config().clone();
@@ -21,7 +24,7 @@ pub trait FetchRunner {
                 .get_provider_settings(provider.name())
                 .ok_or(AiChatError::ProviderSettingsNotFound(provider.name().to_string()))?;
             let settings = settings.clone();
-            let stream = provider.fetch_by_request_body(config, settings, self.request_body());
+            let stream = provider.run(config, settings, self.run_request());
             pin_mut!(stream);
             for await item in stream {
                 yield item?;

--- a/app/ai-chat/src/llm/types.rs
+++ b/app/ai-chat/src/llm/types.rs
@@ -1,8 +1,10 @@
 mod history;
 mod item;
+mod run;
 
 pub(crate) use history::{LlmHistoryMessage, build_input_items};
 pub(crate) use item::{
     LlmAttachmentRef, LlmContentPart, LlmHostedToolCall, LlmInputItem, LlmMcpApprovalRequest,
     LlmOutputItem, LlmToolCall, LlmToolResult,
 };
+pub(crate) use run::{ProviderRunEvent, ProviderRunRequest, ProviderRunState, ProviderUsage};

--- a/app/ai-chat/src/llm/types/run.rs
+++ b/app/ai-chat/src/llm/types/run.rs
@@ -1,0 +1,107 @@
+use serde::{Deserialize, Serialize};
+
+use crate::database::Content;
+
+use super::{LlmInputItem, LlmMcpApprovalRequest, LlmOutputItem, LlmToolCall, LlmToolResult};
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub(crate) struct ProviderRunRequest {
+    pub(crate) provider_name: String,
+    pub(crate) request_body: serde_json::Value,
+    pub(crate) input_items: Vec<LlmInputItem>,
+    pub(crate) state: Option<ProviderRunState>,
+}
+
+impl ProviderRunRequest {
+    pub(crate) fn new(
+        provider_name: impl Into<String>,
+        request_body: serde_json::Value,
+        input_items: Vec<LlmInputItem>,
+    ) -> Self {
+        Self {
+            provider_name: provider_name.into(),
+            request_body,
+            input_items,
+            state: None,
+        }
+    }
+
+    pub(crate) fn from_request_body(
+        provider_name: impl Into<String>,
+        request_body: serde_json::Value,
+    ) -> Self {
+        Self::new(provider_name, request_body, Vec::new())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub(crate) struct ProviderRunState {
+    pub(crate) provider_name: String,
+    pub(crate) run_id: Option<String>,
+    pub(crate) output_item_ids: Vec<String>,
+    pub(crate) continuation_metadata: serde_json::Value,
+    pub(crate) request_body: serde_json::Value,
+}
+
+impl ProviderRunState {
+    pub(crate) fn new(
+        provider_name: impl Into<String>,
+        run_id: Option<String>,
+        output_item_ids: Vec<String>,
+        request_body: serde_json::Value,
+    ) -> Self {
+        Self {
+            provider_name: provider_name.into(),
+            run_id,
+            output_item_ids,
+            continuation_metadata: serde_json::Value::Null,
+            request_body,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub(crate) struct ProviderUsage {
+    pub(crate) input_tokens: Option<u64>,
+    pub(crate) output_tokens: Option<u64>,
+    pub(crate) total_tokens: Option<u64>,
+    pub(crate) metadata: serde_json::Value,
+}
+
+impl ProviderUsage {
+    pub(crate) fn new(
+        input_tokens: Option<u64>,
+        output_tokens: Option<u64>,
+        total_tokens: Option<u64>,
+    ) -> Self {
+        Self {
+            input_tokens,
+            output_tokens,
+            total_tokens,
+            metadata: serde_json::Value::Null,
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum ProviderRunEvent {
+    ThinkingStarted,
+    ReasoningSummaryDelta(String),
+    TextDelta(String),
+    OutputItemAdded(LlmOutputItem),
+    OutputItemDone(LlmOutputItem),
+    ToolCallRequested(LlmToolCall),
+    ToolResultReceived(LlmToolResult),
+    McpApprovalRequested(LlmMcpApprovalRequest),
+    UsageUpdated(ProviderUsage),
+    Completed {
+        content: Content,
+        state: Option<ProviderRunState>,
+        usage: Option<ProviderUsage>,
+    },
+    Failed {
+        message: String,
+    },
+}


### PR DESCRIPTION
## Summary

- Adds the first-stage provider-neutral run/event abstraction for `ai-chat`.
- Affected scope: `ai-chat`.

## Motivation

- Addresses #139 under the #137 LLM abstraction work.
- Moves runtime streaming away from the text-only `FetchUpdate` shape so future provider state, output items, tool calls, usage, and continuation metadata have a common Rust vocabulary without making OpenAI Responses the core model.

## Changes

- Adds `ProviderRunRequest`, `ProviderRunEvent`, `ProviderRunState`, and `ProviderUsage`.
- Updates `Provider` to build run requests and stream provider-neutral run events while keeping request JSON snapshots compatible with `messages.send_content`.
- Migrates conversation panel and temporary detail streaming paths to `ProviderRunRunner`.
- Maps OpenAI Responses stream events and Ollama chat streaming into the shared run event vocabulary.
- Keeps Ollama experimental web search/fetch execution provider-local and leaves generic tool execution, MCP approval UI, and run-state persistence for later child issues.
- Updates the #137 coordination doc with #139 status and follow-up constraints.

## Validation

- [ ] `cargo build`
- [ ] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
cargo fmt
cargo test -p ai-chat llm::types
cargo test -p ai-chat llm::provider
cargo test -p ai-chat llm::provider::openai
cargo test -p ai-chat llm::provider::ollama
cargo test -p ai-chat features::home::tabs::conversation_panel
cargo test -p ai-chat features::temporary::detail
cargo clippy -p ai-chat --all-targets --all-features -- -D warnings

All listed commands passed.

Full cargo build, full cargo test, and manual app verification were not run for this child issue.
```

## Risks

- Runtime event consumers now ignore future tool/output/usage events unless they map to existing visible text/reasoning/completion behavior.
- Run state is exposed in code but not yet persisted; #141 should add additive storage without breaking old `messages.content` and `messages.send_content`.

## Related Issues

- Closes #139
- Related to #137
