### PR TITLE
ai-chat: persist LLM run state

### DIFF
--- a/app/ai-chat/docs/dev/issue-137-llm-abstractions.md
+++ b/app/ai-chat/docs/dev/issue-137-llm-abstractions.md
@@ -20,7 +20,7 @@ Delete it before the final merge to `main`, unless the remaining content is prom
 | #138 | `codex/issue-138-model-capabilities` | Provider-neutral model capability types | Merged to integration via PR #147; GitHub issue still open |
 | #142 | `codex/issue-142-llm-items` | Typed input, content, and output items | Merged to integration via PR #148; GitHub issue still open |
 | #139 | `codex/issue-139-provider-runtime` | Run-based provider trait and events | Merged to integration via PR #149; GitHub issue still open |
-| #141 | `codex/issue-141-llm-persistence` | Run state, output items, tools, attachments persistence | Pending |
+| #141 | `codex/issue-141-llm-persistence` | Run state, output items, tools, attachments persistence | Implemented and pushed; pending PR |
 | #143 | `codex/issue-143-openai-responses-abstraction` | OpenAI Responses migration on shared abstraction | Pending |
 | #144 | `codex/issue-144-ollama-shared-abstraction` | Ollama migration on shared abstraction | Pending |
 | #140 | `codex/issue-140-capability-gating` | Template, shortcut, and UI capability gating | Pending |
@@ -33,7 +33,8 @@ Last synchronized: 2026-05-20.
 - #138 remains open on GitHub, but PR #147 merged `codex/issue-138-model-capabilities` into `codex/issue-137-llm-abstractions`.
 - #142 remains open on GitHub, but PR #148 merged `codex/issue-142-llm-items` into `codex/issue-137-llm-abstractions`.
 - #139 remains open on GitHub, but PR #149 merged `codex/issue-139-provider-runtime` into `codex/issue-137-llm-abstractions`.
-- #141, #143, #144, and #140 remain open and pending behind the typed item and run/event model.
+- #141 remains open on GitHub, with `codex/issue-141-llm-persistence` pushed and carrying the first additive persistence implementation.
+- #143, #144, and #140 remain open and pending behind the persistence layer.
 
 ## Current Architecture Facts
 
@@ -48,7 +49,8 @@ Last synchronized: 2026-05-20.
 - `Provider` now builds `ProviderRunRequest` values from typed input items and streams provider-neutral `ProviderRunEvent` values.
 - `ProviderRunRequest` keeps the provider request JSON snapshot so existing `messages.send_content` resend behavior remains compatible.
 - `ProviderRunEvent` replaces `FetchUpdate` and covers thinking start, reasoning summary delta, text delta, output item added/done, tool call/result, MCP approval request, usage update, completed, and failed states.
-- `ProviderRunState` and `ProviderUsage` are available for provider response/run metadata, output item ids, continuation metadata, and token usage, but database persistence remains a follow-up.
+- `ProviderRunState` and `ProviderUsage` are available for provider response/run metadata, output item ids, continuation metadata, and token usage, and #141 persists them additively for assistant messages.
+- `message_run_states`, `message_output_items`, and `message_attachments` now persist provider run state, output item events, usage, and attachment metadata additively without changing `messages.content` or `messages.send_content`.
 - `messages.content` stores rendered message content; `messages.send_content` stores the request body snapshot used for resend.
 - OpenAI already uses `/v1/responses`, reasoning effort, reasoning summaries, and hosted web search citations.
 - Ollama has provider-specific thinking and experimental web search/fetch behavior that must not be forced into OpenAI-shaped types.
@@ -167,8 +169,27 @@ The current implementation keeps request persistence additive: existing provider
   - `cargo test -p ai-chat features::temporary::detail`
   - `cargo clippy -p ai-chat --all-targets --all-features -- -D warnings`
 
+### #141 LLM Run State, Output Item, Tool, And Attachment Persistence
+
+- Added database v6 and migrates legacy v1-v5 stores into `history_v6.sqlite3`.
+- Preserved `messages.content` and `messages.send_content` as the compatibility surface for display, export, and resend.
+- Added additive run persistence tables for assistant message run state, ordered output item events, and attachment metadata.
+- Added typed message persistence wrappers around `ProviderRunState`, `ProviderUsage`, `LlmOutputItem`, and attachment refs.
+- Conversation streaming now accumulates output item events, tool/MCP events, usage, and completed run state, then persists them with terminal message state.
+- Temporary chat remains in-memory but carries run persistence when saved into a normal conversation.
+- Resending an assistant message clears old run persistence while keeping the existing request body snapshot behavior.
+- Validation run:
+  - `cargo fmt`
+  - `cargo test -p ai-chat database::migrations`
+  - `cargo test -p ai-chat database::service`
+  - `cargo test -p ai-chat llm::provider`
+  - `cargo test -p ai-chat features::home::tabs::conversation_panel`
+  - `cargo test -p ai-chat features::temporary::detail`
+  - `cargo test -p ai-chat`
+  - `cargo clippy -p ai-chat --all-targets --all-features -- -D warnings`
+
 ## Next Child Issue Constraints
 
-Next child issue is #141.
+Next child issue is #143 unless #141 needs PR review follow-up first.
 
-#141 should persist the runtime state introduced by #139 without breaking old conversations. It should preserve `messages.content` and `messages.send_content` compatibility, add storage for provider run state/output items/tool calls/attachments as additive data, and avoid storing binary attachment data directly inside message text.
+#143 should use the persisted run state from #141 for OpenAI Responses continuation and richer Responses output item handling without leaking OpenAI-specific schema into the provider-neutral core.

--- a/app/ai-chat/docs/dev/issue-137-llm-abstractions.md
+++ b/app/ai-chat/docs/dev/issue-137-llm-abstractions.md
@@ -20,7 +20,7 @@ Delete it before the final merge to `main`, unless the remaining content is prom
 | #138 | `codex/issue-138-model-capabilities` | Provider-neutral model capability types | Merged to integration via PR #147; GitHub issue still open |
 | #142 | `codex/issue-142-llm-items` | Typed input, content, and output items | Merged to integration via PR #148; GitHub issue still open |
 | #139 | `codex/issue-139-provider-runtime` | Run-based provider trait and events | Merged to integration via PR #149; GitHub issue still open |
-| #141 | `codex/issue-141-llm-persistence` | Run state, output items, tools, attachments persistence | Implemented and pushed; pending PR |
+| #141 | `codex/issue-141-llm-persistence` | Run state, output items, tools, attachments persistence | PR #150 open to integration |
 | #143 | `codex/issue-143-openai-responses-abstraction` | OpenAI Responses migration on shared abstraction | Pending |
 | #144 | `codex/issue-144-ollama-shared-abstraction` | Ollama migration on shared abstraction | Pending |
 | #140 | `codex/issue-140-capability-gating` | Template, shortcut, and UI capability gating | Pending |
@@ -33,7 +33,7 @@ Last synchronized: 2026-05-20.
 - #138 remains open on GitHub, but PR #147 merged `codex/issue-138-model-capabilities` into `codex/issue-137-llm-abstractions`.
 - #142 remains open on GitHub, but PR #148 merged `codex/issue-142-llm-items` into `codex/issue-137-llm-abstractions`.
 - #139 remains open on GitHub, but PR #149 merged `codex/issue-139-provider-runtime` into `codex/issue-137-llm-abstractions`.
-- #141 remains open on GitHub, with `codex/issue-141-llm-persistence` pushed and carrying the first additive persistence implementation.
+- #141 remains open on GitHub, with PR #150 carrying the first additive persistence implementation into `codex/issue-137-llm-abstractions`.
 - #143, #144, and #140 remain open and pending behind the persistence layer.
 
 ## Current Architecture Facts

--- a/app/ai-chat/migrations/2026-05-20-000000_create_tables_v6/down.sql
+++ b/app/ai-chat/migrations/2026-05-20-000000_create_tables_v6/down.sql
@@ -1,0 +1,8 @@
+drop table if exists global_shortcut_bindings;
+drop table if exists message_attachments;
+drop table if exists message_output_items;
+drop table if exists message_run_states;
+drop table if exists messages;
+drop table if exists conversations;
+drop table if exists conversation_templates;
+drop table if exists folders;

--- a/app/ai-chat/migrations/2026-05-20-000000_create_tables_v6/up.sql
+++ b/app/ai-chat/migrations/2026-05-20-000000_create_tables_v6/up.sql
@@ -1,0 +1,135 @@
+create table folders
+(
+    id           INTEGER primary key autoincrement not null,
+    name         TEXT                              not null,
+    path         TEXT                              not null,
+    parent_id    INTEGER,
+    created_time DateTime                          not null,
+    updated_time DateTime                          not null,
+    unique (name, parent_id),
+    unique (path),
+    foreign key (parent_id) references folders (id)
+);
+
+CREATE TABLE conversation_templates
+(
+    id           Integer PRIMARY KEY AUTOINCREMENT not null,
+    name         TEXT                              NOT NULL,
+    icon         TEXT                              not null,
+    description  TEXT,
+    prompts      JSON                              NOT NULL,
+    created_time DateTime                          not null,
+    updated_time DateTime                          not null
+);
+
+create table conversations
+(
+    id           INTEGER primary key autoincrement not null,
+    folder_id    INTEGER,
+    path         TEXT                              not null,
+    title        TEXT                              not null,
+    icon         TEXT                              not null,
+    created_time DateTime                          not null,
+    updated_time DateTime                          not null,
+    info         TEXT,
+    foreign key (folder_id) references folders (id),
+    unique (path)
+);
+
+create table messages
+(
+    id                INTEGER primary key autoincrement not null,
+    conversation_id   INTEGER                           not null,
+    conversation_path TEXT                              not null,
+    provider          TEXT                              not null,
+    role              TEXT                              not null check ( role in ('developer', 'user', 'assistant') ),
+    content           JSON                              not null,
+    send_content      JSON                              not null,
+    status            TEXT                              not null check ( status in ('normal', 'hidden', 'loading', 'thinking', 'paused', 'error') ),
+    created_time      DateTime                          not null,
+    updated_time      DateTime                          not null,
+    start_time        DateTime                          not null,
+    end_time          DateTime                          not null,
+    error             TEXT,
+    foreign key (conversation_id) references conversations (id)
+);
+
+create table message_run_states
+(
+    message_id            INTEGER  primary key not null,
+    provider              TEXT                 not null,
+    run_id                TEXT,
+    output_item_ids       JSON                 not null default '[]',
+    continuation_metadata JSON                 not null default 'null',
+    request_body          JSON                 not null,
+    usage                 JSON,
+    model                 TEXT,
+    settings              JSON,
+    created_time          DateTime             not null,
+    updated_time          DateTime             not null,
+    foreign key (message_id) references messages (id) on delete cascade
+);
+
+create table message_output_items
+(
+    id               INTEGER primary key autoincrement not null,
+    message_id       INTEGER                           not null,
+    sequence         INTEGER                           not null,
+    item_kind        TEXT                              not null,
+    provider_item_id TEXT,
+    status           TEXT                              not null,
+    payload          JSON                              not null,
+    created_time     DateTime                          not null,
+    updated_time     DateTime                          not null,
+    foreign key (message_id) references messages (id) on delete cascade,
+    unique (message_id, sequence)
+);
+
+create table message_attachments
+(
+    id               INTEGER primary key autoincrement not null,
+    message_id       INTEGER                           not null,
+    attachment_id    TEXT                              not null,
+    kind             TEXT                              not null,
+    mime_type        TEXT,
+    name             TEXT,
+    metadata         JSON                              not null default '{}',
+    external_uri     TEXT,
+    path             TEXT,
+    sha256           TEXT,
+    created_time     DateTime                          not null,
+    updated_time     DateTime                          not null,
+    foreign key (message_id) references messages (id) on delete cascade,
+    unique (message_id, attachment_id, kind)
+);
+
+create table global_shortcut_bindings
+(
+    id               INTEGER primary key autoincrement not null,
+    hotkey           TEXT                              not null,
+    enabled          BOOLEAN                           not null default 1 check ( enabled in (0, 1) ),
+    template_id      INTEGER,
+    provider_name    TEXT                              not null,
+    model_id         TEXT                              not null,
+    mode             TEXT                              not null check ( mode in ('contextual', 'single', 'assistant-only') ),
+    request_template JSON                              not null default '{}',
+    input_source     TEXT                              not null check ( input_source in ('selection_or_clipboard', 'screenshot') ),
+    created_time     DateTime                          not null,
+    updated_time     DateTime                          not null,
+    foreign key (template_id) references conversation_templates (id),
+    unique (hotkey)
+);
+
+CREATE INDEX idx_messages_conversation_id ON messages (conversation_id);
+
+CREATE INDEX idx_messages_start_time ON messages (start_time);
+
+CREATE INDEX idx_messages_status ON messages (status);
+
+CREATE INDEX idx_messages_content ON messages (content);
+
+CREATE INDEX idx_message_output_items_message_sequence ON message_output_items (message_id, sequence);
+
+CREATE INDEX idx_message_output_items_kind ON message_output_items (item_kind);
+
+CREATE INDEX idx_message_attachments_message_id ON message_attachments (message_id);

--- a/app/ai-chat/src/database.rs
+++ b/app/ai-chat/src/database.rs
@@ -17,9 +17,14 @@ pub use service::{
 };
 #[allow(unused_imports)]
 pub use service::{GlobalShortcutBinding, NewGlobalShortcutBinding, UpdateGlobalShortcutBinding};
+#[allow(unused_imports)]
+pub(crate) use service::{
+    MessageAttachment, MessageAttachmentKind, MessageOutputItem, MessageOutputItemStatus,
+    MessageRunPersistence, MessageRunState,
+};
 pub use types::{Mode, Role, ShortcutInputSource, Status};
 const CREATE_TABLE_SQL: &str =
-    include_str!("../migrations/2026-03-20-000000_create_tables_v5/up.sql");
+    include_str!("../migrations/2026-05-20-000000_create_tables_v6/up.sql");
 
 pub(crate) type DbConn = Pool<ConnectionManager<SqliteConnection>>;
 

--- a/app/ai-chat/src/database/bootstrap.rs
+++ b/app/ai-chat/src/database/bootstrap.rs
@@ -20,8 +20,9 @@ const DATABASE_FILE_V2: &str = "history_v2.sqlite3";
 const DATABASE_FILE_V3: &str = "history_v3.sqlite3";
 const DATABASE_FILE_V4: &str = "history_v4.sqlite3";
 const DATABASE_FILE_V5: &str = "history_v5.sqlite3";
+const DATABASE_FILE_V6: &str = "history_v6.sqlite3";
 const CREATE_TABLE_SQL: &str =
-    include_str!("../../migrations/2026-03-20-000000_create_tables_v5/up.sql");
+    include_str!("../../migrations/2026-05-20-000000_create_tables_v6/up.sql");
 
 pub(crate) fn init_store(cx: &mut App) {
     let conn = match establish_connection() {
@@ -58,7 +59,11 @@ enum StoreVersion {
         conn: DbConn,
         source_path: std::path::PathBuf,
     },
-    V5(DbConn),
+    V5 {
+        conn: DbConn,
+        source_path: std::path::PathBuf,
+    },
+    V6(DbConn),
 }
 
 impl StoreVersion {
@@ -68,85 +73,102 @@ impl StoreVersion {
         let v3_path = data_dir.join(DATABASE_FILE_V3);
         let v4_path = data_dir.join(DATABASE_FILE_V4);
         let v5_path = data_dir.join(DATABASE_FILE_V5);
+        let v6_path = data_dir.join(DATABASE_FILE_V6);
         match (
             v1_path.exists(),
             v2_path.exists(),
             v3_path.exists(),
             v4_path.exists(),
             v5_path.exists(),
+            v6_path.exists(),
         ) {
-            (_, _, _, _, true) => Ok(Self::V5(get_dbconn(&v5_path)?)),
-            (_, _, _, true, false) => Ok(Self::V4 {
-                conn: get_dbconn(&v5_path)?,
+            (_, _, _, _, _, true) => Ok(Self::V6(get_dbconn(&v6_path)?)),
+            (_, _, _, _, true, false) => Ok(Self::V5 {
+                conn: get_dbconn(&v6_path)?,
+                source_path: v5_path,
+            }),
+            (_, _, _, true, false, false) => Ok(Self::V4 {
+                conn: get_dbconn(&v6_path)?,
                 source_path: v4_path,
             }),
-            (_, _, true, false, false) => Ok(Self::V3 {
-                conn: get_dbconn(&v5_path)?,
+            (_, _, true, false, false, false) => Ok(Self::V3 {
+                conn: get_dbconn(&v6_path)?,
                 source_path: v3_path,
             }),
-            (_, true, false, false, false) => Ok(Self::V2 {
-                conn: get_dbconn(&v5_path)?,
+            (_, true, false, false, false, false) => Ok(Self::V2 {
+                conn: get_dbconn(&v6_path)?,
                 source_path: v2_path,
             }),
-            (true, false, false, false, false) => Ok(Self::V1 {
-                conn: get_dbconn(&v5_path)?,
+            (true, false, false, false, false, false) => Ok(Self::V1 {
+                conn: get_dbconn(&v6_path)?,
                 v1_db: SqliteConnection::establish(v1_path.to_str().ok_or(AiChatError::DbPath)?)?,
             }),
-            _ => Ok(Self::None(get_dbconn(&v5_path)?)),
+            _ => Ok(Self::None(get_dbconn(&v6_path)?)),
         }
     }
 
     fn migration(self) -> AiChatResult<DbConn> {
         match self {
             Self::None(conn) => {
-                event!(Level::INFO, "initialize database v5");
+                event!(Level::INFO, "initialize database v6");
                 let mut db = conn.get()?;
                 init_tables(&mut db)?;
                 Ok(conn)
             }
             Self::V1 { conn, mut v1_db } => {
-                event!(Level::INFO, "migrate database from v1 to v5");
-                let v5_db = &mut conn.get()?;
-                if let Err(err) = super::migrations::v1_to_v5(&mut v1_db, v5_db) {
-                    event!(Level::ERROR, "database migration v1 -> v5 failed: {}", err);
-                    init_tables(v5_db)?;
+                event!(Level::INFO, "migrate database from v1 to v6");
+                let v6_db = &mut conn.get()?;
+                if let Err(err) = super::migrations::v1_to_v6(&mut v1_db, v6_db) {
+                    event!(Level::ERROR, "database migration v1 -> v6 failed: {}", err);
+                    init_tables(v6_db)?;
                 }
                 Ok(conn)
             }
             Self::V2 { conn, source_path } => {
-                event!(Level::INFO, "migrate database from v2 to v5");
+                event!(Level::INFO, "migrate database from v2 to v6");
                 let mut v2_db =
                     SqliteConnection::establish(source_path.to_str().ok_or(AiChatError::DbPath)?)?;
-                let v5_db = &mut conn.get()?;
-                if let Err(err) = super::migrations::v2_to_v5(&mut v2_db, v5_db) {
-                    event!(Level::ERROR, "database migration v2 -> v5 failed: {}", err);
-                    init_tables(v5_db)?;
+                let v6_db = &mut conn.get()?;
+                if let Err(err) = super::migrations::v2_to_v6(&mut v2_db, v6_db) {
+                    event!(Level::ERROR, "database migration v2 -> v6 failed: {}", err);
+                    init_tables(v6_db)?;
                 }
                 Ok(conn)
             }
             Self::V3 { conn, source_path } => {
-                event!(Level::INFO, "migrate database from v3 to v5");
+                event!(Level::INFO, "migrate database from v3 to v6");
                 let mut v3_db =
                     SqliteConnection::establish(source_path.to_str().ok_or(AiChatError::DbPath)?)?;
-                let v5_db = &mut conn.get()?;
-                if let Err(err) = super::migrations::v3_to_v5(&mut v3_db, v5_db) {
-                    event!(Level::ERROR, "database migration v3 -> v5 failed: {}", err);
-                    init_tables(v5_db)?;
+                let v6_db = &mut conn.get()?;
+                if let Err(err) = super::migrations::v3_to_v6(&mut v3_db, v6_db) {
+                    event!(Level::ERROR, "database migration v3 -> v6 failed: {}", err);
+                    init_tables(v6_db)?;
                 }
                 Ok(conn)
             }
             Self::V4 { conn, source_path } => {
-                event!(Level::INFO, "migrate database from v4 to v5");
+                event!(Level::INFO, "migrate database from v4 to v6");
                 let mut v4_db =
                     SqliteConnection::establish(source_path.to_str().ok_or(AiChatError::DbPath)?)?;
-                let v5_db = &mut conn.get()?;
-                if let Err(err) = super::migrations::v4_to_v5(&mut v4_db, v5_db) {
-                    event!(Level::ERROR, "database migration v4 -> v5 failed: {}", err);
-                    init_tables(v5_db)?;
+                let v6_db = &mut conn.get()?;
+                if let Err(err) = super::migrations::v4_to_v6(&mut v4_db, v6_db) {
+                    event!(Level::ERROR, "database migration v4 -> v6 failed: {}", err);
+                    init_tables(v6_db)?;
                 }
                 Ok(conn)
             }
-            Self::V5(conn) => Ok(conn),
+            Self::V5 { conn, source_path } => {
+                event!(Level::INFO, "migrate database from v5 to v6");
+                let mut v5_db =
+                    SqliteConnection::establish(source_path.to_str().ok_or(AiChatError::DbPath)?)?;
+                let v6_db = &mut conn.get()?;
+                if let Err(err) = super::migrations::v5_to_v6(&mut v5_db, v6_db) {
+                    event!(Level::ERROR, "database migration v5 -> v6 failed: {}", err);
+                    init_tables(v6_db)?;
+                }
+                Ok(conn)
+            }
+            Self::V6(conn) => Ok(conn),
         }
     }
 }

--- a/app/ai-chat/src/database/migrations.rs
+++ b/app/ai-chat/src/database/migrations.rs
@@ -1,7 +1,10 @@
 use crate::{
     database::{
         CREATE_TABLE_SQL, Content, ConversationTemplatePrompt, Mode, Role, Status,
-        model::{SqlConversation, SqlConversationTemplate, SqlFolder, SqlMessage},
+        model::{
+            SqlConversation, SqlConversationTemplate, SqlFolder, SqlGlobalShortcutBinding,
+            SqlMessage,
+        },
     },
     errors::AiChatResult,
     llm::{LlmInputItem, provider_by_name},
@@ -36,7 +39,7 @@ pub(super) fn v1_to_v3(
     )
 }
 
-pub(super) fn v1_to_v5(
+pub(super) fn v1_to_v6(
     v1_conn: &mut SqliteConnection,
     target_conn: &mut SqliteConnection,
 ) -> AiChatResult<()> {
@@ -69,14 +72,14 @@ pub(super) fn v2_to_v3(
     )
 }
 
-pub(super) fn v2_to_v5(
+pub(super) fn v2_to_v6(
     v2_conn: &mut SqliteConnection,
     target_conn: &mut SqliteConnection,
 ) -> AiChatResult<()> {
     v2_to_v3(v2_conn, target_conn)
 }
 
-pub(super) fn v3_to_v5(
+pub(super) fn v3_to_v6(
     v3_conn: &mut SqliteConnection,
     target_conn: &mut SqliteConnection,
 ) -> AiChatResult<()> {
@@ -96,7 +99,7 @@ pub(super) fn v3_to_v5(
     })
 }
 
-pub(super) fn v4_to_v5(
+pub(super) fn v4_to_v6(
     v4_conn: &mut SqliteConnection,
     target_conn: &mut SqliteConnection,
 ) -> AiChatResult<()> {
@@ -109,6 +112,27 @@ pub(super) fn v4_to_v5(
         )?;
         SqlConversation::migration_save(SqlConversation::get_all(v4_conn)?, target_conn)?;
         SqlMessage::migration_save(SqlMessage::all(v4_conn)?, target_conn)?;
+        Ok(())
+    })
+}
+
+pub(super) fn v5_to_v6(
+    v5_conn: &mut SqliteConnection,
+    target_conn: &mut SqliteConnection,
+) -> AiChatResult<()> {
+    target_conn.immediate_transaction(|target_conn| {
+        target_conn.batch_execute(CREATE_TABLE_SQL)?;
+        SqlFolder::migration_save(SqlFolder::all(v5_conn)?, target_conn)?;
+        SqlConversationTemplate::migration_save(
+            SqlConversationTemplate::all(v5_conn)?,
+            target_conn,
+        )?;
+        SqlConversation::migration_save(SqlConversation::get_all(v5_conn)?, target_conn)?;
+        SqlMessage::migration_save(SqlMessage::all(v5_conn)?, target_conn)?;
+        SqlGlobalShortcutBinding::migration_save(
+            SqlGlobalShortcutBinding::all(v5_conn)?,
+            target_conn,
+        )?;
         Ok(())
     })
 }

--- a/app/ai-chat/src/database/migrations/tests.rs
+++ b/app/ai-chat/src/database/migrations/tests.rs
@@ -1,6 +1,7 @@
-use super::{v1_to_v5, v2_to_v5, v3_to_v5, v4_to_v5};
+use super::{v1_to_v6, v2_to_v6, v3_to_v6, v4_to_v6, v5_to_v6};
 use crate::database::model::{
     SqlConversation, SqlConversationTemplate, SqlGlobalShortcutBinding, SqlMessage,
+    SqlMessageAttachment, SqlMessageOutputItem, SqlMessageRunState,
 };
 use diesel::{Connection, RunQueryDsl, SqliteConnection, connection::SimpleConnection, sql_query};
 use std::{
@@ -76,6 +77,8 @@ const V3_CREATE_TABLE_SQL: &str =
     include_str!("../../../migrations/2026-03-08-000000_create_tables_v3/up.sql");
 const V4_CREATE_TABLE_SQL: &str =
     include_str!("../../../migrations/2026-03-15-000000_create_tables_v4/up.sql");
+const V5_CREATE_TABLE_SQL: &str =
+    include_str!("../../../migrations/2026-03-20-000000_create_tables_v5/up.sql");
 
 static TEMP_DB_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -89,6 +92,13 @@ fn temp_db_path(name: &str) -> PathBuf {
     std::env::temp_dir().join(format!(
         "gpui-ai-chat-{name}-{pid}-{unique}-{counter}.sqlite3"
     ))
+}
+
+fn assert_run_tables_empty(conn: &mut SqliteConnection) -> anyhow::Result<()> {
+    assert!(SqlMessageRunState::all(conn)?.is_empty());
+    assert!(SqlMessageOutputItem::all(conn)?.is_empty());
+    assert!(SqlMessageAttachment::all(conn)?.is_empty());
+    Ok(())
 }
 
 fn template_json() -> &'static str {
@@ -137,7 +147,7 @@ fn v1_migration_backfills_send_content_from_request_logic() -> anyhow::Result<()
     v1_conn.batch_execute(V1_CREATE_TABLE_SQL)?;
     insert_seed_data(&mut v1_conn, false)?;
 
-    v1_to_v5(&mut v1_conn, &mut v5_conn)?;
+    v1_to_v6(&mut v1_conn, &mut v5_conn)?;
 
     let templates = SqlConversationTemplate::all(&mut v5_conn)?;
     assert_eq!(templates.len(), 1);
@@ -156,6 +166,7 @@ fn v1_migration_backfills_send_content_from_request_logic() -> anyhow::Result<()
     assert_eq!(first_send_content["model"], "gpt-4o");
     assert_eq!(first_send_content["input"][0]["content"], "hello");
     assert_eq!(second_send_content, first_send_content);
+    assert_run_tables_empty(&mut v5_conn)?;
 
     drop(v1_conn);
     drop(v5_conn);
@@ -174,13 +185,14 @@ fn v2_migration_keeps_send_content_and_adds_provider() -> anyhow::Result<()> {
     v2_conn.batch_execute(V2_CREATE_TABLE_SQL)?;
     insert_seed_data(&mut v2_conn, true)?;
 
-    v2_to_v5(&mut v2_conn, &mut v5_conn)?;
+    v2_to_v6(&mut v2_conn, &mut v5_conn)?;
 
     let messages = SqlMessage::all(&mut v5_conn)?;
     assert_eq!(messages.len(), 2);
     assert!(messages.iter().all(|message| message.provider == "OpenAI"));
     assert_eq!(messages[0].send_content["model"], "gpt-4o");
     assert!(SqlGlobalShortcutBinding::all(&mut v5_conn)?.is_empty());
+    assert_run_tables_empty(&mut v5_conn)?;
 
     drop(v2_conn);
     drop(v5_conn);
@@ -213,7 +225,7 @@ fn v3_migration_converts_legacy_content_enum_to_json_struct_in_v5() -> anyhow::R
         )
         .execute(&mut v3_conn)?;
 
-    v3_to_v5(&mut v3_conn, &mut v5_conn)?;
+    v3_to_v6(&mut v3_conn, &mut v5_conn)?;
 
     let messages = SqlMessage::all(&mut v5_conn)?;
     assert_eq!(messages.len(), 1);
@@ -224,6 +236,7 @@ fn v3_migration_converts_legacy_content_enum_to_json_struct_in_v5() -> anyhow::R
         "https://example.com"
     );
     assert!(SqlGlobalShortcutBinding::all(&mut v5_conn)?.is_empty());
+    assert_run_tables_empty(&mut v5_conn)?;
 
     drop(v3_conn);
     drop(v5_conn);
@@ -261,16 +274,57 @@ fn v4_migration_creates_empty_global_shortcut_table() -> anyhow::Result<()> {
         )
         .execute(&mut v4_conn)?;
 
-    v4_to_v5(&mut v4_conn, &mut v5_conn)?;
+    v4_to_v6(&mut v4_conn, &mut v5_conn)?;
 
     assert_eq!(SqlConversationTemplate::all(&mut v5_conn)?.len(), 1);
     assert_eq!(SqlConversation::get_all(&mut v5_conn)?.len(), 1);
     assert_eq!(SqlMessage::all(&mut v5_conn)?.len(), 1);
     assert!(SqlGlobalShortcutBinding::all(&mut v5_conn)?.is_empty());
+    assert_run_tables_empty(&mut v5_conn)?;
 
     drop(v4_conn);
     drop(v5_conn);
     let _ = fs::remove_file(v4_path);
     let _ = fs::remove_file(v5_path);
+    Ok(())
+}
+
+#[test]
+fn v5_migration_preserves_messages_and_creates_empty_run_tables() -> anyhow::Result<()> {
+    let v5_path = temp_db_path("v5-source");
+    let v6_path = temp_db_path("v6-target");
+    let mut v5_conn = SqliteConnection::establish(v5_path.to_str().expect("v5 path"))?;
+    let mut v6_conn = SqliteConnection::establish(v6_path.to_str().expect("v6 path"))?;
+
+    v5_conn.batch_execute(V5_CREATE_TABLE_SQL)?;
+    sql_query(
+        "insert into conversation_templates (id, name, icon, description, prompts, created_time, updated_time)
+         values (1, 'base', '🤖', null, '[]', '2026-01-01 00:00:00+00:00', '2026-01-01 00:00:00+00:00')",
+    )
+    .execute(&mut v5_conn)?;
+    sql_query(
+        "insert into conversations (id, folder_id, path, title, icon, created_time, updated_time, info)
+         values (1, null, '/默认', '默认', '🤖', '2026-01-01 00:00:00+00:00', '2026-01-01 00:00:00+00:00', null)",
+    )
+    .execute(&mut v5_conn)?;
+    sql_query(
+        "insert into messages (id, conversation_id, conversation_path, provider, role, content, send_content, status, created_time, updated_time, start_time, end_time, error)
+         values (1, 1, '/默认', 'OpenAI', 'assistant', '{\"text\":\"hello\",\"reasoningSummary\":\"why\",\"citations\":[{\"url\":\"https://example.com\"}]}', '{\"model\":\"gpt-4o\"}', 'normal', '2026-01-01 00:00:00+00:00', '2026-01-01 00:00:00+00:00', '2026-01-01 00:00:00+00:00', '2026-01-01 00:00:00+00:00', null)",
+    )
+    .execute(&mut v5_conn)?;
+
+    v5_to_v6(&mut v5_conn, &mut v6_conn)?;
+
+    let messages = SqlMessage::all(&mut v6_conn)?;
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].content["text"], "hello");
+    assert_eq!(messages[0].content["reasoningSummary"], "why");
+    assert_eq!(messages[0].send_content["model"], "gpt-4o");
+    assert_run_tables_empty(&mut v6_conn)?;
+
+    drop(v5_conn);
+    drop(v6_conn);
+    let _ = fs::remove_file(v5_path);
+    let _ = fs::remove_file(v6_path);
     Ok(())
 }

--- a/app/ai-chat/src/database/model.rs
+++ b/app/ai-chat/src/database/model.rs
@@ -9,6 +9,9 @@ mod conversation_templates;
 mod conversations;
 mod folders;
 mod global_shortcut_bindings;
+mod message_attachments;
+mod message_output_items;
+mod message_run_states;
 mod messages;
 pub use conversation_templates::{
     SqlConversationTemplate, SqlNewConversationTemplate, SqlUpdateConversationTemplate,
@@ -18,4 +21,7 @@ pub use folders::{SqlFolder, SqlNewFolder, SqlUpdateFolder};
 pub use global_shortcut_bindings::{
     SqlGlobalShortcutBinding, SqlNewGlobalShortcutBinding, SqlUpdateGlobalShortcutBinding,
 };
+pub use message_attachments::{SqlMessageAttachment, SqlNewMessageAttachment};
+pub use message_output_items::{SqlMessageOutputItem, SqlNewMessageOutputItem};
+pub use message_run_states::{SqlMessageRunState, SqlNewMessageRunState};
 pub use messages::{SqlMessage, SqlNewMessage};

--- a/app/ai-chat/src/database/model/message_attachments.rs
+++ b/app/ai-chat/src/database/model/message_attachments.rs
@@ -1,0 +1,81 @@
+use crate::{database::schema::message_attachments, errors::AiChatResult};
+use diesel::prelude::*;
+use time::OffsetDateTime;
+
+#[derive(Insertable)]
+#[diesel(table_name = message_attachments)]
+pub struct SqlNewMessageAttachment<'a> {
+    pub(in super::super) message_id: i32,
+    pub(in super::super) attachment_id: &'a str,
+    pub(in super::super) kind: &'a str,
+    pub(in super::super) mime_type: Option<&'a str>,
+    pub(in super::super) name: Option<&'a str>,
+    pub(in super::super) metadata: &'a serde_json::Value,
+    pub(in super::super) external_uri: Option<&'a str>,
+    pub(in super::super) path: Option<&'a str>,
+    pub(in super::super) sha256: Option<&'a str>,
+    pub(in super::super) created_time: OffsetDateTime,
+    pub(in super::super) updated_time: OffsetDateTime,
+}
+
+impl SqlNewMessageAttachment<'_> {
+    pub fn insert_many(data: &[Self], conn: &mut SqliteConnection) -> AiChatResult<()> {
+        if data.is_empty() {
+            return Ok(());
+        }
+        diesel::insert_into(message_attachments::table)
+            .values(data)
+            .execute(conn)?;
+        Ok(())
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Queryable)]
+pub struct SqlMessageAttachment {
+    pub id: i32,
+    pub message_id: i32,
+    pub attachment_id: String,
+    pub kind: String,
+    pub mime_type: Option<String>,
+    pub name: Option<String>,
+    pub metadata: serde_json::Value,
+    pub external_uri: Option<String>,
+    pub path: Option<String>,
+    pub sha256: Option<String>,
+    pub created_time: OffsetDateTime,
+    pub updated_time: OffsetDateTime,
+}
+
+impl SqlMessageAttachment {
+    #[cfg(test)]
+    pub fn query_by_message_id(
+        message_id: i32,
+        conn: &mut SqliteConnection,
+    ) -> AiChatResult<Vec<Self>> {
+        message_attachments::table
+            .filter(message_attachments::message_id.eq(message_id))
+            .order(message_attachments::id.asc())
+            .load::<Self>(conn)
+            .map_err(Into::into)
+    }
+
+    pub fn delete_by_message_id(message_id: i32, conn: &mut SqliteConnection) -> AiChatResult<()> {
+        diesel::delete(
+            message_attachments::table.filter(message_attachments::message_id.eq(message_id)),
+        )
+        .execute(conn)?;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub fn all(conn: &mut SqliteConnection) -> AiChatResult<Vec<Self>> {
+        message_attachments::table
+            .order((
+                message_attachments::message_id.asc(),
+                message_attachments::id.asc(),
+            ))
+            .load::<Self>(conn)
+            .map_err(Into::into)
+    }
+}

--- a/app/ai-chat/src/database/model/message_output_items.rs
+++ b/app/ai-chat/src/database/model/message_output_items.rs
@@ -1,0 +1,75 @@
+use crate::{database::schema::message_output_items, errors::AiChatResult};
+use diesel::prelude::*;
+use time::OffsetDateTime;
+
+#[derive(Insertable)]
+#[diesel(table_name = message_output_items)]
+pub struct SqlNewMessageOutputItem<'a> {
+    pub(in super::super) message_id: i32,
+    pub(in super::super) sequence: i32,
+    pub(in super::super) item_kind: &'a str,
+    pub(in super::super) provider_item_id: Option<&'a str>,
+    pub(in super::super) status: &'a str,
+    pub(in super::super) payload: &'a serde_json::Value,
+    pub(in super::super) created_time: OffsetDateTime,
+    pub(in super::super) updated_time: OffsetDateTime,
+}
+
+impl SqlNewMessageOutputItem<'_> {
+    pub fn insert_many(data: &[Self], conn: &mut SqliteConnection) -> AiChatResult<()> {
+        if data.is_empty() {
+            return Ok(());
+        }
+        diesel::insert_into(message_output_items::table)
+            .values(data)
+            .execute(conn)?;
+        Ok(())
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Queryable)]
+pub struct SqlMessageOutputItem {
+    pub id: i32,
+    pub message_id: i32,
+    pub sequence: i32,
+    pub item_kind: String,
+    pub provider_item_id: Option<String>,
+    pub status: String,
+    pub payload: serde_json::Value,
+    pub created_time: OffsetDateTime,
+    pub updated_time: OffsetDateTime,
+}
+
+impl SqlMessageOutputItem {
+    #[cfg(test)]
+    pub fn query_by_message_id(
+        message_id: i32,
+        conn: &mut SqliteConnection,
+    ) -> AiChatResult<Vec<Self>> {
+        message_output_items::table
+            .filter(message_output_items::message_id.eq(message_id))
+            .order(message_output_items::sequence.asc())
+            .load::<Self>(conn)
+            .map_err(Into::into)
+    }
+
+    pub fn delete_by_message_id(message_id: i32, conn: &mut SqliteConnection) -> AiChatResult<()> {
+        diesel::delete(
+            message_output_items::table.filter(message_output_items::message_id.eq(message_id)),
+        )
+        .execute(conn)?;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub fn all(conn: &mut SqliteConnection) -> AiChatResult<Vec<Self>> {
+        message_output_items::table
+            .order((
+                message_output_items::message_id.asc(),
+                message_output_items::sequence.asc(),
+            ))
+            .load::<Self>(conn)
+            .map_err(Into::into)
+    }
+}

--- a/app/ai-chat/src/database/model/message_run_states.rs
+++ b/app/ai-chat/src/database/model/message_run_states.rs
@@ -1,0 +1,73 @@
+use crate::{database::schema::message_run_states, errors::AiChatResult};
+use diesel::prelude::*;
+use time::OffsetDateTime;
+
+#[derive(Insertable)]
+#[diesel(table_name = message_run_states)]
+pub struct SqlNewMessageRunState<'a> {
+    pub(in super::super) message_id: i32,
+    pub(in super::super) provider: &'a str,
+    pub(in super::super) run_id: Option<&'a str>,
+    pub(in super::super) output_item_ids: &'a serde_json::Value,
+    pub(in super::super) continuation_metadata: &'a serde_json::Value,
+    pub(in super::super) request_body: &'a serde_json::Value,
+    pub(in super::super) usage: Option<&'a serde_json::Value>,
+    pub(in super::super) model: Option<&'a str>,
+    pub(in super::super) settings: Option<&'a serde_json::Value>,
+    pub(in super::super) created_time: OffsetDateTime,
+    pub(in super::super) updated_time: OffsetDateTime,
+}
+
+impl SqlNewMessageRunState<'_> {
+    pub fn insert(&self, conn: &mut SqliteConnection) -> AiChatResult<()> {
+        diesel::insert_into(message_run_states::table)
+            .values(self)
+            .execute(conn)?;
+        Ok(())
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Queryable)]
+pub struct SqlMessageRunState {
+    pub message_id: i32,
+    pub provider: String,
+    pub run_id: Option<String>,
+    pub output_item_ids: serde_json::Value,
+    pub continuation_metadata: serde_json::Value,
+    pub request_body: serde_json::Value,
+    pub usage: Option<serde_json::Value>,
+    pub model: Option<String>,
+    pub settings: Option<serde_json::Value>,
+    pub created_time: OffsetDateTime,
+    pub updated_time: OffsetDateTime,
+}
+
+impl SqlMessageRunState {
+    #[cfg(test)]
+    pub fn find_by_message_id(
+        message_id: i32,
+        conn: &mut SqliteConnection,
+    ) -> AiChatResult<Option<Self>> {
+        message_run_states::table
+            .filter(message_run_states::message_id.eq(message_id))
+            .first::<Self>(conn)
+            .optional()
+            .map_err(Into::into)
+    }
+
+    pub fn delete_by_message_id(message_id: i32, conn: &mut SqliteConnection) -> AiChatResult<()> {
+        diesel::delete(
+            message_run_states::table.filter(message_run_states::message_id.eq(message_id)),
+        )
+        .execute(conn)?;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub fn all(conn: &mut SqliteConnection) -> AiChatResult<Vec<Self>> {
+        message_run_states::table
+            .load::<Self>(conn)
+            .map_err(Into::into)
+    }
+}

--- a/app/ai-chat/src/database/model/messages.rs
+++ b/app/ai-chat/src/database/model/messages.rs
@@ -5,6 +5,8 @@ use crate::{
 use diesel::prelude::*;
 use time::OffsetDateTime;
 
+use super::{SqlMessageAttachment, SqlMessageOutputItem, SqlMessageRunState};
+
 #[derive(Insertable)]
 #[diesel(table_name = messages)]
 pub struct SqlNewMessage<'a> {
@@ -115,12 +117,26 @@ impl SqlMessage {
         conversation_id: i32,
         conn: &mut SqliteConnection,
     ) -> AiChatResult<()> {
+        let ids = messages::table
+            .filter(messages::conversation_id.eq(conversation_id))
+            .select(messages::id)
+            .load::<i32>(conn)?;
+        for id in ids {
+            delete_run_persistence(id, conn)?;
+        }
         diesel::delete(messages::table.filter(messages::conversation_id.eq(conversation_id)))
             .execute(conn)?;
         Ok(())
     }
     pub fn delete_by_path(path: &str, conn: &mut SqliteConnection) -> AiChatResult<()> {
         let path = format!("{path}/%");
+        let ids = messages::table
+            .filter(messages::conversation_path.like(&path))
+            .select(messages::id)
+            .load::<i32>(conn)?;
+        for id in ids {
+            delete_run_persistence(id, conn)?;
+        }
         diesel::delete(messages::table.filter(messages::conversation_path.like(path)))
             .execute(conn)?;
         Ok(())
@@ -169,6 +185,7 @@ impl SqlMessage {
         Ok(())
     }
     pub fn delete(id: i32, conn: &mut SqliteConnection) -> AiChatResult<()> {
+        delete_run_persistence(id, conn)?;
         diesel::delete(messages::table.filter(messages::id.eq(id))).execute(conn)?;
         Ok(())
     }
@@ -213,4 +230,11 @@ impl SqlMessage {
     pub fn all(conn: &mut SqliteConnection) -> AiChatResult<Vec<Self>> {
         messages::table.load::<Self>(conn).map_err(|e| e.into())
     }
+}
+
+fn delete_run_persistence(id: i32, conn: &mut SqliteConnection) -> AiChatResult<()> {
+    SqlMessageAttachment::delete_by_message_id(id, conn)?;
+    SqlMessageOutputItem::delete_by_message_id(id, conn)?;
+    SqlMessageRunState::delete_by_message_id(id, conn)?;
+    Ok(())
 }

--- a/app/ai-chat/src/database/schema.rs
+++ b/app/ai-chat/src/database/schema.rs
@@ -70,8 +70,58 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    message_run_states (message_id) {
+        message_id -> Integer,
+        provider -> Text,
+        run_id -> Nullable<Text>,
+        output_item_ids -> Json,
+        continuation_metadata -> Json,
+        request_body -> Json,
+        usage -> Nullable<Json>,
+        model -> Nullable<Text>,
+        settings -> Nullable<Json>,
+        created_time -> TimestamptzSqlite,
+        updated_time -> TimestamptzSqlite,
+    }
+}
+
+diesel::table! {
+    message_output_items (id) {
+        id -> Integer,
+        message_id -> Integer,
+        sequence -> Integer,
+        item_kind -> Text,
+        provider_item_id -> Nullable<Text>,
+        status -> Text,
+        payload -> Json,
+        created_time -> TimestamptzSqlite,
+        updated_time -> TimestamptzSqlite,
+    }
+}
+
+diesel::table! {
+    message_attachments (id) {
+        id -> Integer,
+        message_id -> Integer,
+        attachment_id -> Text,
+        kind -> Text,
+        mime_type -> Nullable<Text>,
+        name -> Nullable<Text>,
+        metadata -> Json,
+        external_uri -> Nullable<Text>,
+        path -> Nullable<Text>,
+        sha256 -> Nullable<Text>,
+        created_time -> TimestamptzSqlite,
+        updated_time -> TimestamptzSqlite,
+    }
+}
+
 diesel::joinable!(conversations -> folders (folder_id));
 diesel::joinable!(global_shortcut_bindings -> conversation_templates (template_id));
+diesel::joinable!(message_attachments -> messages (message_id));
+diesel::joinable!(message_output_items -> messages (message_id));
+diesel::joinable!(message_run_states -> messages (message_id));
 diesel::joinable!(messages -> conversations (conversation_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
@@ -79,5 +129,8 @@ diesel::allow_tables_to_appear_in_same_query!(
     conversations,
     folders,
     global_shortcut_bindings,
+    message_attachments,
+    message_output_items,
+    message_run_states,
     messages,
 );

--- a/app/ai-chat/src/database/service.rs
+++ b/app/ai-chat/src/database/service.rs
@@ -22,3 +22,7 @@ pub use global_shortcut_bindings::{
     GlobalShortcutBinding, NewGlobalShortcutBinding, UpdateGlobalShortcutBinding,
 };
 pub use messages::{Content, Message, NewMessage, UrlCitation};
+pub(crate) use messages::{
+    MessageAttachment, MessageAttachmentKind, MessageOutputItem, MessageOutputItemStatus,
+    MessageRunPersistence, MessageRunState,
+};

--- a/app/ai-chat/src/database/service/messages.rs
+++ b/app/ai-chat/src/database/service/messages.rs
@@ -2,9 +2,17 @@ use super::utils::{deserialize_offset_date_time, serialize_offset_date_time};
 use crate::{
     database::{
         Role, Status,
-        model::{SqlConversation, SqlMessage, SqlNewMessage},
+        model::{
+            SqlConversation, SqlMessage, SqlMessageAttachment, SqlMessageOutputItem,
+            SqlMessageRunState, SqlNewMessage, SqlNewMessageAttachment, SqlNewMessageOutputItem,
+            SqlNewMessageRunState,
+        },
     },
     errors::{AiChatError, AiChatResult},
+    llm::{
+        LlmAttachmentRef, LlmContentPart, LlmHostedToolCall, LlmMcpApprovalRequest, LlmOutputItem,
+        LlmToolCall, LlmToolResult, ProviderRunState, ProviderUsage,
+    },
 };
 use diesel::SqliteConnection;
 use serde::{Deserialize, Serialize};
@@ -177,6 +185,261 @@ mod content_tests {
     }
 }
 
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct MessageRunPersistence {
+    pub(crate) run_state: Option<MessageRunState>,
+    pub(crate) output_items: Vec<MessageOutputItem>,
+    pub(crate) attachments: Vec<MessageAttachment>,
+}
+
+impl MessageRunPersistence {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.run_state.is_none() && self.output_items.is_empty() && self.attachments.is_empty()
+    }
+
+    pub(crate) fn with_deduped_attachments(mut self) -> Self {
+        let mut seen = HashSet::new();
+        self.attachments
+            .retain(|attachment| seen.insert((attachment.attachment_id.clone(), attachment.kind)));
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct MessageRunState {
+    pub(crate) provider: String,
+    pub(crate) run_id: Option<String>,
+    pub(crate) output_item_ids: Vec<String>,
+    pub(crate) continuation_metadata: serde_json::Value,
+    pub(crate) request_body: serde_json::Value,
+    pub(crate) usage: Option<ProviderUsage>,
+    pub(crate) model: Option<String>,
+    pub(crate) settings: Option<serde_json::Value>,
+}
+
+impl MessageRunState {
+    pub(crate) fn from_provider_state(
+        state: ProviderRunState,
+        usage: Option<ProviderUsage>,
+        model: Option<String>,
+        settings: Option<serde_json::Value>,
+    ) -> Self {
+        Self {
+            provider: state.provider_name,
+            run_id: state.run_id,
+            output_item_ids: state.output_item_ids,
+            continuation_metadata: state.continuation_metadata,
+            request_body: state.request_body,
+            usage,
+            model,
+            settings,
+        }
+    }
+
+    pub(crate) fn from_request_snapshot(
+        provider: impl Into<String>,
+        request_body: serde_json::Value,
+        usage: Option<ProviderUsage>,
+        model: Option<String>,
+        settings: Option<serde_json::Value>,
+    ) -> Self {
+        Self {
+            provider: provider.into(),
+            run_id: None,
+            output_item_ids: Vec::new(),
+            continuation_metadata: serde_json::Value::Null,
+            request_body,
+            usage,
+            model,
+            settings,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum MessageOutputItemStatus {
+    Added,
+    Done,
+    ToolCallRequested,
+    ToolResultReceived,
+    McpApprovalRequested,
+}
+
+impl MessageOutputItemStatus {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Added => "added",
+            Self::Done => "done",
+            Self::ToolCallRequested => "tool_call_requested",
+            Self::ToolResultReceived => "tool_result_received",
+            Self::McpApprovalRequested => "mcp_approval_requested",
+        }
+    }
+
+    fn parse(value: &str) -> AiChatResult<Self> {
+        Ok(match value {
+            "added" => Self::Added,
+            "done" => Self::Done,
+            "tool_call_requested" => Self::ToolCallRequested,
+            "tool_result_received" => Self::ToolResultReceived,
+            "mcp_approval_requested" => Self::McpApprovalRequested,
+            _ => {
+                return Err(AiChatError::StreamError(format!(
+                    "unknown message output item status: {value}"
+                )));
+            }
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct MessageOutputItem {
+    pub(crate) sequence: i32,
+    pub(crate) item: LlmOutputItem,
+    pub(crate) status: MessageOutputItemStatus,
+}
+
+impl MessageOutputItem {
+    pub(crate) fn new(sequence: i32, item: LlmOutputItem, status: MessageOutputItemStatus) -> Self {
+        Self {
+            sequence,
+            item,
+            status,
+        }
+    }
+
+    fn item_kind(&self) -> &'static str {
+        output_item_kind(&self.item)
+    }
+
+    fn provider_item_id(&self) -> Option<&str> {
+        output_item_provider_item_id(&self.item)
+    }
+
+    pub(crate) fn attachments(&self) -> Vec<MessageAttachment> {
+        output_item_attachments(&self.item)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Hash)]
+pub(crate) enum MessageAttachmentKind {
+    Image,
+    File,
+    Audio,
+    Generic,
+}
+
+impl MessageAttachmentKind {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Image => "image",
+            Self::File => "file",
+            Self::Audio => "audio",
+            Self::Generic => "generic",
+        }
+    }
+
+    fn parse(value: &str) -> AiChatResult<Self> {
+        Ok(match value {
+            "image" => Self::Image,
+            "file" => Self::File,
+            "audio" => Self::Audio,
+            "generic" => Self::Generic,
+            _ => {
+                return Err(AiChatError::StreamError(format!(
+                    "unknown message attachment kind: {value}"
+                )));
+            }
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct MessageAttachment {
+    pub(crate) attachment_id: String,
+    pub(crate) kind: MessageAttachmentKind,
+    pub(crate) mime_type: Option<String>,
+    pub(crate) name: Option<String>,
+    pub(crate) metadata: serde_json::Value,
+    pub(crate) external_uri: Option<String>,
+    pub(crate) path: Option<String>,
+    pub(crate) sha256: Option<String>,
+}
+
+impl MessageAttachment {
+    pub(crate) fn from_ref(kind: MessageAttachmentKind, attachment: &LlmAttachmentRef) -> Self {
+        Self {
+            attachment_id: attachment.id.clone(),
+            kind,
+            mime_type: attachment.mime_type.clone(),
+            name: attachment.name.clone(),
+            metadata: serde_json::json!({}),
+            external_uri: None,
+            path: None,
+            sha256: None,
+        }
+    }
+}
+
+fn output_item_kind(item: &LlmOutputItem) -> &'static str {
+    match item {
+        LlmOutputItem::Message { .. } => "message",
+        LlmOutputItem::Reasoning { .. } => "reasoning",
+        LlmOutputItem::ToolCall(_) => "tool_call",
+        LlmOutputItem::ToolResult(_) => "tool_result",
+        LlmOutputItem::McpApproval(_) => "mcp_approval",
+        LlmOutputItem::HostedToolCall(_) => "hosted_tool_call",
+    }
+}
+
+fn output_item_provider_item_id(item: &LlmOutputItem) -> Option<&str> {
+    match item {
+        LlmOutputItem::ToolCall(LlmToolCall { call_id, .. })
+        | LlmOutputItem::ToolResult(LlmToolResult { call_id, .. })
+        | LlmOutputItem::HostedToolCall(LlmHostedToolCall { call_id, .. }) => Some(call_id),
+        LlmOutputItem::McpApproval(LlmMcpApprovalRequest { request_id, .. }) => Some(request_id),
+        LlmOutputItem::Message { .. } | LlmOutputItem::Reasoning { .. } => None,
+    }
+}
+
+fn output_item_attachments(item: &LlmOutputItem) -> Vec<MessageAttachment> {
+    match item {
+        LlmOutputItem::Message { content, .. }
+        | LlmOutputItem::ToolResult(LlmToolResult { content, .. }) => {
+            content_parts_attachments(content)
+        }
+        LlmOutputItem::Reasoning { .. }
+        | LlmOutputItem::ToolCall(_)
+        | LlmOutputItem::McpApproval(_)
+        | LlmOutputItem::HostedToolCall(_) => Vec::new(),
+    }
+}
+
+fn content_parts_attachments(content: &[LlmContentPart]) -> Vec<MessageAttachment> {
+    content
+        .iter()
+        .filter_map(|part| match part {
+            LlmContentPart::ImageRef(attachment) => Some(MessageAttachment::from_ref(
+                MessageAttachmentKind::Image,
+                attachment,
+            )),
+            LlmContentPart::FileRef(attachment) => Some(MessageAttachment::from_ref(
+                MessageAttachmentKind::File,
+                attachment,
+            )),
+            LlmContentPart::AudioRef(attachment) => Some(MessageAttachment::from_ref(
+                MessageAttachmentKind::Audio,
+                attachment,
+            )),
+            LlmContentPart::AttachmentRef(attachment) => Some(MessageAttachment::from_ref(
+                MessageAttachmentKind::Generic,
+                attachment,
+            )),
+            LlmContentPart::Text(_) => None,
+        })
+        .collect()
+}
+
 #[derive(Debug, Serialize, Clone, Deserialize, PartialEq, Eq)]
 pub struct Message {
     pub id: i32,
@@ -248,6 +511,7 @@ pub struct NewMessage<'a> {
     pub send_content: &'a serde_json::Value,
     pub status: Status,
     pub error: Option<&'a str>,
+    pub(crate) run_persistence: Option<&'a MessageRunPersistence>,
 }
 
 impl<'a> NewMessage<'a> {
@@ -267,6 +531,7 @@ impl<'a> NewMessage<'a> {
             send_content,
             status,
             error: None,
+            run_persistence: None,
         }
     }
 
@@ -274,6 +539,159 @@ impl<'a> NewMessage<'a> {
         self.error = Some(error);
         self
     }
+
+    pub(crate) fn with_run_persistence(
+        mut self,
+        run_persistence: &'a MessageRunPersistence,
+    ) -> Self {
+        self.run_persistence = Some(run_persistence);
+        self
+    }
+}
+
+impl TryFrom<SqlMessageRunState> for MessageRunState {
+    type Error = AiChatError;
+
+    fn try_from(value: SqlMessageRunState) -> Result<Self, Self::Error> {
+        Ok(Self {
+            provider: value.provider,
+            run_id: value.run_id,
+            output_item_ids: serde_json::from_value(value.output_item_ids)?,
+            continuation_metadata: value.continuation_metadata,
+            request_body: value.request_body,
+            usage: value.usage.map(serde_json::from_value).transpose()?,
+            model: value.model,
+            settings: value.settings,
+        })
+    }
+}
+
+impl TryFrom<SqlMessageOutputItem> for MessageOutputItem {
+    type Error = AiChatError;
+
+    fn try_from(value: SqlMessageOutputItem) -> Result<Self, Self::Error> {
+        Ok(Self {
+            sequence: value.sequence,
+            item: serde_json::from_value(value.payload)?,
+            status: MessageOutputItemStatus::parse(&value.status)?,
+        })
+    }
+}
+
+impl TryFrom<SqlMessageAttachment> for MessageAttachment {
+    type Error = AiChatError;
+
+    fn try_from(value: SqlMessageAttachment) -> Result<Self, Self::Error> {
+        Ok(Self {
+            attachment_id: value.attachment_id,
+            kind: MessageAttachmentKind::parse(&value.kind)?,
+            mime_type: value.mime_type,
+            name: value.name,
+            metadata: value.metadata,
+            external_uri: value.external_uri,
+            path: value.path,
+            sha256: value.sha256,
+        })
+    }
+}
+
+fn clear_message_run_persistence(id: i32, conn: &mut SqliteConnection) -> AiChatResult<()> {
+    SqlMessageAttachment::delete_by_message_id(id, conn)?;
+    SqlMessageOutputItem::delete_by_message_id(id, conn)?;
+    SqlMessageRunState::delete_by_message_id(id, conn)?;
+    Ok(())
+}
+
+fn replace_message_run_persistence(
+    id: i32,
+    run_persistence: &MessageRunPersistence,
+    time: OffsetDateTime,
+    conn: &mut SqliteConnection,
+) -> AiChatResult<()> {
+    clear_message_run_persistence(id, conn)?;
+    if run_persistence.is_empty() {
+        return Ok(());
+    }
+
+    if let Some(run_state) = run_persistence.run_state.as_ref() {
+        let output_item_ids = serde_json::to_value(&run_state.output_item_ids)?;
+        let usage = run_state
+            .usage
+            .as_ref()
+            .map(serde_json::to_value)
+            .transpose()?;
+        SqlNewMessageRunState {
+            message_id: id,
+            provider: &run_state.provider,
+            run_id: run_state.run_id.as_deref(),
+            output_item_ids: &output_item_ids,
+            continuation_metadata: &run_state.continuation_metadata,
+            request_body: &run_state.request_body,
+            usage: usage.as_ref(),
+            model: run_state.model.as_deref(),
+            settings: run_state.settings.as_ref(),
+            created_time: time,
+            updated_time: time,
+        }
+        .insert(conn)?;
+    }
+
+    struct OutputInsertValue {
+        sequence: i32,
+        item_kind: &'static str,
+        provider_item_id: Option<String>,
+        status: &'static str,
+        payload: serde_json::Value,
+    }
+
+    let output_values = run_persistence
+        .output_items
+        .iter()
+        .map(|item| {
+            Ok(OutputInsertValue {
+                sequence: item.sequence,
+                item_kind: item.item_kind(),
+                provider_item_id: item.provider_item_id().map(ToString::to_string),
+                status: item.status.as_str(),
+                payload: serde_json::to_value(&item.item)?,
+            })
+        })
+        .collect::<AiChatResult<Vec<_>>>()?;
+    let output_rows = output_values
+        .iter()
+        .map(|value| SqlNewMessageOutputItem {
+            message_id: id,
+            sequence: value.sequence,
+            item_kind: value.item_kind,
+            provider_item_id: value.provider_item_id.as_deref(),
+            status: value.status,
+            payload: &value.payload,
+            created_time: time,
+            updated_time: time,
+        })
+        .collect::<Vec<_>>();
+    SqlNewMessageOutputItem::insert_many(&output_rows, conn)?;
+
+    let run_persistence = run_persistence.clone().with_deduped_attachments();
+    let attachment_rows = run_persistence
+        .attachments
+        .iter()
+        .map(|attachment| SqlNewMessageAttachment {
+            message_id: id,
+            attachment_id: &attachment.attachment_id,
+            kind: attachment.kind.as_str(),
+            mime_type: attachment.mime_type.as_deref(),
+            name: attachment.name.as_deref(),
+            metadata: &attachment.metadata,
+            external_uri: attachment.external_uri.as_deref(),
+            path: attachment.path.as_deref(),
+            sha256: attachment.sha256.as_deref(),
+            created_time: time,
+            updated_time: time,
+        })
+        .collect::<Vec<_>>();
+    SqlNewMessageAttachment::insert_many(&attachment_rows, conn)?;
+    Ok(())
 }
 
 impl Message {
@@ -286,6 +704,7 @@ impl Message {
             send_content,
             status,
             error,
+            run_persistence,
         }: NewMessage<'_>,
         conn: &mut SqliteConnection,
     ) -> AiChatResult<Message> {
@@ -311,6 +730,9 @@ impl Message {
                 error,
             };
             let message = new_message.insert(conn)?;
+            if let Some(run_persistence) = run_persistence {
+                replace_message_run_persistence(message.id, run_persistence, time, conn)?;
+            }
             Message::try_from(message)
         })
     }
@@ -362,9 +784,210 @@ impl Message {
         SqlMessage::update_content(id, serde_json::to_value(content)?, time, conn)?;
         Ok(time)
     }
+    #[cfg(test)]
+    pub(crate) fn run_persistence(
+        id: i32,
+        conn: &mut SqliteConnection,
+    ) -> AiChatResult<MessageRunPersistence> {
+        let run_state = SqlMessageRunState::find_by_message_id(id, conn)?
+            .map(TryFrom::try_from)
+            .transpose()?;
+        let output_items = SqlMessageOutputItem::query_by_message_id(id, conn)?
+            .into_iter()
+            .map(TryFrom::try_from)
+            .collect::<AiChatResult<_>>()?;
+        let attachments = SqlMessageAttachment::query_by_message_id(id, conn)?
+            .into_iter()
+            .map(TryFrom::try_from)
+            .collect::<AiChatResult<_>>()?;
+        Ok(MessageRunPersistence {
+            run_state,
+            output_items,
+            attachments,
+        })
+    }
+    pub(crate) fn replace_run_persistence(
+        id: i32,
+        run_persistence: &MessageRunPersistence,
+        conn: &mut SqliteConnection,
+    ) -> AiChatResult<()> {
+        let time = OffsetDateTime::now_utc();
+        replace_message_run_persistence(id, run_persistence, time, conn)
+    }
     pub fn reset_for_resend(id: i32, conn: &mut SqliteConnection) -> AiChatResult<()> {
         let time = OffsetDateTime::now_utc();
-        SqlMessage::reset_for_resend(id, serde_json::to_value(Content::default())?, time, conn)?;
+        conn.immediate_transaction(|conn| {
+            SqlMessage::reset_for_resend(
+                id,
+                serde_json::to_value(Content::default())?,
+                time,
+                conn,
+            )?;
+            clear_message_run_persistence(id, conn)
+        })?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod run_persistence_tests {
+    use super::{
+        Content, Message, MessageAttachment, MessageAttachmentKind, MessageOutputItem,
+        MessageOutputItemStatus, MessageRunPersistence, MessageRunState, NewMessage,
+    };
+    use crate::{
+        database::{
+            CREATE_TABLE_SQL, NewConversation, Role, Status,
+            model::{SqlMessageAttachment, SqlMessageOutputItem, SqlMessageRunState},
+        },
+        llm::{LlmHostedToolCall, LlmOutputItem, ProviderRunState, ProviderUsage},
+    };
+    use diesel::{Connection, SqliteConnection, connection::SimpleConnection};
+
+    fn conn() -> anyhow::Result<SqliteConnection> {
+        let mut conn = SqliteConnection::establish(":memory:")?;
+        conn.batch_execute(CREATE_TABLE_SQL)?;
+        Ok(conn)
+    }
+
+    fn insert_conversation(conn: &mut SqliteConnection) -> anyhow::Result<i32> {
+        insert_conversation_named("test", conn)
+    }
+
+    fn insert_conversation_named(title: &str, conn: &mut SqliteConnection) -> anyhow::Result<i32> {
+        let conversation = crate::database::Conversation::insert(
+            NewConversation {
+                title,
+                folder_id: None,
+                icon: "T",
+                info: None,
+            },
+            conn,
+        )?;
+        Ok(conversation.id)
+    }
+
+    fn insert_assistant_message(conn: &mut SqliteConnection) -> anyhow::Result<Message> {
+        let conversation_id = insert_conversation(conn)?;
+        Ok(Message::insert(
+            NewMessage::new(
+                conversation_id,
+                "OpenAI",
+                Role::Assistant,
+                &Content::default(),
+                &serde_json::json!({"model": "gpt-4o"}),
+                Status::Normal,
+            ),
+            conn,
+        )?)
+    }
+
+    fn sample_persistence() -> MessageRunPersistence {
+        let state = ProviderRunState::new(
+            "OpenAI",
+            Some("resp_1".to_string()),
+            vec!["item_1".to_string()],
+            serde_json::json!({"model": "gpt-4o"}),
+        );
+        MessageRunPersistence {
+            run_state: Some(MessageRunState::from_provider_state(
+                state,
+                Some(ProviderUsage::new(Some(3), Some(5), Some(8))),
+                Some("gpt-4o".to_string()),
+                Some(serde_json::json!({"base_url": "https://example.com"})),
+            )),
+            output_items: vec![
+                MessageOutputItem::new(
+                    0,
+                    LlmOutputItem::Reasoning {
+                        summary: Some("thinking".to_string()),
+                    },
+                    MessageOutputItemStatus::Added,
+                ),
+                MessageOutputItem::new(
+                    1,
+                    LlmOutputItem::HostedToolCall(LlmHostedToolCall {
+                        call_id: "call_1".to_string(),
+                        tool_type: "web_search_call".to_string(),
+                        status: Some("completed".to_string()),
+                    }),
+                    MessageOutputItemStatus::Done,
+                ),
+            ],
+            attachments: vec![MessageAttachment {
+                attachment_id: "att_1".to_string(),
+                kind: MessageAttachmentKind::File,
+                mime_type: Some("text/plain".to_string()),
+                name: Some("notes.txt".to_string()),
+                metadata: serde_json::json!({"source": "test"}),
+                external_uri: None,
+                path: Some("/tmp/notes.txt".to_string()),
+                sha256: Some("abc".to_string()),
+            }],
+        }
+    }
+
+    #[test]
+    fn message_run_persistence_round_trips_state_usage_and_items() -> anyhow::Result<()> {
+        let mut conn = conn()?;
+        let message = insert_assistant_message(&mut conn)?;
+        let persistence = sample_persistence();
+
+        Message::replace_run_persistence(message.id, &persistence, &mut conn)?;
+
+        let loaded = Message::run_persistence(message.id, &mut conn)?;
+        assert_eq!(loaded.run_state, persistence.run_state);
+        assert_eq!(loaded.output_items, persistence.output_items);
+        assert_eq!(loaded.attachments, persistence.attachments);
+        Ok(())
+    }
+
+    #[test]
+    fn reset_for_resend_clears_run_persistence() -> anyhow::Result<()> {
+        let mut conn = conn()?;
+        let message = insert_assistant_message(&mut conn)?;
+        Message::replace_run_persistence(message.id, &sample_persistence(), &mut conn)?;
+
+        Message::reset_for_resend(message.id, &mut conn)?;
+
+        assert!(Message::run_persistence(message.id, &mut conn)?.is_empty());
+        let reloaded = Message::find(message.id, &mut conn)?;
+        assert_eq!(reloaded.content, Content::default());
+        assert_eq!(reloaded.status, Status::Loading);
+        Ok(())
+    }
+
+    #[test]
+    fn message_delete_and_conversation_clear_remove_run_rows() -> anyhow::Result<()> {
+        let mut conn = conn()?;
+        let message = insert_assistant_message(&mut conn)?;
+        Message::replace_run_persistence(message.id, &sample_persistence(), &mut conn)?;
+
+        Message::delete(message.id, &mut conn)?;
+
+        assert!(SqlMessageRunState::all(&mut conn)?.is_empty());
+        assert!(SqlMessageOutputItem::all(&mut conn)?.is_empty());
+        assert!(SqlMessageAttachment::all(&mut conn)?.is_empty());
+
+        let conversation_id = insert_conversation_named("test-2", &mut conn)?;
+        let message = Message::insert(
+            NewMessage::new(
+                conversation_id,
+                "OpenAI",
+                Role::Assistant,
+                &Content::default(),
+                &serde_json::json!({"model": "gpt-4o"}),
+                Status::Normal,
+            ),
+            &mut conn,
+        )?;
+        Message::replace_run_persistence(message.id, &sample_persistence(), &mut conn)?;
+
+        Message::delete_by_conversation_id(conversation_id, &mut conn)?;
+
+        assert!(SqlMessageRunState::all(&mut conn)?.is_empty());
+        assert!(SqlMessageOutputItem::all(&mut conn)?.is_empty());
+        assert!(SqlMessageAttachment::all(&mut conn)?.is_empty());
         Ok(())
     }
 }

--- a/app/ai-chat/src/features/home/tabs/conversation_panel.rs
+++ b/app/ai-chat/src/features/home/tabs/conversation_panel.rs
@@ -4,7 +4,9 @@ use crate::{
         chat_form::ChatFormSnapshot,
         delete_confirm::{DestructiveAction, open_destructive_confirm_dialog},
     },
-    database::{Content, Conversation, Db, Message, Mode, NewMessage, Role, Status},
+    database::{
+        Content, Conversation, Db, Message, MessageRunPersistence, Mode, NewMessage, Role, Status,
+    },
     errors::{AiChatError, AiChatResult},
     features::conversation::detail::{
         ConversationDetailView, ConversationDetailViewExt, MessageRevisionExt,
@@ -13,8 +15,8 @@ use crate::{
     foundation::assets::IconName,
     foundation::i18n::I18n,
     llm::{
-        LlmHistoryMessage, ProviderRunEvent, ProviderRunRequest, ProviderRunRunner,
-        build_input_items, provider_by_name,
+        LlmHistoryMessage, ProviderRunEvent, ProviderRunPersistenceAccumulator, ProviderRunRequest,
+        ProviderRunRunner, build_input_items, provider_by_name,
     },
     platform::gpui_ext::{AsyncWindowContextResultExt, EntityResultExt, WeakEntityResultExt},
     state::{
@@ -378,7 +380,7 @@ impl ConversationPanelView {
         });
         let conn = &mut cx.global::<Db>().get()?;
         for message in &paused_messages {
-            Self::persist_message_snapshot(message, conn)?;
+            Self::persist_message_snapshot(message, None, conn)?;
         }
         self.set_chat_form_running(false, cx);
         cx.notify();
@@ -406,7 +408,7 @@ impl ConversationPanelView {
         };
 
         let conn = &mut cx.global::<Db>().get()?;
-        Self::persist_message_snapshot(&message, conn)?;
+        Self::persist_message_snapshot(&message, None, conn)?;
         self.set_chat_form_running(false, cx);
         cx.notify();
         Ok(())
@@ -549,6 +551,7 @@ impl ConversationPanelView {
             .clone();
         let request =
             ProviderRunRequest::from_request_body(provider.name(), context.request_body.clone());
+        let mut run_persistence = ProviderRunPersistenceAccumulator::new(&request, &context.config);
         let stream = provider.run(context.config, settings, &request);
         pin_mut!(stream);
         while let Some(message) = stream.next().await {
@@ -580,7 +583,12 @@ impl ConversationPanelView {
                         cx,
                     )?;
                 }
-                Ok(ProviderRunEvent::Completed { content, .. }) => {
+                Ok(ProviderRunEvent::Completed {
+                    content,
+                    state,
+                    usage,
+                }) => {
+                    run_persistence.record_completed(state, usage);
                     Self::replace_assistant_message_content_by_id(
                         &context.chat_data,
                         context.conversation_id,
@@ -589,14 +597,24 @@ impl ConversationPanelView {
                         cx,
                     )?;
                 }
-                Ok(
-                    ProviderRunEvent::OutputItemAdded(_)
-                    | ProviderRunEvent::OutputItemDone(_)
-                    | ProviderRunEvent::ToolCallRequested(_)
-                    | ProviderRunEvent::ToolResultReceived(_)
-                    | ProviderRunEvent::McpApprovalRequested(_)
-                    | ProviderRunEvent::UsageUpdated(_),
-                ) => {}
+                Ok(ProviderRunEvent::OutputItemAdded(item)) => {
+                    run_persistence.record_output_item_added(item);
+                }
+                Ok(ProviderRunEvent::OutputItemDone(item)) => {
+                    run_persistence.record_output_item_done(item);
+                }
+                Ok(ProviderRunEvent::ToolCallRequested(tool_call)) => {
+                    run_persistence.record_tool_call_requested(tool_call);
+                }
+                Ok(ProviderRunEvent::ToolResultReceived(tool_result)) => {
+                    run_persistence.record_tool_result_received(tool_result);
+                }
+                Ok(ProviderRunEvent::McpApprovalRequested(request)) => {
+                    run_persistence.record_mcp_approval_requested(request);
+                }
+                Ok(ProviderRunEvent::UsageUpdated(usage)) => {
+                    run_persistence.record_usage(usage);
+                }
                 Ok(ProviderRunEvent::Failed { message }) => {
                     Self::record_stream_error(
                         state,
@@ -604,6 +622,7 @@ impl ConversationPanelView {
                         context.conversation_id,
                         assistant_message_id,
                         message,
+                        run_persistence.persistence(),
                         cx,
                     )?;
                     return Ok(());
@@ -616,6 +635,7 @@ impl ConversationPanelView {
                         context.conversation_id,
                         assistant_message_id,
                         error.to_string(),
+                        run_persistence.persistence(),
                         cx,
                     )?;
                     return Ok(());
@@ -627,6 +647,7 @@ impl ConversationPanelView {
             &context.chat_data,
             context.conversation_id,
             assistant_message_id,
+            run_persistence.persistence(),
             cx,
         )?;
         Ok(())
@@ -755,6 +776,8 @@ impl ConversationPanelView {
         assistant_message_id: i32,
         cx: &mut AsyncWindowContext,
     ) -> AiChatResult<()> {
+        let mut run_persistence =
+            ProviderRunPersistenceAccumulator::new(runner.run_request(), runner.get_config());
         let stream = runner.run();
         pin_mut!(stream);
         while let Some(message) = stream.next().await {
@@ -778,7 +801,12 @@ impl ConversationPanelView {
                 Ok(ProviderRunEvent::TextDelta(delta)) => {
                     Self::append_assistant_message(context, assistant_message_id, delta, cx)?;
                 }
-                Ok(ProviderRunEvent::Completed { content, .. }) => {
+                Ok(ProviderRunEvent::Completed {
+                    content,
+                    state,
+                    usage,
+                }) => {
+                    run_persistence.record_completed(state, usage);
                     Self::replace_assistant_message_content(
                         context,
                         assistant_message_id,
@@ -786,14 +814,24 @@ impl ConversationPanelView {
                         cx,
                     )?;
                 }
-                Ok(
-                    ProviderRunEvent::OutputItemAdded(_)
-                    | ProviderRunEvent::OutputItemDone(_)
-                    | ProviderRunEvent::ToolCallRequested(_)
-                    | ProviderRunEvent::ToolResultReceived(_)
-                    | ProviderRunEvent::McpApprovalRequested(_)
-                    | ProviderRunEvent::UsageUpdated(_),
-                ) => {}
+                Ok(ProviderRunEvent::OutputItemAdded(item)) => {
+                    run_persistence.record_output_item_added(item);
+                }
+                Ok(ProviderRunEvent::OutputItemDone(item)) => {
+                    run_persistence.record_output_item_done(item);
+                }
+                Ok(ProviderRunEvent::ToolCallRequested(tool_call)) => {
+                    run_persistence.record_tool_call_requested(tool_call);
+                }
+                Ok(ProviderRunEvent::ToolResultReceived(tool_result)) => {
+                    run_persistence.record_tool_result_received(tool_result);
+                }
+                Ok(ProviderRunEvent::McpApprovalRequested(request)) => {
+                    run_persistence.record_mcp_approval_requested(request);
+                }
+                Ok(ProviderRunEvent::UsageUpdated(usage)) => {
+                    run_persistence.record_usage(usage);
+                }
                 Ok(ProviderRunEvent::Failed { message }) => {
                     Self::record_stream_error(
                         state,
@@ -801,6 +839,7 @@ impl ConversationPanelView {
                         context.conversation_id,
                         assistant_message_id,
                         message,
+                        run_persistence.persistence(),
                         cx,
                     )?;
                     return Ok(());
@@ -813,6 +852,7 @@ impl ConversationPanelView {
                         context.conversation_id,
                         assistant_message_id,
                         error.to_string(),
+                        run_persistence.persistence(),
                         cx,
                     )?;
                     return Ok(());
@@ -824,6 +864,7 @@ impl ConversationPanelView {
             &context.chat_data,
             context.conversation_id,
             assistant_message_id,
+            run_persistence.persistence(),
             cx,
         )?;
         Ok(())
@@ -995,6 +1036,7 @@ impl ConversationPanelView {
         conversation_id: i32,
         assistant_message_id: i32,
         error: String,
+        run_persistence: Option<MessageRunPersistence>,
         cx: &mut AsyncWindowContext,
     ) -> AiChatResult<()> {
         let now = OffsetDateTime::now_utc();
@@ -1013,7 +1055,7 @@ impl ConversationPanelView {
         if let Some(message) = message {
             cx.read_global_result(|db: &Db, _window, _cx| {
                 let conn = &mut db.get()?;
-                Self::persist_message_snapshot(&message, conn)
+                Self::persist_message_snapshot(&message, run_persistence.as_ref(), conn)
             })??;
         }
         state.update_result(cx, |this, cx| {
@@ -1027,6 +1069,7 @@ impl ConversationPanelView {
         chat_data: &Entity<AiChatResult<ChatDataInner>>,
         conversation_id: i32,
         assistant_message_id: i32,
+        run_persistence: Option<MessageRunPersistence>,
         cx: &mut AsyncWindowContext,
     ) -> AiChatResult<()> {
         let now = OffsetDateTime::now_utc();
@@ -1045,7 +1088,7 @@ impl ConversationPanelView {
         if let Some(message) = message {
             cx.read_global_result(|db: &Db, _window, _cx| {
                 let conn = &mut db.get()?;
-                Self::persist_message_snapshot(&message, conn)
+                Self::persist_message_snapshot(&message, run_persistence.as_ref(), conn)
             })??;
         }
         state.update_result(cx, |this, cx| {
@@ -1080,16 +1123,24 @@ impl ConversationPanelView {
 
     fn persist_message_snapshot(
         message: &Message,
+        run_persistence: Option<&MessageRunPersistence>,
         conn: &mut diesel::SqliteConnection,
     ) -> AiChatResult<()> {
-        Message::update_content(message.id, &message.content, conn)?;
-        match message.status {
-            Status::Error => {
-                Message::record_error(message.id, message.error.clone().unwrap_or_default(), conn)?
+        conn.immediate_transaction(|conn| {
+            Message::update_content(message.id, &message.content, conn)?;
+            match message.status {
+                Status::Error => Message::record_error(
+                    message.id,
+                    message.error.clone().unwrap_or_default(),
+                    conn,
+                )?,
+                status => Message::update_status(message.id, status, conn)?,
             }
-            status => Message::update_status(message.id, status, conn)?,
-        }
-        Ok(())
+            if let Some(run_persistence) = run_persistence {
+                Message::replace_run_persistence(message.id, run_persistence, conn)?;
+            }
+            Ok(())
+        })
     }
 
     fn replace_chat_message_by_id(

--- a/app/ai-chat/src/features/temporary/detail.rs
+++ b/app/ai-chat/src/features/temporary/detail.rs
@@ -8,7 +8,7 @@ use crate::{
         delete_confirm::{DestructiveAction, open_destructive_confirm_dialog},
         message::MessageViewExt,
     },
-    database::{Content, Mode, Role, Status},
+    database::{Content, MessageRunPersistence, Mode, Role, Status},
     errors::{AiChatError, AiChatResult},
     features::hotkey::GlobalHotkeyState,
     features::{
@@ -22,8 +22,8 @@ use crate::{
     },
     foundation::i18n::I18n,
     llm::{
-        LlmHistoryMessage, ProviderRunEvent, ProviderRunRequest, ProviderRunRunner,
-        build_input_items, provider_by_name,
+        LlmHistoryMessage, ProviderRunEvent, ProviderRunPersistenceAccumulator, ProviderRunRequest,
+        ProviderRunRunner, build_input_items, provider_by_name,
     },
     platform::gpui_ext::WeakEntityResultExt,
     state::{AddConversationMessage, AiChatConfig, ChatData},
@@ -52,7 +52,7 @@ pub fn init(cx: &mut App) {
 
 pub(crate) type TemplateDetailView = ConversationDetailView<TemporaryDetailState>;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TemporaryMessage {
     pub id: usize,
     pub provider: String,
@@ -61,6 +61,7 @@ pub struct TemporaryMessage {
     pub send_content: Rc<serde_json::Value>,
     pub status: Status,
     pub error: Option<String>,
+    pub run_persistence: MessageRunPersistence,
     pub created_time: OffsetDateTime,
     pub updated_time: OffsetDateTime,
     pub start_time: OffsetDateTime,
@@ -285,6 +286,7 @@ impl TemporaryMessage {
         self.content = Content::default();
         self.status = Status::Loading;
         self.error = None;
+        self.run_persistence = MessageRunPersistence::default();
         self.updated_time = now;
         self.start_time = now;
         self.end_time = now;
@@ -334,6 +336,7 @@ struct NewTemporaryMessage {
     send_content: Rc<serde_json::Value>,
     status: Status,
     error: Option<String>,
+    run_persistence: MessageRunPersistence,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -604,6 +607,7 @@ fn temporary_messages_to_add_conversation_messages(
             send_content: (*message.send_content).clone(),
             status: message.status,
             error: message.error,
+            run_persistence: message.run_persistence.clone(),
         })
         .collect()
 }
@@ -693,6 +697,7 @@ impl TemplateDetailView {
             send_content: input.send_content,
             status: input.status,
             error: input.error,
+            run_persistence: input.run_persistence,
             created_time: input.now,
             updated_time: input.now,
             start_time: input.now,
@@ -724,15 +729,32 @@ impl TemplateDetailView {
             last.update_status(Status::Thinking);
         }
     }
-    fn on_error(&mut self, message_id: usize, error: String, cx: &mut Context<Self>) {
+    fn on_error(
+        &mut self,
+        message_id: usize,
+        error: String,
+        run_persistence: Option<MessageRunPersistence>,
+        cx: &mut Context<Self>,
+    ) {
         if let Some(last) = self.detail.messages.iter_mut().find(|m| m.id == message_id) {
             last.record_error(error);
+            if let Some(run_persistence) = run_persistence {
+                last.run_persistence = run_persistence;
+            }
         }
         self.clear_running_task_for_message(Some(message_id), cx);
     }
-    fn on_success(&mut self, message_id: usize, cx: &mut Context<Self>) {
+    fn on_success(
+        &mut self,
+        message_id: usize,
+        run_persistence: Option<MessageRunPersistence>,
+        cx: &mut Context<Self>,
+    ) {
         if let Some(last) = self.detail.messages.iter_mut().find(|m| m.id == message_id) {
             last.update_status(Status::Normal);
+            if let Some(run_persistence) = run_persistence {
+                last.run_persistence = run_persistence;
+            }
         }
         self.clear_running_task_for_message(Some(message_id), cx);
     }
@@ -851,6 +873,7 @@ impl TemplateDetailView {
                     send_content: send_content.clone(),
                     status: Status::Normal,
                     error: None,
+                    run_persistence: MessageRunPersistence::default(),
                 })
                 .id;
             let assistant_message_id = this
@@ -862,6 +885,7 @@ impl TemplateDetailView {
                     send_content: send_content.clone(),
                     status: Status::Loading,
                     error: None,
+                    run_persistence: MessageRunPersistence::default(),
                 })
                 .id;
             this.bind_running_task_messages(Some(user_message_id), Some(assistant_message_id));
@@ -908,6 +932,8 @@ impl TemplateDetailView {
         assistant_message_id: usize,
         cx: &mut AsyncWindowContext,
     ) -> AiChatResult<()> {
+        let mut run_persistence =
+            ProviderRunPersistenceAccumulator::new(runner.run_request(), runner.get_config());
         let stream = runner.run();
         pin_mut!(stream);
         while let Some(message) = stream.next().await {
@@ -927,36 +953,61 @@ impl TemplateDetailView {
                         this.on_message(&message, assistant_message_id);
                     })?;
                 }
-                Ok(ProviderRunEvent::Completed { content, .. }) => {
+                Ok(ProviderRunEvent::Completed {
+                    content,
+                    state: run_state,
+                    usage,
+                }) => {
+                    run_persistence.record_completed(run_state, usage);
                     state.update_result(cx, |this, _cx| {
                         this.on_complete_content(content, assistant_message_id);
                     })?;
                 }
-                Ok(
-                    ProviderRunEvent::OutputItemAdded(_)
-                    | ProviderRunEvent::OutputItemDone(_)
-                    | ProviderRunEvent::ToolCallRequested(_)
-                    | ProviderRunEvent::ToolResultReceived(_)
-                    | ProviderRunEvent::McpApprovalRequested(_)
-                    | ProviderRunEvent::UsageUpdated(_),
-                ) => {}
+                Ok(ProviderRunEvent::OutputItemAdded(item)) => {
+                    run_persistence.record_output_item_added(item);
+                }
+                Ok(ProviderRunEvent::OutputItemDone(item)) => {
+                    run_persistence.record_output_item_done(item);
+                }
+                Ok(ProviderRunEvent::ToolCallRequested(tool_call)) => {
+                    run_persistence.record_tool_call_requested(tool_call);
+                }
+                Ok(ProviderRunEvent::ToolResultReceived(tool_result)) => {
+                    run_persistence.record_tool_result_received(tool_result);
+                }
+                Ok(ProviderRunEvent::McpApprovalRequested(request)) => {
+                    run_persistence.record_mcp_approval_requested(request);
+                }
+                Ok(ProviderRunEvent::UsageUpdated(usage)) => {
+                    run_persistence.record_usage(usage);
+                }
                 Ok(ProviderRunEvent::Failed { message }) => {
                     state.update_result(cx, |this, cx| {
-                        this.on_error(assistant_message_id, message, cx);
+                        this.on_error(
+                            assistant_message_id,
+                            message,
+                            run_persistence.persistence(),
+                            cx,
+                        );
                     })?;
                     return Ok(());
                 }
                 Err(error) => {
                     event!(Level::ERROR, "Connection Error: {}", error);
                     state.update_result(cx, |this, cx| {
-                        this.on_error(assistant_message_id, error.to_string(), cx);
+                        this.on_error(
+                            assistant_message_id,
+                            error.to_string(),
+                            run_persistence.persistence(),
+                            cx,
+                        );
                     })?;
                     return Ok(());
                 }
             }
         }
         state.update_result(cx, |this, cx| {
-            this.on_success(assistant_message_id, cx);
+            this.on_success(assistant_message_id, run_persistence.persistence(), cx);
         })?;
         Ok(())
     }
@@ -978,6 +1029,7 @@ impl TemplateDetailView {
             .clone();
         let request =
             ProviderRunRequest::from_request_body(provider.name(), request_body.as_ref().clone());
+        let mut run_persistence = ProviderRunPersistenceAccumulator::new(&request, &config);
         let stream = provider.run(config, settings, &request);
         pin_mut!(stream);
         while let Some(message) = stream.next().await {
@@ -997,36 +1049,61 @@ impl TemplateDetailView {
                         this.on_message(&message, assistant_message_id);
                     })?;
                 }
-                Ok(ProviderRunEvent::Completed { content, .. }) => {
+                Ok(ProviderRunEvent::Completed {
+                    content,
+                    state: run_state,
+                    usage,
+                }) => {
+                    run_persistence.record_completed(run_state, usage);
                     state.update_result(cx, |this, _cx| {
                         this.on_complete_content(content, assistant_message_id);
                     })?;
                 }
-                Ok(
-                    ProviderRunEvent::OutputItemAdded(_)
-                    | ProviderRunEvent::OutputItemDone(_)
-                    | ProviderRunEvent::ToolCallRequested(_)
-                    | ProviderRunEvent::ToolResultReceived(_)
-                    | ProviderRunEvent::McpApprovalRequested(_)
-                    | ProviderRunEvent::UsageUpdated(_),
-                ) => {}
+                Ok(ProviderRunEvent::OutputItemAdded(item)) => {
+                    run_persistence.record_output_item_added(item);
+                }
+                Ok(ProviderRunEvent::OutputItemDone(item)) => {
+                    run_persistence.record_output_item_done(item);
+                }
+                Ok(ProviderRunEvent::ToolCallRequested(tool_call)) => {
+                    run_persistence.record_tool_call_requested(tool_call);
+                }
+                Ok(ProviderRunEvent::ToolResultReceived(tool_result)) => {
+                    run_persistence.record_tool_result_received(tool_result);
+                }
+                Ok(ProviderRunEvent::McpApprovalRequested(request)) => {
+                    run_persistence.record_mcp_approval_requested(request);
+                }
+                Ok(ProviderRunEvent::UsageUpdated(usage)) => {
+                    run_persistence.record_usage(usage);
+                }
                 Ok(ProviderRunEvent::Failed { message }) => {
                     state.update_result(cx, |this, cx| {
-                        this.on_error(assistant_message_id, message, cx);
+                        this.on_error(
+                            assistant_message_id,
+                            message,
+                            run_persistence.persistence(),
+                            cx,
+                        );
                     })?;
                     return Ok(());
                 }
                 Err(error) => {
                     event!(Level::ERROR, "Connection Error: {}", error);
                     state.update_result(cx, |this, cx| {
-                        this.on_error(assistant_message_id, error.to_string(), cx);
+                        this.on_error(
+                            assistant_message_id,
+                            error.to_string(),
+                            run_persistence.persistence(),
+                            cx,
+                        );
                     })?;
                     return Ok(());
                 }
             }
         }
         state.update_result(cx, |this, cx| {
-            this.on_success(assistant_message_id, cx);
+            this.on_success(assistant_message_id, run_persistence.persistence(), cx);
         })?;
         Ok(())
     }

--- a/app/ai-chat/src/features/temporary/detail/tests.rs
+++ b/app/ai-chat/src/features/temporary/detail/tests.rs
@@ -2,8 +2,12 @@ use super::{
     TEMPORARY_SAVE_TITLE_MAX_CHARS, TemporaryDetailState, TemporaryMessage, build_history_messages,
     build_request_body, temporary_messages_to_add_conversation_messages, temporary_save_title,
 };
-use crate::database::{Content, ConversationTemplatePrompt, Mode, Role, Status};
+use crate::database::{
+    Content, ConversationTemplatePrompt, MessageOutputItem, MessageOutputItemStatus,
+    MessageRunPersistence, Mode, Role, Status,
+};
 use crate::features::conversation::detail::ConversationDetailViewExt;
+use crate::llm::LlmOutputItem;
 use std::rc::Rc;
 use time::OffsetDateTime;
 
@@ -27,6 +31,7 @@ fn make_message(role: Role, status: Status, content: Content) -> TemporaryMessag
         send_content: Rc::new(serde_json::json!({})),
         status,
         error: None,
+        run_persistence: MessageRunPersistence::default(),
         created_time: now,
         updated_time: now,
         start_time: now,
@@ -51,6 +56,7 @@ fn make_provider_message(
         send_content: Rc::new(send_content),
         status,
         error,
+        run_persistence: MessageRunPersistence::default(),
         created_time: now,
         updated_time: now,
         start_time: now,
@@ -140,7 +146,7 @@ fn empty_temporary_chat_hides_clear_and_save_actions() {
 #[test]
 fn temporary_messages_convert_to_add_conversation_messages() {
     let send_content = serde_json::json!({"messages": [{"role": "user", "content": "hello"}]});
-    let message = make_provider_message(
+    let mut message = make_provider_message(
         "Ollama",
         Role::Assistant,
         Status::Error,
@@ -148,6 +154,14 @@ fn temporary_messages_convert_to_add_conversation_messages() {
         send_content.clone(),
         Some("network failed".to_string()),
     );
+    message
+        .run_persistence
+        .output_items
+        .push(MessageOutputItem::new(
+            0,
+            LlmOutputItem::Reasoning { summary: None },
+            MessageOutputItemStatus::Added,
+        ));
 
     let messages = temporary_messages_to_add_conversation_messages(&[message]);
 
@@ -158,6 +172,7 @@ fn temporary_messages_convert_to_add_conversation_messages() {
     assert_eq!(messages[0].send_content, send_content);
     assert_eq!(messages[0].status, Status::Error);
     assert_eq!(messages[0].error.as_deref(), Some("network failed"));
+    assert_eq!(messages[0].run_persistence.output_items.len(), 1);
 }
 
 #[test]

--- a/app/ai-chat/src/llm.rs
+++ b/app/ai-chat/src/llm.rs
@@ -1,5 +1,6 @@
 mod preset;
 mod provider;
+mod run_persistence;
 mod runner;
 mod types;
 
@@ -17,6 +18,7 @@ pub(crate) use provider::{
     ProviderSettingsSpec, ReasoningCapability, ReasoningEffort, available_models, provider_by_name,
     provider_is_configured, provider_names, provider_settings_specs,
 };
+pub(crate) use run_persistence::ProviderRunPersistenceAccumulator;
 pub(crate) use runner::ProviderRunRunner;
 // Re-export the full provider-neutral item vocabulary for staged follow-up issues.
 #[allow(unused_imports)]

--- a/app/ai-chat/src/llm/run_persistence.rs
+++ b/app/ai-chat/src/llm/run_persistence.rs
@@ -6,7 +6,8 @@ use crate::{
 };
 
 use super::{
-    LlmOutputItem, LlmToolCall, LlmToolResult, ProviderRunRequest, ProviderRunState, ProviderUsage,
+    LlmOutputItem, LlmToolCall, LlmToolResult, ProviderRunRequest, ProviderRunState,
+    ProviderSettingsFieldKind, ProviderUsage, provider_settings_specs,
 };
 
 #[derive(Debug, Clone)]
@@ -23,9 +24,7 @@ pub(crate) struct ProviderRunPersistenceAccumulator {
 
 impl ProviderRunPersistenceAccumulator {
     pub(crate) fn new(request: &ProviderRunRequest, config: &AiChatConfig) -> Self {
-        let settings = config
-            .get_provider_settings(&request.provider_name)
-            .and_then(|settings| serde_json::to_value(settings).ok());
+        let settings = persisted_provider_settings_snapshot(&request.provider_name, config);
         Self {
             provider_name: request.provider_name.clone(),
             request_body: request.request_body.clone(),
@@ -136,6 +135,54 @@ impl ProviderRunPersistenceAccumulator {
     }
 }
 
+fn persisted_provider_settings_snapshot(
+    provider_name: &str,
+    config: &AiChatConfig,
+) -> Option<serde_json::Value> {
+    let settings = config.get_provider_settings(provider_name)?;
+    let settings = serde_json::to_value(settings).ok()?;
+    let settings = settings.as_object()?;
+    let spec = provider_settings_specs()
+        .into_iter()
+        .find(|spec| spec.provider_name == provider_name)?;
+
+    let mut snapshot = serde_json::Map::new();
+    for field in spec.fields {
+        if field.kind == ProviderSettingsFieldKind::SecretText {
+            continue;
+        }
+        if let Some(value) = settings.get(field.key) {
+            snapshot.insert(field.key.to_string(), safe_provider_setting_value(value));
+        }
+    }
+
+    (!snapshot.is_empty()).then(|| serde_json::Value::Object(snapshot))
+}
+
+fn safe_provider_setting_value(value: &serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::String(value) => {
+            serde_json::Value::String(redact_url_credentials(value))
+        }
+        _ => value.clone(),
+    }
+}
+
+fn redact_url_credentials(value: &str) -> String {
+    let Ok(mut url) = reqwest::Url::parse(value) else {
+        return value.to_string();
+    };
+    if url.username().is_empty() && url.password().is_none() {
+        return value.to_string();
+    }
+
+    if !url.username().is_empty() {
+        let _ = url.set_username("redacted");
+    }
+    let _ = url.set_password(None);
+    url.to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -229,5 +276,38 @@ mod tests {
                 .and_then(|usage| usage.input_tokens),
             Some(1)
         );
+    }
+
+    #[test]
+    fn persisted_settings_exclude_secret_provider_fields() -> anyhow::Result<()> {
+        let request = request();
+        let mut config = AiChatConfig::default();
+        config.set_provider_settings(
+            "OpenAI",
+            toml::from_str(
+                r#"
+apiKey = "sk-test-secret"
+baseUrl = "https://api.openai.com/v1"
+httpProxy = "http://proxy-user:proxy-pass@127.0.0.1:7890"
+"#,
+            )?,
+        );
+        let mut accumulator = ProviderRunPersistenceAccumulator::new(&request, &config);
+        accumulator.record_usage(ProviderUsage::new(Some(1), None, Some(1)));
+
+        let persistence = accumulator.persistence().expect("persistence");
+        let settings = persistence
+            .run_state
+            .expect("run state")
+            .settings
+            .expect("settings snapshot");
+        assert_eq!(settings["baseUrl"], "https://api.openai.com/v1");
+        assert_eq!(settings["httpProxy"], "http://redacted@127.0.0.1:7890/");
+        assert!(settings.get("apiKey").is_none());
+        let serialized = serde_json::to_string(&settings)?;
+        assert!(!serialized.contains("sk-test-secret"));
+        assert!(!serialized.contains("proxy-user"));
+        assert!(!serialized.contains("proxy-pass"));
+        Ok(())
     }
 }

--- a/app/ai-chat/src/llm/run_persistence.rs
+++ b/app/ai-chat/src/llm/run_persistence.rs
@@ -1,0 +1,233 @@
+use crate::{
+    database::{
+        MessageOutputItem, MessageOutputItemStatus, MessageRunPersistence, MessageRunState,
+    },
+    state::AiChatConfig,
+};
+
+use super::{
+    LlmOutputItem, LlmToolCall, LlmToolResult, ProviderRunRequest, ProviderRunState, ProviderUsage,
+};
+
+#[derive(Debug, Clone)]
+pub(crate) struct ProviderRunPersistenceAccumulator {
+    provider_name: String,
+    request_body: serde_json::Value,
+    model: Option<String>,
+    settings: Option<serde_json::Value>,
+    state: Option<ProviderRunState>,
+    usage: Option<ProviderUsage>,
+    output_items: Vec<MessageOutputItem>,
+    next_sequence: i32,
+}
+
+impl ProviderRunPersistenceAccumulator {
+    pub(crate) fn new(request: &ProviderRunRequest, config: &AiChatConfig) -> Self {
+        let settings = config
+            .get_provider_settings(&request.provider_name)
+            .and_then(|settings| serde_json::to_value(settings).ok());
+        Self {
+            provider_name: request.provider_name.clone(),
+            request_body: request.request_body.clone(),
+            model: request
+                .request_body
+                .get("model")
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string),
+            settings,
+            state: None,
+            usage: None,
+            output_items: Vec::new(),
+            next_sequence: 0,
+        }
+    }
+
+    pub(crate) fn record_output_item_added(&mut self, item: LlmOutputItem) {
+        self.push_output_item(item, MessageOutputItemStatus::Added);
+    }
+
+    pub(crate) fn record_output_item_done(&mut self, item: LlmOutputItem) {
+        self.push_output_item(item, MessageOutputItemStatus::Done);
+    }
+
+    pub(crate) fn record_tool_call_requested(&mut self, tool_call: LlmToolCall) {
+        self.push_output_item(
+            LlmOutputItem::ToolCall(tool_call),
+            MessageOutputItemStatus::ToolCallRequested,
+        );
+    }
+
+    pub(crate) fn record_tool_result_received(&mut self, tool_result: LlmToolResult) {
+        self.push_output_item(
+            LlmOutputItem::ToolResult(tool_result),
+            MessageOutputItemStatus::ToolResultReceived,
+        );
+    }
+
+    pub(crate) fn record_mcp_approval_requested(&mut self, request: super::LlmMcpApprovalRequest) {
+        self.push_output_item(
+            LlmOutputItem::McpApproval(request),
+            MessageOutputItemStatus::McpApprovalRequested,
+        );
+    }
+
+    pub(crate) fn record_usage(&mut self, usage: ProviderUsage) {
+        self.usage = Some(usage);
+    }
+
+    pub(crate) fn record_completed(
+        &mut self,
+        state: Option<ProviderRunState>,
+        usage: Option<ProviderUsage>,
+    ) {
+        if let Some(state) = state {
+            self.state = Some(state);
+        }
+        if let Some(usage) = usage {
+            self.usage = Some(usage);
+        }
+    }
+
+    pub(crate) fn persistence(&self) -> Option<MessageRunPersistence> {
+        let run_state = self
+            .state
+            .clone()
+            .map(|state| {
+                MessageRunState::from_provider_state(
+                    state,
+                    self.usage.clone(),
+                    self.model.clone(),
+                    self.settings.clone(),
+                )
+            })
+            .or_else(|| {
+                self.usage.as_ref().map(|usage| {
+                    MessageRunState::from_request_snapshot(
+                        self.provider_name.clone(),
+                        self.request_body.clone(),
+                        Some(usage.clone()),
+                        self.model.clone(),
+                        self.settings.clone(),
+                    )
+                })
+            });
+        let mut persistence = MessageRunPersistence {
+            run_state,
+            output_items: self.output_items.clone(),
+            attachments: self
+                .output_items
+                .iter()
+                .flat_map(MessageOutputItem::attachments)
+                .collect(),
+        }
+        .with_deduped_attachments();
+        if persistence.is_empty() {
+            None
+        } else {
+            Some(std::mem::take(&mut persistence))
+        }
+    }
+
+    fn push_output_item(&mut self, item: LlmOutputItem, status: MessageOutputItemStatus) {
+        let sequence = self.next_sequence;
+        self.next_sequence += 1;
+        self.output_items
+            .push(MessageOutputItem::new(sequence, item, status));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        database::MessageOutputItemStatus,
+        llm::{LlmHostedToolCall, LlmOutputItem, ProviderRunState, ProviderUsage},
+        state::AiChatConfig,
+    };
+
+    use super::{ProviderRunPersistenceAccumulator, ProviderRunRequest};
+
+    fn request() -> ProviderRunRequest {
+        ProviderRunRequest::new(
+            "OpenAI",
+            serde_json::json!({
+                "model": "gpt-4o",
+                "input": []
+            }),
+            Vec::new(),
+        )
+    }
+
+    #[test]
+    fn completed_event_persists_run_state_and_usage() {
+        let request = request();
+        let mut accumulator =
+            ProviderRunPersistenceAccumulator::new(&request, &AiChatConfig::default());
+        let usage = ProviderUsage::new(Some(10), Some(20), Some(30));
+
+        accumulator.record_completed(
+            Some(ProviderRunState::new(
+                "OpenAI",
+                Some("resp_1".to_string()),
+                vec!["item_1".to_string()],
+                request.request_body.clone(),
+            )),
+            Some(usage.clone()),
+        );
+
+        let persistence = accumulator.persistence().expect("persistence");
+        let run_state = persistence.run_state.expect("run state");
+        assert_eq!(run_state.provider, "OpenAI");
+        assert_eq!(run_state.run_id.as_deref(), Some("resp_1"));
+        assert_eq!(run_state.output_item_ids, vec!["item_1"]);
+        assert_eq!(run_state.usage, Some(usage));
+        assert_eq!(run_state.model.as_deref(), Some("gpt-4o"));
+    }
+
+    #[test]
+    fn output_item_events_preserve_stream_order() {
+        let request = request();
+        let mut accumulator =
+            ProviderRunPersistenceAccumulator::new(&request, &AiChatConfig::default());
+
+        accumulator.record_output_item_added(LlmOutputItem::Reasoning { summary: None });
+        accumulator.record_output_item_done(LlmOutputItem::HostedToolCall(LlmHostedToolCall {
+            call_id: "call_1".to_string(),
+            tool_type: "web_search_call".to_string(),
+            status: Some("completed".to_string()),
+        }));
+
+        let persistence = accumulator.persistence().expect("persistence");
+        assert_eq!(persistence.output_items.len(), 2);
+        assert_eq!(persistence.output_items[0].sequence, 0);
+        assert_eq!(
+            persistence.output_items[0].status,
+            MessageOutputItemStatus::Added
+        );
+        assert_eq!(persistence.output_items[1].sequence, 1);
+        assert_eq!(
+            persistence.output_items[1].status,
+            MessageOutputItemStatus::Done
+        );
+    }
+
+    #[test]
+    fn usage_only_failed_run_still_persists_partial_state() {
+        let request = request();
+        let mut accumulator =
+            ProviderRunPersistenceAccumulator::new(&request, &AiChatConfig::default());
+        accumulator.record_usage(ProviderUsage::new(Some(1), None, Some(1)));
+
+        let persistence = accumulator.persistence().expect("persistence");
+        let run_state = persistence.run_state.expect("usage snapshot");
+        assert!(run_state.run_id.is_none());
+        assert_eq!(run_state.provider, "OpenAI");
+        assert_eq!(run_state.request_body["model"], "gpt-4o");
+        assert_eq!(
+            run_state
+                .usage
+                .as_ref()
+                .and_then(|usage| usage.input_tokens),
+            Some(1)
+        );
+    }
+}

--- a/app/ai-chat/src/state/chat/runtime.rs
+++ b/app/ai-chat/src/state/chat/runtime.rs
@@ -15,7 +15,7 @@ use std::ops::Deref;
 use tracing::{Level, event};
 
 #[derive(Debug)]
-pub enum ChatDataEvent {
+pub(crate) enum ChatDataEvent {
     AddConversation {
         name: SharedString,
         icon: SharedString,
@@ -326,6 +326,9 @@ fn insert_conversation(
             );
             if let Some(error) = initial_message.error.as_ref() {
                 new_message = new_message.with_error(error);
+            }
+            if !initial_message.run_persistence.is_empty() {
+                new_message = new_message.with_run_persistence(&initial_message.run_persistence);
             }
             let message = Message::insert(new_message, conn)?;
             conversation.messages.push(message);

--- a/app/ai-chat/src/state/chat/tree.rs
+++ b/app/ai-chat/src/state/chat/tree.rs
@@ -1,5 +1,5 @@
 use crate::{
-    database::{Content, Conversation, Db, Folder, Message, Role, Status},
+    database::{Content, Conversation, Db, Folder, Message, MessageRunPersistence, Role, Status},
     errors::AiChatResult,
     foundation::search::field_matches_query,
 };
@@ -32,13 +32,14 @@ impl ConversationSearchResult {
 }
 
 #[derive(Debug, Clone)]
-pub struct AddConversationMessage {
-    pub provider: String,
-    pub role: Role,
-    pub content: Content,
-    pub send_content: serde_json::Value,
-    pub status: Status,
-    pub error: Option<String>,
+pub(crate) struct AddConversationMessage {
+    pub(crate) provider: String,
+    pub(crate) role: Role,
+    pub(crate) content: Content,
+    pub(crate) send_content: serde_json::Value,
+    pub(crate) status: Status,
+    pub(crate) error: Option<String>,
+    pub(crate) run_persistence: MessageRunPersistence,
 }
 
 // Bootstraps chat data from the database-backed tree.


### PR DESCRIPTION
## Summary

- Adds v6 persistence for ai-chat LLM run state, output items, usage, and attachment metadata.
- Affected app: `ai-chat`.

## Motivation

- #141 needs the provider-neutral runtime state from #139 to survive process restarts without changing existing message display, export, or resend behavior.
- The persistence layer is intentionally additive so old conversations still load through `messages.content` and resend through `messages.send_content`.

## Changes

- Adds `history_v6.sqlite3` schema and v1-v5 migration paths into v6.
- Adds `message_run_states`, `message_output_items`, and `message_attachments` tables.
- Adds typed database/service wrappers around `ProviderRunState`, `ProviderUsage`, `LlmOutputItem`, and attachment refs.
- Accumulates provider run events during conversation streaming and persists terminal snapshots with message status/content updates.
- Keeps temporary chat persistence in memory, then carries the completed run snapshot when saving temporary chats as normal conversations.
- Clears old run persistence during resend while preserving the existing request body snapshot behavior.
- Updates the #137 coordination document with the #141 implementation status and validation notes.

## Validation

- [ ] `cargo build`
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
cargo fmt
cargo test -p ai-chat database::migrations
cargo test -p ai-chat database::service
cargo test -p ai-chat llm::provider
cargo test -p ai-chat features::home::tabs::conversation_panel
cargo test -p ai-chat features::temporary::detail
cargo test -p ai-chat
cargo clippy -p ai-chat --all-targets --all-features -- -D warnings
git diff --check

Not run:
cargo build
Manual desktop app verification
```

## Risks

- Introduces a database file-level migration to v6; legacy migration tests cover v1-v5 upgrade paths.
- New tables store JSON payload snapshots for provider-neutral typed data, but do not change existing `messages.content` or `messages.send_content` compatibility.
- Provider continuation/resume behavior is intentionally left for #143/#144.

## Related Issues

- Related to #137
- Related to #141