### PR TITLE
ai-chat: migrate OpenAI adapter to Responses run state

### DIFF
--- a/app/ai-chat/docs/dev/issue-137-llm-abstractions.md
+++ b/app/ai-chat/docs/dev/issue-137-llm-abstractions.md
@@ -194,11 +194,13 @@ The current implementation keeps request persistence additive: existing provider
 
 - Added optional provider run state plumbing so OpenAI can build request bodies with `previous_response_id` while other providers keep existing request construction behavior.
 - Conversation panel and temporary chat now use compatible persisted OpenAI assistant run state in contextual mode, trim history before that response, and fall back to full transcript behavior for non-contextual modes or incompatible state.
+- OpenAI continuation is gated by matching persisted provider/model/run id, non-secret provider settings snapshot, and request context key. The request context key is the Responses request body with `input` and `previous_response_id` removed, so template/tool/reasoning/stream changes prevent stale continuation while input deltas do not.
 - OpenAI request conversion now emits Responses content parts for text, image references, file references, tool results, and item references; unsupported audio or generic attachments fail explicitly.
 - OpenAI stream and response parsing now maps message, reasoning, hosted tool, function-call, and MCP-related output items into provider-neutral events where existing core types can represent them.
 - Function-call argument completion now yields `ToolCallRequested`; this stage intentionally does not add generic tool execution, MCP server configuration, approval UI, or capability-gated controls.
 - Validation run:
   - `cargo fmt`
+  - `cargo test -p ai-chat llm::run_persistence`
   - `cargo test -p ai-chat llm::provider::openai -- --nocapture`
   - `cargo test -p ai-chat features::home::tabs::conversation_panel -- --nocapture`
   - `cargo test -p ai-chat features::temporary::detail -- --nocapture`

--- a/app/ai-chat/docs/dev/issue-137-llm-abstractions.md
+++ b/app/ai-chat/docs/dev/issue-137-llm-abstractions.md
@@ -21,7 +21,7 @@ Delete it before the final merge to `main`, unless the remaining content is prom
 | #142 | `codex/issue-142-llm-items` | Typed input, content, and output items | Merged to integration via PR #148; GitHub issue still open |
 | #139 | `codex/issue-139-provider-runtime` | Run-based provider trait and events | Merged to integration via PR #149; GitHub issue still open |
 | #141 | `codex/issue-141-llm-persistence` | Run state, output items, tools, attachments persistence | Merged to integration via PR #150; GitHub issue still open |
-| #143 | `codex/issue-143-openai-responses-abstraction` | OpenAI Responses migration on shared abstraction | Pending |
+| #143 | `codex/issue-143-openai-responses-abstraction` | OpenAI Responses migration on shared abstraction | Implemented; pending PR |
 | #144 | `codex/issue-144-ollama-shared-abstraction` | Ollama migration on shared abstraction | Pending |
 | #140 | `codex/issue-140-capability-gating` | Template, shortcut, and UI capability gating | Pending |
 
@@ -34,7 +34,8 @@ Last synchronized: 2026-05-21.
 - #142 remains open on GitHub, but PR #148 merged `codex/issue-142-llm-items` into `codex/issue-137-llm-abstractions`.
 - #139 remains open on GitHub, but PR #149 merged `codex/issue-139-provider-runtime` into `codex/issue-137-llm-abstractions`.
 - #141 remains open on GitHub, but PR #150 merged `codex/issue-141-llm-persistence` into `codex/issue-137-llm-abstractions`.
-- #143, #144, and #140 remain open and pending behind the persistence layer.
+- #143 remains open on GitHub, but `codex/issue-143-openai-responses-abstraction` implements the OpenAI Responses adapter stage.
+- #144 and #140 remain open and pending behind the OpenAI adapter stage.
 
 ## Current Architecture Facts
 
@@ -52,7 +53,8 @@ Last synchronized: 2026-05-21.
 - `ProviderRunState` and `ProviderUsage` are available for provider response/run metadata, output item ids, continuation metadata, and token usage, and #141 persists them additively for assistant messages.
 - `message_run_states`, `message_output_items`, and `message_attachments` now persist provider run state, output item events, usage, and attachment metadata additively without changing `messages.content` or `messages.send_content`.
 - `messages.content` stores rendered message content; `messages.send_content` stores the request body snapshot used for resend.
-- OpenAI already uses `/v1/responses`, reasoning effort, reasoning summaries, and hosted web search citations.
+- OpenAI uses `/v1/responses`, reasoning effort, reasoning summaries, hosted web search citations, provider-neutral output item events, and persisted `previous_response_id` continuation when compatible run state is available.
+- OpenAI adapter-specific Responses request fields such as `include`, `text`, `tool_choice`, `tools`, and `parallel_tool_calls` remain inside the OpenAI provider schema rather than the generic provider trait.
 - Ollama has provider-specific thinking and experimental web search/fetch behavior that must not be forced into OpenAI-shaped types.
 
 ## Shared Design Decisions
@@ -188,8 +190,24 @@ The current implementation keeps request persistence additive: existing provider
   - `cargo test -p ai-chat`
   - `cargo clippy -p ai-chat --all-targets --all-features -- -D warnings`
 
+### #143 OpenAI Responses Adapter Migration
+
+- Added optional provider run state plumbing so OpenAI can build request bodies with `previous_response_id` while other providers keep existing request construction behavior.
+- Conversation panel and temporary chat now use compatible persisted OpenAI assistant run state in contextual mode, trim history before that response, and fall back to full transcript behavior for non-contextual modes or incompatible state.
+- OpenAI request conversion now emits Responses content parts for text, image references, file references, tool results, and item references; unsupported audio or generic attachments fail explicitly.
+- OpenAI stream and response parsing now maps message, reasoning, hosted tool, function-call, and MCP-related output items into provider-neutral events where existing core types can represent them.
+- Function-call argument completion now yields `ToolCallRequested`; this stage intentionally does not add generic tool execution, MCP server configuration, approval UI, or capability-gated controls.
+- Validation run:
+  - `cargo fmt`
+  - `cargo test -p ai-chat llm::provider::openai -- --nocapture`
+  - `cargo test -p ai-chat features::home::tabs::conversation_panel -- --nocapture`
+  - `cargo test -p ai-chat features::temporary::detail -- --nocapture`
+  - `cargo test -p ai-chat database::service -- --nocapture`
+  - `cargo test -p ai-chat database::migrations -- --nocapture`
+  - `cargo clippy -p ai-chat --all-targets --all-features -- -D warnings`
+
 ## Next Child Issue Constraints
 
-Next child issue is #143.
+Next child issue after #143 lands is #144.
 
-#143 should use the persisted run state from #141 for OpenAI Responses continuation and richer Responses output item handling without leaking OpenAI-specific schema into the provider-neutral core.
+#144 should migrate Ollama onto the shared abstraction and verify the core types are not OpenAI-shaped.

--- a/app/ai-chat/src/database/migrations/tests.rs
+++ b/app/ai-chat/src/database/migrations/tests.rs
@@ -164,7 +164,10 @@ fn v1_migration_backfills_send_content_from_request_logic() -> anyhow::Result<()
     let first_send_content = &messages[0].send_content;
     let second_send_content = &messages[1].send_content;
     assert_eq!(first_send_content["model"], "gpt-4o");
-    assert_eq!(first_send_content["input"][0]["content"], "hello");
+    assert_eq!(
+        first_send_content["input"][0]["content"][0]["text"],
+        "hello"
+    );
     assert_eq!(second_send_content, first_send_content);
     assert_run_tables_empty(&mut v5_conn)?;
 

--- a/app/ai-chat/src/database/model/message_run_states.rs
+++ b/app/ai-chat/src/database/model/message_run_states.rs
@@ -44,7 +44,6 @@ pub struct SqlMessageRunState {
 }
 
 impl SqlMessageRunState {
-    #[cfg(test)]
     pub fn find_by_message_id(
         message_id: i32,
         conn: &mut SqliteConnection,

--- a/app/ai-chat/src/database/service/messages.rs
+++ b/app/ai-chat/src/database/service/messages.rs
@@ -254,6 +254,16 @@ impl MessageRunState {
             settings,
         }
     }
+
+    pub(crate) fn to_provider_state(&self) -> ProviderRunState {
+        ProviderRunState {
+            provider_name: self.provider.clone(),
+            run_id: self.run_id.clone(),
+            output_item_ids: self.output_item_ids.clone(),
+            continuation_metadata: self.continuation_metadata.clone(),
+            request_body: self.request_body.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -763,6 +773,14 @@ impl Message {
     pub fn find(id: i32, conn: &mut SqliteConnection) -> AiChatResult<Message> {
         let message = SqlMessage::find(id, conn)?;
         Message::try_from(message)
+    }
+    pub(crate) fn run_state(
+        id: i32,
+        conn: &mut SqliteConnection,
+    ) -> AiChatResult<Option<MessageRunState>> {
+        SqlMessageRunState::find_by_message_id(id, conn)?
+            .map(TryFrom::try_from)
+            .transpose()
     }
     pub fn delete(id: i32, conn: &mut SqliteConnection) -> AiChatResult<()> {
         SqlMessage::delete(id, conn)?;

--- a/app/ai-chat/src/features/home/tabs/conversation_panel.rs
+++ b/app/ai-chat/src/features/home/tabs/conversation_panel.rs
@@ -5,7 +5,8 @@ use crate::{
         delete_confirm::{DestructiveAction, open_destructive_confirm_dialog},
     },
     database::{
-        Content, Conversation, Db, Message, MessageRunPersistence, Mode, NewMessage, Role, Status,
+        Content, Conversation, Db, Message, MessageRunPersistence, MessageRunState, Mode,
+        NewMessage, Role, Status,
     },
     errors::{AiChatError, AiChatResult},
     features::conversation::detail::{
@@ -16,7 +17,7 @@ use crate::{
     foundation::i18n::I18n,
     llm::{
         LlmHistoryMessage, ProviderRunEvent, ProviderRunPersistenceAccumulator, ProviderRunRequest,
-        ProviderRunRunner, build_input_items, provider_by_name,
+        ProviderRunRunner, ProviderRunState, build_input_items, provider_by_name,
     },
     platform::gpui_ext::{AsyncWindowContextResultExt, EntityResultExt, WeakEntityResultExt},
     state::{
@@ -722,23 +723,31 @@ impl ConversationPanelView {
         user_message_content: String,
         cx: &mut AsyncWindowContext,
     ) -> AiChatResult<Runner> {
-        let history_messages = cx.read_global_result(|db: &Db, _window, _cx| {
-            let conn = &mut db.get()?;
-            let conversation = Conversation::find(context.conversation_id, conn)?;
-            Ok::<_, AiChatError>(conversation.messages)
-        })??;
         let provider_name = context.composer_snapshot.provider_name.clone();
         let template = context.composer_snapshot.request_template.clone();
-        let prompts = context.composer_snapshot.prompts.clone();
         let mode = context.composer_snapshot.mode;
-        let run_request = build_run_request(
+        let (history_messages, continuation) =
+            cx.read_global_result(|db: &Db, _window, _cx| {
+                let conn = &mut db.get()?;
+                let conversation = Conversation::find(context.conversation_id, conn)?;
+                let continuation = openai_continuation_candidate(
+                    &provider_name,
+                    &template,
+                    mode,
+                    &conversation.messages,
+                    conn,
+                )?;
+                Ok::<_, AiChatError>((conversation.messages, continuation))
+            })??;
+        let prompts = context.composer_snapshot.prompts.clone();
+        let run_request = build_run_request_with_continuation(
             &provider_name,
             &template,
             prompts,
             mode,
             &history_messages,
-            user_message_role,
-            &user_message_content,
+            (user_message_role, &user_message_content),
+            continuation,
         )?;
         Ok(Runner {
             config: context.config.clone(),
@@ -1204,6 +1213,12 @@ impl ProviderRunRunner for Runner {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+struct ContinuationCandidate {
+    after_index: usize,
+    state: ProviderRunState,
+}
+
 fn build_history_messages(
     prompts: Vec<crate::database::ConversationTemplatePrompt>,
     mode: Mode,
@@ -1223,6 +1238,56 @@ fn build_history_messages(
     )
 }
 
+fn template_model(template: &serde_json::Value) -> Option<&str> {
+    template.get("model").and_then(serde_json::Value::as_str)
+}
+
+fn compatible_openai_run_state(
+    provider_name: &str,
+    model: &str,
+    run_state: &MessageRunState,
+) -> bool {
+    provider_name == "OpenAI"
+        && run_state.provider == provider_name
+        && run_state.run_id.as_ref().is_some_and(|id| !id.is_empty())
+        && run_state.model.as_deref() == Some(model)
+}
+
+fn openai_continuation_candidate(
+    provider_name: &str,
+    template: &serde_json::Value,
+    mode: Mode,
+    history_messages: &[Message],
+    conn: &mut diesel::SqliteConnection,
+) -> AiChatResult<Option<ContinuationCandidate>> {
+    if provider_name != "OpenAI" || mode != Mode::Contextual {
+        return Ok(None);
+    }
+    let Some(model) = template_model(template) else {
+        return Ok(None);
+    };
+
+    for (index, message) in history_messages.iter().enumerate().rev() {
+        if message.role != Role::Assistant
+            || message.status != Status::Normal
+            || message.provider != provider_name
+        {
+            continue;
+        }
+        let Some(run_state) = Message::run_state(message.id, conn)? else {
+            continue;
+        };
+        if compatible_openai_run_state(provider_name, model, &run_state) {
+            return Ok(Some(ContinuationCandidate {
+                after_index: index,
+                state: run_state.to_provider_state(),
+            }));
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
 fn build_run_request(
     provider_name: &str,
     template: &serde_json::Value,
@@ -1232,14 +1297,41 @@ fn build_run_request(
     user_message_role: Role,
     user_message_content: &str,
 ) -> AiChatResult<ProviderRunRequest> {
+    build_run_request_with_continuation(
+        provider_name,
+        template,
+        prompts,
+        mode,
+        history_messages,
+        (user_message_role, user_message_content),
+        None,
+    )
+}
+
+fn build_run_request_with_continuation(
+    provider_name: &str,
+    template: &serde_json::Value,
+    prompts: Vec<crate::database::ConversationTemplatePrompt>,
+    mode: Mode,
+    history_messages: &[Message],
+    current_user_message: (Role, &str),
+    continuation: Option<ContinuationCandidate>,
+) -> AiChatResult<ProviderRunRequest> {
+    let state = continuation
+        .as_ref()
+        .map(|continuation| continuation.state.clone());
+    let history_messages = continuation
+        .as_ref()
+        .map(|continuation| &history_messages[(continuation.after_index + 1)..])
+        .unwrap_or(history_messages);
     let history = build_history_messages(
         prompts,
         mode,
         history_messages,
-        user_message_role,
-        user_message_content,
+        current_user_message.0,
+        current_user_message.1,
     );
-    provider_by_name(provider_name)?.build_run_request(template, history)
+    provider_by_name(provider_name)?.build_run_request_with_state(template, history, state)
 }
 
 #[cfg(test)]

--- a/app/ai-chat/src/features/home/tabs/conversation_panel.rs
+++ b/app/ai-chat/src/features/home/tabs/conversation_panel.rs
@@ -17,7 +17,8 @@ use crate::{
     foundation::i18n::I18n,
     llm::{
         LlmHistoryMessage, ProviderRunEvent, ProviderRunPersistenceAccumulator, ProviderRunRequest,
-        ProviderRunRunner, ProviderRunState, build_input_items, provider_by_name,
+        ProviderRunRunner, ProviderRunState, build_input_items,
+        persisted_provider_settings_snapshot, provider_by_name, provider_run_request_context_key,
     },
     platform::gpui_ext::{AsyncWindowContextResultExt, EntityResultExt, WeakEntityResultExt},
     state::{
@@ -726,20 +727,30 @@ impl ConversationPanelView {
         let provider_name = context.composer_snapshot.provider_name.clone();
         let template = context.composer_snapshot.request_template.clone();
         let mode = context.composer_snapshot.mode;
+        let prompts = context.composer_snapshot.prompts.clone();
         let (history_messages, continuation) =
             cx.read_global_result(|db: &Db, _window, _cx| {
                 let conn = &mut db.get()?;
                 let conversation = Conversation::find(context.conversation_id, conn)?;
+                let request_context_key = openai_request_context_key(
+                    &provider_name,
+                    &template,
+                    prompts.clone(),
+                    mode,
+                    &conversation.messages,
+                    (user_message_role, &user_message_content),
+                )?;
                 let continuation = openai_continuation_candidate(
                     &provider_name,
                     &template,
                     mode,
                     &conversation.messages,
+                    &context.config,
+                    request_context_key.as_ref(),
                     conn,
                 )?;
                 Ok::<_, AiChatError>((conversation.messages, continuation))
             })??;
-        let prompts = context.composer_snapshot.prompts.clone();
         let run_request = build_run_request_with_continuation(
             &provider_name,
             &template,
@@ -1245,12 +1256,44 @@ fn template_model(template: &serde_json::Value) -> Option<&str> {
 fn compatible_openai_run_state(
     provider_name: &str,
     model: &str,
+    current_settings: &serde_json::Value,
+    current_request_context_key: &serde_json::Value,
     run_state: &MessageRunState,
 ) -> bool {
-    provider_name == "OpenAI"
-        && run_state.provider == provider_name
-        && run_state.run_id.as_ref().is_some_and(|id| !id.is_empty())
-        && run_state.model.as_deref() == Some(model)
+    if provider_name != "OpenAI"
+        || run_state.provider != provider_name
+        || run_state.run_id.as_ref().is_none_or(|id| id.is_empty())
+        || run_state.model.as_deref() != Some(model)
+        || run_state.settings.as_ref() != Some(current_settings)
+    {
+        return false;
+    }
+
+    provider_run_request_context_key(&run_state.request_body) == *current_request_context_key
+}
+
+fn openai_request_context_key(
+    provider_name: &str,
+    template: &serde_json::Value,
+    prompts: Vec<crate::database::ConversationTemplatePrompt>,
+    mode: Mode,
+    history_messages: &[Message],
+    current_user_message: (Role, &str),
+) -> AiChatResult<Option<serde_json::Value>> {
+    if provider_name != "OpenAI" || mode != Mode::Contextual {
+        return Ok(None);
+    }
+    let history = build_history_messages(
+        prompts,
+        mode,
+        history_messages,
+        current_user_message.0,
+        current_user_message.1,
+    );
+    let request = provider_by_name(provider_name)?.build_run_request(template, history)?;
+    Ok(Some(provider_run_request_context_key(
+        &request.request_body,
+    )))
 }
 
 fn openai_continuation_candidate(
@@ -1258,12 +1301,20 @@ fn openai_continuation_candidate(
     template: &serde_json::Value,
     mode: Mode,
     history_messages: &[Message],
+    config: &AiChatConfig,
+    current_request_context_key: Option<&serde_json::Value>,
     conn: &mut diesel::SqliteConnection,
 ) -> AiChatResult<Option<ContinuationCandidate>> {
     if provider_name != "OpenAI" || mode != Mode::Contextual {
         return Ok(None);
     }
     let Some(model) = template_model(template) else {
+        return Ok(None);
+    };
+    let Some(current_settings) = persisted_provider_settings_snapshot(provider_name, config) else {
+        return Ok(None);
+    };
+    let Some(current_request_context_key) = current_request_context_key else {
         return Ok(None);
     };
 
@@ -1277,7 +1328,13 @@ fn openai_continuation_candidate(
         let Some(run_state) = Message::run_state(message.id, conn)? else {
             continue;
         };
-        if compatible_openai_run_state(provider_name, model, &run_state) {
+        if compatible_openai_run_state(
+            provider_name,
+            model,
+            &current_settings,
+            current_request_context_key,
+            &run_state,
+        ) {
             return Ok(Some(ContinuationCandidate {
                 after_index: index,
                 state: run_state.to_provider_state(),

--- a/app/ai-chat/src/features/home/tabs/conversation_panel/tests.rs
+++ b/app/ai-chat/src/features/home/tabs/conversation_panel/tests.rs
@@ -172,6 +172,61 @@ fn build_request_body_uses_override_template_model() -> anyhow::Result<()> {
 }
 
 #[test]
+fn build_run_request_with_openai_continuation_trims_prior_history() -> anyhow::Result<()> {
+    let template = serde_json::json!({
+        "model": "gpt-4o",
+        "stream": false
+    });
+    let request = build_run_request_with_continuation(
+        "OpenAI",
+        &template,
+        vec![ConversationTemplatePrompt {
+            prompt: "system".to_string(),
+            role: Role::Developer,
+        }],
+        Mode::Contextual,
+        &[
+            make_message(1, Role::User, Status::Normal, Content::new("old user")),
+            make_message(
+                2,
+                Role::Assistant,
+                Status::Normal,
+                Content::new("old answer"),
+            ),
+            make_message(
+                3,
+                Role::User,
+                Status::Normal,
+                Content::new("after continuation"),
+            ),
+        ],
+        (Role::User, "latest"),
+        Some(ContinuationCandidate {
+            after_index: 1,
+            state: ProviderRunState::new(
+                "OpenAI",
+                Some("resp_1".to_string()),
+                vec!["msg_1".to_string()],
+                serde_json::json!({ "model": "gpt-4o" }),
+            ),
+        }),
+    )?;
+
+    assert_eq!(request.request_body["previous_response_id"], "resp_1");
+    let input = request.request_body["input"]
+        .as_array()
+        .expect("input array");
+    assert_eq!(input.len(), 3);
+    assert_eq!(input[0]["role"], "developer");
+    assert_eq!(input[0]["content"][0]["text"], "system");
+    assert_eq!(input[1]["role"], "user");
+    assert_eq!(input[1]["content"][0]["text"], "after continuation");
+    assert_eq!(input[2]["role"], "user");
+    assert_eq!(input[2]["content"][0]["text"], "latest");
+    Ok(())
+}
+
+#[test]
 fn pause_message_snapshot_updates_loading_messages() {
     let now = OffsetDateTime::now_utc();
     let mut message = make_message(1, Role::Assistant, Status::Loading, Content::new("a1"));

--- a/app/ai-chat/src/features/home/tabs/conversation_panel/tests.rs
+++ b/app/ai-chat/src/features/home/tabs/conversation_panel/tests.rs
@@ -2,6 +2,8 @@ use super::*;
 use crate::database::{Content, ConversationTemplatePrompt, Status};
 use time::OffsetDateTime;
 
+const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+
 fn input_texts(items: Vec<crate::llm::LlmInputItem>) -> Vec<(&'static str, String)> {
     items
         .into_iter()
@@ -28,6 +30,26 @@ fn make_message(id: i32, role: Role, status: Status, content: Content) -> Messag
         start_time: now,
         end_time: now,
         error: None,
+    }
+}
+
+fn openai_settings(base_url: &str) -> serde_json::Value {
+    serde_json::json!({ "baseUrl": base_url })
+}
+
+fn message_run_state(
+    settings: Option<serde_json::Value>,
+    request_body: serde_json::Value,
+) -> MessageRunState {
+    MessageRunState {
+        provider: "OpenAI".to_string(),
+        run_id: Some("resp_1".to_string()),
+        output_item_ids: vec!["msg_1".to_string()],
+        continuation_metadata: serde_json::Value::Null,
+        request_body,
+        usage: None,
+        model: Some("gpt-4o".to_string()),
+        settings,
     }
 }
 
@@ -224,6 +246,70 @@ fn build_run_request_with_openai_continuation_trims_prior_history() -> anyhow::R
     assert_eq!(input[2]["role"], "user");
     assert_eq!(input[2]["content"][0]["text"], "latest");
     Ok(())
+}
+
+#[test]
+fn compatible_openai_run_state_requires_settings_and_request_context() {
+    let settings = openai_settings(DEFAULT_OPENAI_BASE_URL);
+    let current_context = provider_run_request_context_key(&serde_json::json!({
+        "model": "gpt-4o",
+        "stream": false,
+        "input": [{ "role": "user", "content": [{ "type": "input_text", "text": "current" }] }]
+    }));
+    let state = message_run_state(
+        Some(settings.clone()),
+        serde_json::json!({
+            "model": "gpt-4o",
+            "stream": false,
+            "previous_response_id": "resp_0",
+            "input": [{ "role": "user", "content": [{ "type": "input_text", "text": "old" }] }]
+        }),
+    );
+
+    assert!(compatible_openai_run_state(
+        "OpenAI",
+        "gpt-4o",
+        &settings,
+        &current_context,
+        &state,
+    ));
+
+    let missing_settings = message_run_state(None, state.request_body.clone());
+    assert!(!compatible_openai_run_state(
+        "OpenAI",
+        "gpt-4o",
+        &settings,
+        &current_context,
+        &missing_settings,
+    ));
+
+    let different_settings = message_run_state(
+        Some(openai_settings("https://proxy.openai.local/v1")),
+        state.request_body.clone(),
+    );
+    assert!(!compatible_openai_run_state(
+        "OpenAI",
+        "gpt-4o",
+        &settings,
+        &current_context,
+        &different_settings,
+    ));
+
+    let different_context = message_run_state(
+        Some(settings.clone()),
+        serde_json::json!({
+            "model": "gpt-4o",
+            "stream": true,
+            "input": [{ "role": "user", "content": [{ "type": "input_text", "text": "old" }] }]
+        }),
+    );
+    assert!(!compatible_openai_run_state(
+        "OpenAI",
+        "gpt-4o",
+        &settings,
+        &current_context,
+        &different_context,
+    ));
 }
 
 #[test]

--- a/app/ai-chat/src/features/temporary/detail.rs
+++ b/app/ai-chat/src/features/temporary/detail.rs
@@ -23,7 +23,8 @@ use crate::{
     foundation::i18n::I18n,
     llm::{
         LlmHistoryMessage, ProviderRunEvent, ProviderRunPersistenceAccumulator, ProviderRunRequest,
-        ProviderRunRunner, ProviderRunState, build_input_items, provider_by_name,
+        ProviderRunRunner, ProviderRunState, build_input_items,
+        persisted_provider_settings_snapshot, provider_by_name, provider_run_request_context_key,
     },
     platform::gpui_ext::WeakEntityResultExt,
     state::{AddConversationMessage, AiChatConfig, ChatData},
@@ -912,8 +913,8 @@ impl TemplateDetailView {
                 &composer_snapshot.prompts,
                 composer_snapshot.mode,
                 &this.detail.messages,
-                user_message_role,
-                &user_message_content,
+                &config,
+                (user_message_role, &user_message_content),
             )?;
             Ok(Runner {
                 config,
@@ -1172,12 +1173,44 @@ fn template_model(template: &serde_json::Value) -> Option<&str> {
 fn compatible_openai_run_state(
     provider_name: &str,
     model: &str,
+    current_settings: &serde_json::Value,
+    current_request_context_key: &serde_json::Value,
     run_state: &MessageRunState,
 ) -> bool {
-    provider_name == "OpenAI"
-        && run_state.provider == provider_name
-        && run_state.run_id.as_ref().is_some_and(|id| !id.is_empty())
-        && run_state.model.as_deref() == Some(model)
+    if provider_name != "OpenAI"
+        || run_state.provider != provider_name
+        || run_state.run_id.as_ref().is_none_or(|id| id.is_empty())
+        || run_state.model.as_deref() != Some(model)
+        || run_state.settings.as_ref() != Some(current_settings)
+    {
+        return false;
+    }
+
+    provider_run_request_context_key(&run_state.request_body) == *current_request_context_key
+}
+
+fn openai_request_context_key(
+    provider_name: &str,
+    template: &serde_json::Value,
+    prompts: &[crate::database::ConversationTemplatePrompt],
+    mode: Mode,
+    messages: &[TemporaryMessage],
+    current_user_message: (Role, &str),
+) -> AiChatResult<Option<serde_json::Value>> {
+    if provider_name != "OpenAI" || mode != Mode::Contextual {
+        return Ok(None);
+    }
+    let history = build_history_messages(
+        prompts,
+        mode,
+        messages,
+        current_user_message.0,
+        current_user_message.1,
+    );
+    let request = provider_by_name(provider_name)?.build_run_request(template, history)?;
+    Ok(Some(provider_run_request_context_key(
+        &request.request_body,
+    )))
 }
 
 fn openai_continuation_candidate(
@@ -1185,11 +1218,15 @@ fn openai_continuation_candidate(
     template: &serde_json::Value,
     mode: Mode,
     messages: &[TemporaryMessage],
+    config: &AiChatConfig,
+    current_request_context_key: Option<&serde_json::Value>,
 ) -> Option<ContinuationCandidate> {
     if provider_name != "OpenAI" || mode != Mode::Contextual {
         return None;
     }
     let model = template_model(template)?;
+    let current_settings = persisted_provider_settings_snapshot(provider_name, config)?;
+    let current_request_context_key = current_request_context_key?;
     for (index, message) in messages.iter().enumerate().rev() {
         if message.role != Role::Assistant
             || message.status != Status::Normal
@@ -1200,7 +1237,13 @@ fn openai_continuation_candidate(
         let Some(run_state) = message.run_persistence.run_state.as_ref() else {
             continue;
         };
-        if compatible_openai_run_state(provider_name, model, run_state) {
+        if compatible_openai_run_state(
+            provider_name,
+            model,
+            &current_settings,
+            current_request_context_key,
+            run_state,
+        ) {
             return Some(ContinuationCandidate {
                 after_index: index,
                 state: run_state.to_provider_state(),
@@ -1216,17 +1259,32 @@ fn build_run_request(
     prompts: &[crate::database::ConversationTemplatePrompt],
     mode: Mode,
     messages: &[TemporaryMessage],
-    user_message_role: Role,
-    user_message_content: &str,
+    config: &AiChatConfig,
+    current_user_message: (Role, &str),
 ) -> AiChatResult<ProviderRunRequest> {
-    let continuation = openai_continuation_candidate(provider_name, template, mode, messages);
+    let request_context_key = openai_request_context_key(
+        provider_name,
+        template,
+        prompts,
+        mode,
+        messages,
+        current_user_message,
+    )?;
+    let continuation = openai_continuation_candidate(
+        provider_name,
+        template,
+        mode,
+        messages,
+        config,
+        request_context_key.as_ref(),
+    );
     build_run_request_with_continuation(
         provider_name,
         template,
         prompts,
         mode,
         messages,
-        (user_message_role, user_message_content),
+        current_user_message,
         continuation,
     )
 }
@@ -1264,8 +1322,8 @@ fn build_request_body(
     prompts: &[crate::database::ConversationTemplatePrompt],
     mode: Mode,
     messages: &[TemporaryMessage],
-    user_message_role: Role,
-    user_message_content: &str,
+    config: &AiChatConfig,
+    current_user_message: (Role, &str),
 ) -> AiChatResult<serde_json::Value> {
     Ok(build_run_request(
         provider_name,
@@ -1273,8 +1331,8 @@ fn build_request_body(
         prompts,
         mode,
         messages,
-        user_message_role,
-        user_message_content,
+        config,
+        current_user_message,
     )?
     .request_body)
 }

--- a/app/ai-chat/src/features/temporary/detail.rs
+++ b/app/ai-chat/src/features/temporary/detail.rs
@@ -8,7 +8,7 @@ use crate::{
         delete_confirm::{DestructiveAction, open_destructive_confirm_dialog},
         message::MessageViewExt,
     },
-    database::{Content, MessageRunPersistence, Mode, Role, Status},
+    database::{Content, MessageRunPersistence, MessageRunState, Mode, Role, Status},
     errors::{AiChatError, AiChatResult},
     features::hotkey::GlobalHotkeyState,
     features::{
@@ -23,7 +23,7 @@ use crate::{
     foundation::i18n::I18n,
     llm::{
         LlmHistoryMessage, ProviderRunEvent, ProviderRunPersistenceAccumulator, ProviderRunRequest,
-        ProviderRunRunner, build_input_items, provider_by_name,
+        ProviderRunRunner, ProviderRunState, build_input_items, provider_by_name,
     },
     platform::gpui_ext::WeakEntityResultExt,
     state::{AddConversationMessage, AiChatConfig, ChatData},
@@ -1140,6 +1140,12 @@ impl ProviderRunRunner for Runner {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+struct ContinuationCandidate {
+    after_index: usize,
+    state: ProviderRunState,
+}
+
 fn build_history_messages(
     prompts: &[crate::database::ConversationTemplatePrompt],
     mode: Mode,
@@ -1159,6 +1165,51 @@ fn build_history_messages(
     )
 }
 
+fn template_model(template: &serde_json::Value) -> Option<&str> {
+    template.get("model").and_then(serde_json::Value::as_str)
+}
+
+fn compatible_openai_run_state(
+    provider_name: &str,
+    model: &str,
+    run_state: &MessageRunState,
+) -> bool {
+    provider_name == "OpenAI"
+        && run_state.provider == provider_name
+        && run_state.run_id.as_ref().is_some_and(|id| !id.is_empty())
+        && run_state.model.as_deref() == Some(model)
+}
+
+fn openai_continuation_candidate(
+    provider_name: &str,
+    template: &serde_json::Value,
+    mode: Mode,
+    messages: &[TemporaryMessage],
+) -> Option<ContinuationCandidate> {
+    if provider_name != "OpenAI" || mode != Mode::Contextual {
+        return None;
+    }
+    let model = template_model(template)?;
+    for (index, message) in messages.iter().enumerate().rev() {
+        if message.role != Role::Assistant
+            || message.status != Status::Normal
+            || message.provider != provider_name
+        {
+            continue;
+        }
+        let Some(run_state) = message.run_persistence.run_state.as_ref() else {
+            continue;
+        };
+        if compatible_openai_run_state(provider_name, model, run_state) {
+            return Some(ContinuationCandidate {
+                after_index: index,
+                state: run_state.to_provider_state(),
+            });
+        }
+    }
+    None
+}
+
 fn build_run_request(
     provider_name: &str,
     template: &serde_json::Value,
@@ -1168,14 +1219,42 @@ fn build_run_request(
     user_message_role: Role,
     user_message_content: &str,
 ) -> AiChatResult<ProviderRunRequest> {
+    let continuation = openai_continuation_candidate(provider_name, template, mode, messages);
+    build_run_request_with_continuation(
+        provider_name,
+        template,
+        prompts,
+        mode,
+        messages,
+        (user_message_role, user_message_content),
+        continuation,
+    )
+}
+
+fn build_run_request_with_continuation(
+    provider_name: &str,
+    template: &serde_json::Value,
+    prompts: &[crate::database::ConversationTemplatePrompt],
+    mode: Mode,
+    messages: &[TemporaryMessage],
+    current_user_message: (Role, &str),
+    continuation: Option<ContinuationCandidate>,
+) -> AiChatResult<ProviderRunRequest> {
+    let state = continuation
+        .as_ref()
+        .map(|continuation| continuation.state.clone());
+    let messages = continuation
+        .as_ref()
+        .map(|continuation| &messages[(continuation.after_index + 1)..])
+        .unwrap_or(messages);
     let history = build_history_messages(
         prompts,
         mode,
         messages,
-        user_message_role,
-        user_message_content,
+        current_user_message.0,
+        current_user_message.1,
     );
-    provider_by_name(provider_name)?.build_run_request(template, history)
+    provider_by_name(provider_name)?.build_run_request_with_state(template, history, state)
 }
 
 #[cfg(test)]

--- a/app/ai-chat/src/features/temporary/detail/tests.rs
+++ b/app/ai-chat/src/features/temporary/detail/tests.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::database::{
     Content, ConversationTemplatePrompt, MessageOutputItem, MessageOutputItemStatus,
-    MessageRunPersistence, Mode, Role, Status,
+    MessageRunPersistence, MessageRunState, Mode, Role, Status,
 };
 use crate::features::conversation::detail::ConversationDetailViewExt;
 use crate::llm::LlmOutputItem;
@@ -64,6 +64,23 @@ fn make_provider_message(
     }
 }
 
+fn openai_run_persistence(run_id: &str, model: &str) -> MessageRunPersistence {
+    MessageRunPersistence {
+        run_state: Some(MessageRunState {
+            provider: "OpenAI".to_string(),
+            run_id: Some(run_id.to_string()),
+            output_item_ids: vec!["msg_1".to_string()],
+            continuation_metadata: serde_json::Value::Null,
+            request_body: serde_json::json!({ "model": model }),
+            usage: None,
+            model: Some(model.to_string()),
+            settings: None,
+        }),
+        output_items: Vec::new(),
+        attachments: Vec::new(),
+    }
+}
+
 #[test]
 fn runner_history_appends_current_user_message() {
     let history = build_history_messages(
@@ -108,6 +125,68 @@ fn build_request_body_uses_override_template_model() -> anyhow::Result<()> {
         "hello",
     )?;
     assert_eq!(request_body["model"], serde_json::json!("override-model"));
+    Ok(())
+}
+
+#[test]
+fn contextual_openai_request_uses_latest_compatible_run_state() -> anyhow::Result<()> {
+    let mut assistant = make_message(Role::Assistant, Status::Normal, Content::new("old answer"));
+    assistant.run_persistence = openai_run_persistence("resp_1", "gpt-4o");
+    let request_body = build_request_body(
+        "OpenAI",
+        &serde_json::json!({
+            "model": "gpt-4o",
+            "stream": false
+        }),
+        &[ConversationTemplatePrompt {
+            prompt: "system".to_string(),
+            role: Role::Developer,
+        }],
+        Mode::Contextual,
+        &[
+            make_message(Role::User, Status::Normal, Content::new("old user")),
+            assistant,
+            make_message(
+                Role::User,
+                Status::Normal,
+                Content::new("after continuation"),
+            ),
+        ],
+        Role::User,
+        "latest",
+    )?;
+
+    assert_eq!(request_body["previous_response_id"], "resp_1");
+    let input = request_body["input"].as_array().expect("input array");
+    assert_eq!(input.len(), 3);
+    assert_eq!(input[0]["content"][0]["text"], "system");
+    assert_eq!(input[1]["content"][0]["text"], "after continuation");
+    assert_eq!(input[2]["content"][0]["text"], "latest");
+    Ok(())
+}
+
+#[test]
+fn non_contextual_openai_request_ignores_run_state_continuation() -> anyhow::Result<()> {
+    let mut assistant = make_message(Role::Assistant, Status::Normal, Content::new("old answer"));
+    assistant.run_persistence = openai_run_persistence("resp_1", "gpt-4o");
+    let request_body = build_request_body(
+        "OpenAI",
+        &serde_json::json!({
+            "model": "gpt-4o",
+            "stream": false
+        }),
+        &[],
+        Mode::AssistantOnly,
+        &[assistant],
+        Role::User,
+        "latest",
+    )?;
+
+    assert!(request_body.get("previous_response_id").is_none());
+    let input = request_body["input"].as_array().expect("input array");
+    assert_eq!(input.len(), 2);
+    assert_eq!(input[0]["content"][0]["text"], "old answer");
+    assert_eq!(input[1]["content"][0]["text"], "latest");
     Ok(())
 }
 

--- a/app/ai-chat/src/features/temporary/detail/tests.rs
+++ b/app/ai-chat/src/features/temporary/detail/tests.rs
@@ -8,8 +8,11 @@ use crate::database::{
 };
 use crate::features::conversation::detail::ConversationDetailViewExt;
 use crate::llm::LlmOutputItem;
+use crate::state::AiChatConfig;
 use std::rc::Rc;
 use time::OffsetDateTime;
+
+const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
 
 fn input_texts(items: Vec<crate::llm::LlmInputItem>) -> Vec<(&'static str, String)> {
     items
@@ -64,17 +67,52 @@ fn make_provider_message(
     }
 }
 
+fn openai_config(base_url: &str) -> anyhow::Result<AiChatConfig> {
+    let mut config = AiChatConfig::default();
+    config.set_provider_settings(
+        "OpenAI",
+        toml::from_str(&format!("baseUrl = \"{base_url}\"\n"))?,
+    );
+    Ok(config)
+}
+
+fn openai_settings(base_url: &str) -> serde_json::Value {
+    serde_json::json!({ "baseUrl": base_url })
+}
+
+fn openai_request_body(model: &str, stream: bool) -> serde_json::Value {
+    serde_json::json!({
+        "model": model,
+        "stream": stream,
+        "input": [{ "role": "user", "content": [{ "type": "input_text", "text": "old input" }] }]
+    })
+}
+
 fn openai_run_persistence(run_id: &str, model: &str) -> MessageRunPersistence {
+    openai_run_persistence_with_request(
+        run_id,
+        model,
+        openai_settings(DEFAULT_OPENAI_BASE_URL),
+        openai_request_body(model, false),
+    )
+}
+
+fn openai_run_persistence_with_request(
+    run_id: &str,
+    model: &str,
+    settings: serde_json::Value,
+    request_body: serde_json::Value,
+) -> MessageRunPersistence {
     MessageRunPersistence {
         run_state: Some(MessageRunState {
             provider: "OpenAI".to_string(),
             run_id: Some(run_id.to_string()),
             output_item_ids: vec!["msg_1".to_string()],
             continuation_metadata: serde_json::Value::Null,
-            request_body: serde_json::json!({ "model": model }),
+            request_body,
             usage: None,
             model: Some(model.to_string()),
-            settings: None,
+            settings: Some(settings),
         }),
         output_items: Vec::new(),
         attachments: Vec::new(),
@@ -121,8 +159,8 @@ fn build_request_body_uses_override_template_model() -> anyhow::Result<()> {
         &[],
         Mode::Contextual,
         &[],
-        Role::User,
-        "hello",
+        &AiChatConfig::default(),
+        (Role::User, "hello"),
     )?;
     assert_eq!(request_body["model"], serde_json::json!("override-model"));
     Ok(())
@@ -130,6 +168,7 @@ fn build_request_body_uses_override_template_model() -> anyhow::Result<()> {
 
 #[test]
 fn contextual_openai_request_uses_latest_compatible_run_state() -> anyhow::Result<()> {
+    let config = openai_config(DEFAULT_OPENAI_BASE_URL)?;
     let mut assistant = make_message(Role::Assistant, Status::Normal, Content::new("old answer"));
     assistant.run_persistence = openai_run_persistence("resp_1", "gpt-4o");
     let request_body = build_request_body(
@@ -152,8 +191,8 @@ fn contextual_openai_request_uses_latest_compatible_run_state() -> anyhow::Resul
                 Content::new("after continuation"),
             ),
         ],
-        Role::User,
-        "latest",
+        &config,
+        (Role::User, "latest"),
     )?;
 
     assert_eq!(request_body["previous_response_id"], "resp_1");
@@ -162,6 +201,131 @@ fn contextual_openai_request_uses_latest_compatible_run_state() -> anyhow::Resul
     assert_eq!(input[0]["content"][0]["text"], "system");
     assert_eq!(input[1]["content"][0]["text"], "after continuation");
     assert_eq!(input[2]["content"][0]["text"], "latest");
+    Ok(())
+}
+
+#[test]
+fn contextual_openai_request_falls_back_when_settings_differ() -> anyhow::Result<()> {
+    let config = openai_config(DEFAULT_OPENAI_BASE_URL)?;
+    let mut assistant = make_message(Role::Assistant, Status::Normal, Content::new("old answer"));
+    assistant.run_persistence = openai_run_persistence_with_request(
+        "resp_1",
+        "gpt-4o",
+        openai_settings("https://proxy.openai.local/v1"),
+        openai_request_body("gpt-4o", false),
+    );
+    let request_body = build_request_body(
+        "OpenAI",
+        &serde_json::json!({
+            "model": "gpt-4o",
+            "stream": false
+        }),
+        &[ConversationTemplatePrompt {
+            prompt: "system".to_string(),
+            role: Role::Developer,
+        }],
+        Mode::Contextual,
+        &[
+            make_message(Role::User, Status::Normal, Content::new("old user")),
+            assistant,
+            make_message(
+                Role::User,
+                Status::Normal,
+                Content::new("after continuation"),
+            ),
+        ],
+        &config,
+        (Role::User, "latest"),
+    )?;
+
+    assert!(request_body.get("previous_response_id").is_none());
+    let input = request_body["input"].as_array().expect("input array");
+    assert_eq!(input.len(), 5);
+    assert_eq!(input[1]["content"][0]["text"], "old user");
+    assert_eq!(input[2]["content"][0]["text"], "old answer");
+    Ok(())
+}
+
+#[test]
+fn contextual_openai_request_falls_back_when_request_context_differs() -> anyhow::Result<()> {
+    let config = openai_config(DEFAULT_OPENAI_BASE_URL)?;
+    let mut assistant = make_message(Role::Assistant, Status::Normal, Content::new("old answer"));
+    assistant.run_persistence = openai_run_persistence_with_request(
+        "resp_1",
+        "gpt-4o",
+        openai_settings(DEFAULT_OPENAI_BASE_URL),
+        openai_request_body("gpt-4o", true),
+    );
+    let request_body = build_request_body(
+        "OpenAI",
+        &serde_json::json!({
+            "model": "gpt-4o",
+            "stream": false
+        }),
+        &[ConversationTemplatePrompt {
+            prompt: "system".to_string(),
+            role: Role::Developer,
+        }],
+        Mode::Contextual,
+        &[
+            make_message(Role::User, Status::Normal, Content::new("old user")),
+            assistant,
+            make_message(
+                Role::User,
+                Status::Normal,
+                Content::new("after continuation"),
+            ),
+        ],
+        &config,
+        (Role::User, "latest"),
+    )?;
+
+    assert!(request_body.get("previous_response_id").is_none());
+    let input = request_body["input"].as_array().expect("input array");
+    assert_eq!(input.len(), 5);
+    Ok(())
+}
+
+#[test]
+fn contextual_openai_request_ignores_prior_previous_response_id_in_context_key()
+-> anyhow::Result<()> {
+    let config = openai_config(DEFAULT_OPENAI_BASE_URL)?;
+    let mut assistant = make_message(Role::Assistant, Status::Normal, Content::new("old answer"));
+    let mut request_body = openai_request_body("gpt-4o", false);
+    request_body["previous_response_id"] = serde_json::json!("resp_0");
+    assistant.run_persistence = openai_run_persistence_with_request(
+        "resp_1",
+        "gpt-4o",
+        openai_settings(DEFAULT_OPENAI_BASE_URL),
+        request_body,
+    );
+    let request_body = build_request_body(
+        "OpenAI",
+        &serde_json::json!({
+            "model": "gpt-4o",
+            "stream": false
+        }),
+        &[ConversationTemplatePrompt {
+            prompt: "system".to_string(),
+            role: Role::Developer,
+        }],
+        Mode::Contextual,
+        &[
+            make_message(Role::User, Status::Normal, Content::new("old user")),
+            assistant,
+            make_message(
+                Role::User,
+                Status::Normal,
+                Content::new("after continuation"),
+            ),
+        ],
+        &config,
+        (Role::User, "latest"),
+    )?;
+
+    assert_eq!(request_body["previous_response_id"], "resp_1");
+    let input = request_body["input"].as_array().expect("input array");
+    assert_eq!(input.len(), 3);
     Ok(())
 }
 
@@ -178,8 +342,8 @@ fn non_contextual_openai_request_ignores_run_state_continuation() -> anyhow::Res
         &[],
         Mode::AssistantOnly,
         &[assistant],
-        Role::User,
-        "latest",
+        &AiChatConfig::default(),
+        (Role::User, "latest"),
     )?;
 
     assert!(request_body.get("previous_response_id").is_none());

--- a/app/ai-chat/src/llm.rs
+++ b/app/ai-chat/src/llm.rs
@@ -18,7 +18,10 @@ pub(crate) use provider::{
     ProviderSettingsSpec, ReasoningCapability, ReasoningEffort, available_models, provider_by_name,
     provider_is_configured, provider_names, provider_settings_specs,
 };
-pub(crate) use run_persistence::ProviderRunPersistenceAccumulator;
+pub(crate) use run_persistence::{
+    ProviderRunPersistenceAccumulator, persisted_provider_settings_snapshot,
+    provider_run_request_context_key,
+};
 pub(crate) use runner::ProviderRunRunner;
 // Re-export the full provider-neutral item vocabulary for staged follow-up issues.
 #[allow(unused_imports)]

--- a/app/ai-chat/src/llm/provider.rs
+++ b/app/ai-chat/src/llm/provider.rs
@@ -1,4 +1,4 @@
-use super::{LlmInputItem, ProviderRunEvent, ProviderRunRequest};
+use super::{LlmInputItem, ProviderRunEvent, ProviderRunRequest, ProviderRunState};
 use crate::{
     errors::{AiChatError, AiChatResult},
     state::AiChatConfig,
@@ -264,6 +264,14 @@ pub(crate) trait Provider: Sync {
         template: &serde_json::Value,
         input_items: Vec<LlmInputItem>,
     ) -> AiChatResult<ProviderRunRequest>;
+    fn build_run_request_with_state(
+        &self,
+        template: &serde_json::Value,
+        input_items: Vec<LlmInputItem>,
+        _state: Option<ProviderRunState>,
+    ) -> AiChatResult<ProviderRunRequest> {
+        self.build_run_request(template, input_items)
+    }
     fn run<'a>(
         &'a self,
         config: AiChatConfig,
@@ -276,6 +284,17 @@ pub(crate) trait Provider: Sync {
         input_items: Vec<LlmInputItem>,
     ) -> AiChatResult<serde_json::Value> {
         Ok(self.build_run_request(template, input_items)?.request_body)
+    }
+    #[cfg(test)]
+    fn request_body_with_state(
+        &self,
+        template: &serde_json::Value,
+        input_items: Vec<LlmInputItem>,
+        state: Option<ProviderRunState>,
+    ) -> AiChatResult<serde_json::Value> {
+        Ok(self
+            .build_run_request_with_state(template, input_items, state)?
+            .request_body)
     }
     fn list_models(
         &self,

--- a/app/ai-chat/src/llm/provider/openai.rs
+++ b/app/ai-chat/src/llm/provider/openai.rs
@@ -5,11 +5,11 @@ use super::{
     normalized_or_default, optional_setting_value,
 };
 use crate::{
-    database::{Content, UrlCitation},
+    database::{Content, Role, UrlCitation},
     errors::{AiChatError, AiChatResult},
     llm::{
-        LlmHostedToolCall, LlmInputItem, LlmOutputItem, ProviderRunEvent, ProviderRunRequest,
-        ProviderRunState, ProviderUsage,
+        LlmContentPart, LlmHostedToolCall, LlmInputItem, LlmMcpApprovalRequest, LlmOutputItem,
+        LlmToolCall, ProviderRunEvent, ProviderRunRequest, ProviderRunState, ProviderUsage,
     },
     state::AiChatConfig,
 };
@@ -26,6 +26,7 @@ use nom::{
 };
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value as JsonValue};
 use toml::Value;
 use tracing::{Level, event};
 
@@ -135,10 +136,21 @@ fn save_openai_settings(settings: OpenAISettings, cx: &mut App) {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 struct HostedTool {
     #[serde(rename = "type")]
     tool_type: String,
+    #[serde(default, flatten)]
+    extra: Map<String, JsonValue>,
+}
+
+impl HostedTool {
+    fn new(tool_type: impl Into<String>) -> Self {
+        Self {
+            tool_type: tool_type.into(),
+            extra: Map::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -151,18 +163,68 @@ struct ReasoningConfig {
 #[derive(Debug, Serialize)]
 struct ChatRequest<'a> {
     model: &'a str,
-    input: Vec<OpenAIInputMessage>,
+    input: Vec<OpenAIInputItem>,
     stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    previous_response_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    include: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<HostedTool>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reasoning: Option<ReasoningConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parallel_tool_calls: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum OpenAIInputItem {
+    Message(OpenAIInputMessage),
+    ToolResult(OpenAIToolResultInput),
+    ItemReference(OpenAIItemReferenceInput),
 }
 
 #[derive(Debug, Serialize)]
 struct OpenAIInputMessage {
     role: &'static str,
-    content: String,
+    content: Vec<OpenAIInputContentPart>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type")]
+enum OpenAIInputContentPart {
+    #[serde(rename = "input_text")]
+    Text { text: String },
+    #[serde(rename = "input_image")]
+    Image {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        image_url: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        file_id: Option<String>,
+        detail: &'static str,
+    },
+    #[serde(rename = "input_file")]
+    File { file_id: String },
+}
+
+#[derive(Debug, Serialize)]
+struct OpenAIToolResultInput {
+    #[serde(rename = "type")]
+    item_type: &'static str,
+    call_id: String,
+    output: String,
+}
+
+#[derive(Debug, Serialize)]
+struct OpenAIItemReferenceInput {
+    #[serde(rename = "type")]
+    item_type: &'static str,
+    id: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -173,13 +235,19 @@ enum OpenAIResponseStreamEvent {
     #[serde(rename = "response.in_progress")]
     ResponseInProgress { response: OpenAIResponseSnapshot },
     #[serde(rename = "response.output_item.added")]
-    ResponseOutputItemAdded { item: OpenAIOutputItemEvent },
+    ResponseOutputItemAdded { item: OpenAIOutputItem },
     #[serde(rename = "response.output_item.done")]
-    ResponseOutputItemDone { item: OpenAIOutputItemEvent },
+    ResponseOutputItemDone { item: OpenAIOutputItem },
     #[serde(rename = "response.reasoning_summary_text.delta")]
     ResponseReasoningSummaryTextDelta { delta: String },
     #[serde(rename = "response.output_text.delta")]
     ResponseOutputTextDelta { delta: String },
+    #[serde(rename = "response.function_call_arguments.done")]
+    ResponseFunctionCallArgumentsDone {
+        item_id: String,
+        name: String,
+        arguments: String,
+    },
     #[serde(rename = "response.completed")]
     ResponseCompleted { response: ResponsesCreateResponse },
     #[serde(rename = "response.incomplete")]
@@ -210,18 +278,10 @@ struct OpenAIIncompleteDetails {
 }
 
 #[derive(Debug, Deserialize)]
-struct OpenAIOutputItemEvent {
-    id: Option<String>,
-    #[serde(rename = "type")]
-    item_type: String,
-    status: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
 struct OpenAIResponseSnapshot {
     id: Option<String>,
     #[serde(default)]
-    output: Vec<OpenAIOutputItemEvent>,
+    output: Vec<OpenAIOutputItem>,
     usage: Option<OpenAIUsage>,
 }
 
@@ -230,9 +290,17 @@ pub(crate) struct OpenAIRequestTemplate {
     model: String,
     stream: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    include: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<HostedTool>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     reasoning: Option<ReasoningConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    text: Option<JsonValue>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<JsonValue>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    parallel_tool_calls: Option<bool>,
 }
 
 impl Default for OpenAIRequestTemplate {
@@ -240,8 +308,12 @@ impl Default for OpenAIRequestTemplate {
         Self {
             model: "gpt-4o".to_string(),
             stream: true,
+            include: None,
             tools: None,
             reasoning: None,
+            text: None,
+            tool_choice: None,
+            parallel_tool_calls: None,
         }
     }
 }
@@ -259,18 +331,24 @@ struct ModelListItem {
 #[derive(Debug, Deserialize)]
 struct ResponsesCreateResponse {
     id: Option<String>,
-    output: Vec<OutputItem>,
+    output: Vec<OpenAIOutputItem>,
     usage: Option<OpenAIUsage>,
 }
 
 #[derive(Debug, Deserialize)]
-struct OutputItem {
+struct OpenAIOutputItem {
     id: Option<String>,
     #[serde(rename = "type")]
     item_type: Option<String>,
+    status: Option<String>,
+    role: Option<String>,
     content: Option<Vec<OutputContent>>,
     #[serde(default)]
     summary: Vec<ReasoningSummaryPart>,
+    call_id: Option<String>,
+    name: Option<String>,
+    arguments: Option<JsonValue>,
+    server_label: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -320,20 +398,121 @@ impl OutputAnnotation {
     }
 }
 
-impl OpenAIOutputItemEvent {
+impl OpenAIOutputItem {
+    fn output_item_id(&self) -> Option<String> {
+        self.id.clone().or_else(|| self.call_id.clone())
+    }
+
+    fn call_id(&self) -> Option<String> {
+        self.call_id.clone().or_else(|| self.id.clone())
+    }
+
     fn output_item(&self) -> Option<LlmOutputItem> {
-        match self.item_type.as_str() {
-            "reasoning" => Some(LlmOutputItem::Reasoning { summary: None }),
-            "web_search_call" | "file_search_call" | "image_generation_call" => {
-                Some(LlmOutputItem::HostedToolCall(LlmHostedToolCall {
-                    call_id: self.id.clone().unwrap_or_default(),
-                    tool_type: self.item_type.clone(),
-                    status: self.status.clone(),
-                }))
-            }
+        let item_type = self.item_type.as_deref()?;
+        match item_type {
+            "message" => Some(LlmOutputItem::Message {
+                role: openai_output_role(self.role.as_deref()),
+                content: self.output_content_parts(),
+            }),
+            "reasoning" => Some(LlmOutputItem::Reasoning {
+                summary: self.reasoning_summary(),
+            }),
+            "function_call" | "custom_tool_call" => Some(LlmOutputItem::ToolCall(
+                self.tool_call(item_type.to_string()),
+            )),
+            "mcp_approval_request" => Some(LlmOutputItem::McpApproval(self.mcp_approval_request())),
+            "web_search_call"
+            | "file_search_call"
+            | "image_generation_call"
+            | "code_interpreter_call"
+            | "computer_call"
+            | "computer_call_output"
+            | "mcp_call"
+            | "mcp_list_tools" => Some(LlmOutputItem::HostedToolCall(LlmHostedToolCall {
+                call_id: self.output_item_id().unwrap_or_default(),
+                tool_type: item_type.to_string(),
+                status: self.status.clone(),
+            })),
             _ => None,
         }
     }
+
+    fn output_content_parts(&self) -> Vec<LlmContentPart> {
+        self.content
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|part| part.text_content_part())
+            .collect()
+    }
+
+    fn reasoning_summary(&self) -> Option<String> {
+        let summary = self
+            .summary
+            .iter()
+            .filter(|part| part.part_type == "summary_text")
+            .filter_map(|part| part.text.as_deref())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        (!summary.trim().is_empty()).then_some(summary)
+    }
+
+    fn tool_call(&self, fallback_name: String) -> LlmToolCall {
+        LlmToolCall {
+            call_id: self.call_id().unwrap_or_default(),
+            name: self.name.clone().unwrap_or(fallback_name),
+            arguments: parse_openai_arguments(self.arguments.as_ref()),
+        }
+    }
+
+    fn mcp_approval_request(&self) -> LlmMcpApprovalRequest {
+        LlmMcpApprovalRequest {
+            request_id: self.call_id().unwrap_or_default(),
+            server_label: self.server_label.clone().unwrap_or_default(),
+            tool_name: self.name.clone().unwrap_or_default(),
+            arguments: parse_openai_arguments(self.arguments.as_ref()),
+        }
+    }
+}
+
+impl OutputContent {
+    fn text_content_part(&self) -> Option<LlmContentPart> {
+        match self.content_type.as_str() {
+            "output_text" | "refusal" => self.text.clone().map(LlmContentPart::Text),
+            _ => None,
+        }
+    }
+}
+
+fn parse_openai_arguments(arguments: Option<&JsonValue>) -> JsonValue {
+    match arguments {
+        Some(JsonValue::String(arguments)) => {
+            serde_json::from_str(arguments).unwrap_or_else(|_| JsonValue::String(arguments.clone()))
+        }
+        Some(arguments) => arguments.clone(),
+        None => serde_json::json!({}),
+    }
+}
+
+fn parse_openai_argument_string(arguments: &str) -> JsonValue {
+    serde_json::from_str(arguments).unwrap_or_else(|_| JsonValue::String(arguments.to_string()))
+}
+
+fn openai_output_role(role: Option<&str>) -> Role {
+    match role {
+        Some("developer") | Some("system") => Role::Developer,
+        Some("user") => Role::User,
+        Some("assistant") | None => Role::Assistant,
+        Some(_) => Role::Assistant,
+    }
+}
+
+fn continuation_metadata(request_body: &serde_json::Value) -> serde_json::Value {
+    request_body
+        .get("previous_response_id")
+        .cloned()
+        .map(|previous_response_id| serde_json::json!({ "previous_response_id": previous_response_id }))
+        .unwrap_or(serde_json::Value::Null)
 }
 
 impl OpenAIUsage {
@@ -346,7 +525,14 @@ impl ResponsesCreateResponse {
     fn output_item_ids(&self) -> Vec<String> {
         self.output
             .iter()
-            .filter_map(|item| item.id.clone())
+            .filter_map(OpenAIOutputItem::output_item_id)
+            .collect()
+    }
+
+    fn output_items(&self) -> Vec<LlmOutputItem> {
+        self.output
+            .iter()
+            .filter_map(OpenAIOutputItem::output_item)
             .collect()
     }
 
@@ -359,14 +545,7 @@ impl ResponsesCreateResponse {
         let mut citations = Vec::new();
         for item in self.output {
             if item.item_type.as_deref() == Some("reasoning") {
-                let summary = item
-                    .summary
-                    .into_iter()
-                    .filter(|part| part.part_type == "summary_text")
-                    .filter_map(|part| part.text)
-                    .collect::<Vec<_>>()
-                    .join("\n\n");
-                if !summary.trim().is_empty() {
+                if let Some(summary) = item.reasoning_summary() {
                     append_reasoning_summary_block(&mut content, &summary);
                 }
                 continue;
@@ -559,7 +738,12 @@ fn classify_model(id: &str) -> Option<ModelCapabilities> {
     Some(capabilities)
 }
 
+#[cfg(test)]
 fn parse_response_stream_event(message: &str) -> AiChatResult<Option<ProviderRunEvent>> {
+    Ok(parse_response_stream_events(message)?.into_iter().next())
+}
+
+fn parse_response_stream_events(message: &str) -> AiChatResult<Vec<ProviderRunEvent>> {
     let event = serde_json::from_str::<OpenAIResponseStreamEvent>(message)?;
     match event {
         OpenAIResponseStreamEvent::ResponseCreated { response }
@@ -568,25 +752,41 @@ fn parse_response_stream_event(message: &str) -> AiChatResult<Option<ProviderRun
             let _ = response.output;
             Ok(response
                 .usage
-                .map(|usage| ProviderRunEvent::UsageUpdated(usage.provider_usage())))
+                .map(|usage| vec![ProviderRunEvent::UsageUpdated(usage.provider_usage())])
+                .unwrap_or_default())
         }
         OpenAIResponseStreamEvent::ResponseOutputItemAdded { item }
-            if item.item_type == "reasoning" =>
+            if item.item_type.as_deref() == Some("reasoning") =>
         {
-            Ok(Some(ProviderRunEvent::ThinkingStarted))
+            let mut events = vec![ProviderRunEvent::ThinkingStarted];
+            if let Some(item) = item.output_item() {
+                events.push(ProviderRunEvent::OutputItemAdded(item));
+            }
+            Ok(events)
         }
-        OpenAIResponseStreamEvent::ResponseOutputItemAdded { item } => {
-            Ok(item.output_item().map(ProviderRunEvent::OutputItemAdded))
-        }
-        OpenAIResponseStreamEvent::ResponseOutputItemDone { item } => {
-            Ok(item.output_item().map(ProviderRunEvent::OutputItemDone))
-        }
+        OpenAIResponseStreamEvent::ResponseOutputItemAdded { item } => Ok(item
+            .output_item()
+            .map(|item| vec![ProviderRunEvent::OutputItemAdded(item)])
+            .unwrap_or_default()),
+        OpenAIResponseStreamEvent::ResponseOutputItemDone { item } => Ok(item
+            .output_item()
+            .map(|item| vec![ProviderRunEvent::OutputItemDone(item)])
+            .unwrap_or_default()),
         OpenAIResponseStreamEvent::ResponseReasoningSummaryTextDelta { delta } => {
-            Ok(Some(ProviderRunEvent::ReasoningSummaryDelta(delta)))
+            Ok(vec![ProviderRunEvent::ReasoningSummaryDelta(delta)])
         }
         OpenAIResponseStreamEvent::ResponseOutputTextDelta { delta } => {
-            Ok(Some(ProviderRunEvent::TextDelta(delta)))
+            Ok(vec![ProviderRunEvent::TextDelta(delta)])
         }
+        OpenAIResponseStreamEvent::ResponseFunctionCallArgumentsDone {
+            item_id,
+            name,
+            arguments,
+        } => Ok(vec![ProviderRunEvent::ToolCallRequested(LlmToolCall {
+            call_id: item_id,
+            name,
+            arguments: parse_openai_argument_string(&arguments),
+        })]),
         OpenAIResponseStreamEvent::ResponseCompleted { response } => {
             let state = ProviderRunState::new(
                 OpenAIProvider.name(),
@@ -595,11 +795,11 @@ fn parse_response_stream_event(message: &str) -> AiChatResult<Option<ProviderRun
                 serde_json::Value::Null,
             );
             let usage = response.usage();
-            Ok(Some(ProviderRunEvent::Completed {
+            Ok(vec![ProviderRunEvent::Completed {
                 content: response.into_content(),
                 state: Some(state),
                 usage,
-            }))
+            }])
         }
         OpenAIResponseStreamEvent::Error { message, .. } => Err(AiChatError::StreamError(message)),
         OpenAIResponseStreamEvent::ResponseFailed { response } => {
@@ -616,9 +816,9 @@ fn parse_response_stream_event(message: &str) -> AiChatResult<Option<ProviderRun
                 .or_else(|| response.error.map(|error| error.message))
                 .unwrap_or_else(|| "OpenAI response incomplete".to_string());
             let _ = response.id;
-            Ok(Some(ProviderRunEvent::Failed { message }))
+            Ok(vec![ProviderRunEvent::Failed { message }])
         }
-        OpenAIResponseStreamEvent::Other => Ok(None),
+        OpenAIResponseStreamEvent::Other => Ok(Vec::new()),
     }
 }
 
@@ -729,9 +929,7 @@ impl OpenAIProvider {
     }
 
     fn web_search_tool() -> HostedTool {
-        HostedTool {
-            tool_type: "web_search".to_string(),
-        }
+        HostedTool::new("web_search")
     }
 
     fn default_tools_for_model(model: &ProviderModel) -> Option<Vec<HostedTool>> {
@@ -749,31 +947,135 @@ impl OpenAIProvider {
         (!tools.is_empty()).then_some(tools)
     }
 
-    fn get_body(
-        template: &OpenAIRequestTemplate,
+    fn get_body<'a>(
+        template: &'a OpenAIRequestTemplate,
         input_items: Vec<LlmInputItem>,
-    ) -> AiChatResult<ChatRequest<'_>> {
+        previous_state: Option<&ProviderRunState>,
+    ) -> AiChatResult<ChatRequest<'a>> {
         Ok(ChatRequest {
             input: input_items
                 .into_iter()
-                .map(Self::to_openai_input_message)
+                .map(Self::to_openai_input_item)
                 .collect::<AiChatResult<_>>()?,
             model: template.model.as_str(),
             stream: template.stream,
+            previous_response_id: previous_state
+                .filter(|state| state.provider_name == OpenAIProvider.name())
+                .and_then(|state| state.run_id.clone()),
+            include: template.include.clone(),
             tools: template
                 .tools
                 .clone()
                 .and_then(|tools| Self::sanitize_tools(&template.model, tools)),
             reasoning: Self::sanitize_reasoning(&template.model, template.reasoning.clone()),
+            text: template.text.clone(),
+            tool_choice: template.tool_choice.clone(),
+            parallel_tool_calls: template.parallel_tool_calls,
         })
     }
 
-    fn to_openai_input_message(item: LlmInputItem) -> AiChatResult<OpenAIInputMessage> {
-        let (role, content) = item.single_text()?;
-        Ok(OpenAIInputMessage {
-            role,
-            content: content.to_string(),
+    fn to_openai_input_item(item: LlmInputItem) -> AiChatResult<OpenAIInputItem> {
+        Ok(match item {
+            LlmInputItem::System { content } => OpenAIInputItem::Message(OpenAIInputMessage {
+                role: "system",
+                content: Self::to_openai_content_parts(content)?,
+            }),
+            LlmInputItem::Developer { content } => OpenAIInputItem::Message(OpenAIInputMessage {
+                role: "developer",
+                content: Self::to_openai_content_parts(content)?,
+            }),
+            LlmInputItem::User { content } => OpenAIInputItem::Message(OpenAIInputMessage {
+                role: "user",
+                content: Self::to_openai_content_parts(content)?,
+            }),
+            LlmInputItem::Assistant { content } => OpenAIInputItem::Message(OpenAIInputMessage {
+                role: "assistant",
+                content: Self::to_openai_content_parts(content)?,
+            }),
+            LlmInputItem::ToolResult(result) => {
+                OpenAIInputItem::ToolResult(OpenAIToolResultInput {
+                    item_type: "function_call_output",
+                    call_id: result.call_id,
+                    output: Self::tool_result_output(result.content)?,
+                })
+            }
+            LlmInputItem::ItemReference { item_id } => {
+                OpenAIInputItem::ItemReference(OpenAIItemReferenceInput {
+                    item_type: "item_reference",
+                    id: item_id,
+                })
+            }
         })
+    }
+
+    fn to_openai_content_parts(
+        content: Vec<LlmContentPart>,
+    ) -> AiChatResult<Vec<OpenAIInputContentPart>> {
+        if content.is_empty() {
+            return Err(Self::unsupported_input("empty content"));
+        }
+        content
+            .into_iter()
+            .map(Self::to_openai_content_part)
+            .collect()
+    }
+
+    fn to_openai_content_part(part: LlmContentPart) -> AiChatResult<OpenAIInputContentPart> {
+        Ok(match part {
+            LlmContentPart::Text(text) => OpenAIInputContentPart::Text { text },
+            LlmContentPart::ImageRef(attachment) if Self::is_image_url(&attachment.id) => {
+                OpenAIInputContentPart::Image {
+                    image_url: Some(attachment.id),
+                    file_id: None,
+                    detail: "auto",
+                }
+            }
+            LlmContentPart::ImageRef(attachment) => OpenAIInputContentPart::Image {
+                image_url: None,
+                file_id: Some(attachment.id),
+                detail: "auto",
+            },
+            LlmContentPart::FileRef(attachment) => OpenAIInputContentPart::File {
+                file_id: attachment.id,
+            },
+            LlmContentPart::AudioRef(_) => return Err(Self::unsupported_input("audio content")),
+            LlmContentPart::AttachmentRef(_) => {
+                return Err(Self::unsupported_input("generic attachment content"));
+            }
+        })
+    }
+
+    fn tool_result_output(content: Vec<LlmContentPart>) -> AiChatResult<String> {
+        if content.is_empty() {
+            return Err(Self::unsupported_input("empty tool result"));
+        }
+        let mut output = String::new();
+        for part in content {
+            match part {
+                LlmContentPart::Text(text) => output.push_str(&text),
+                LlmContentPart::ImageRef(_) => {
+                    return Err(Self::unsupported_input("image tool result"));
+                }
+                LlmContentPart::FileRef(_) => {
+                    return Err(Self::unsupported_input("file tool result"));
+                }
+                LlmContentPart::AudioRef(_) => {
+                    return Err(Self::unsupported_input("audio tool result"));
+                }
+                LlmContentPart::AttachmentRef(_) => {
+                    return Err(Self::unsupported_input("generic attachment tool result"));
+                }
+            }
+        }
+        Ok(output)
+    }
+
+    fn is_image_url(id: &str) -> bool {
+        id.starts_with("http://") || id.starts_with("https://") || id.starts_with("data:")
+    }
+
+    fn unsupported_input(kind: &str) -> AiChatError {
+        AiChatError::StreamError(format!("unsupported OpenAI Responses input item: {kind}"))
     }
 
     fn get_reqwest_client(
@@ -811,8 +1113,12 @@ impl Provider for OpenAIProvider {
         Ok(serde_json::to_value(OpenAIRequestTemplate {
             model: model.id.clone(),
             stream: model.capabilities.supports_streaming(),
+            include: None,
             tools: Self::default_tools_for_model(model),
             reasoning: None,
+            text: None,
+            tool_choice: None,
+            parallel_tool_calls: None,
         })?)
     }
 
@@ -821,13 +1127,27 @@ impl Provider for OpenAIProvider {
         template: &serde_json::Value,
         input_items: Vec<LlmInputItem>,
     ) -> AiChatResult<ProviderRunRequest> {
+        self.build_run_request_with_state(template, input_items, None)
+    }
+
+    fn build_run_request_with_state(
+        &self,
+        template: &serde_json::Value,
+        input_items: Vec<LlmInputItem>,
+        state: Option<ProviderRunState>,
+    ) -> AiChatResult<ProviderRunRequest> {
         let template = OpenAIRequestTemplate::deserialize(template)?;
-        let request_body = serde_json::to_value(Self::get_body(&template, input_items.clone())?)?;
-        Ok(ProviderRunRequest::new(
-            self.name(),
+        let request_body = serde_json::to_value(Self::get_body(
+            &template,
+            input_items.clone(),
+            state.as_ref(),
+        )?)?;
+        Ok(ProviderRunRequest {
+            provider_name: self.name().to_string(),
             request_body,
             input_items,
-        ))
+            state,
+        })
     }
 
     fn run<'a>(
@@ -858,11 +1178,15 @@ impl Provider for OpenAIProvider {
                             let message = message.data;
                             if message == "[DONE]" {
                                 break;
-                            } else if let Some(mut event) = parse_response_stream_event(&message)? {
-                                if let ProviderRunEvent::Completed { state: Some(state), .. } = &mut event {
-                                    state.request_body = request.request_body.clone();
+                            } else {
+                                for mut event in parse_response_stream_events(&message)? {
+                                    if let ProviderRunEvent::Completed { state: Some(state), .. } = &mut event {
+                                        state.request_body = request.request_body.clone();
+                                        state.continuation_metadata =
+                                            continuation_metadata(&request.request_body);
+                                    }
+                                    yield event;
                                 }
-                                yield event;
                             }
                         }
                         Err(err) => {
@@ -879,13 +1203,19 @@ impl Provider for OpenAIProvider {
                 let response = response
                     .json::<ResponsesCreateResponse>()
                     .await?;
+                let output_items = response.output_items();
                 let state = ProviderRunState::new(
                     self.name(),
                     response.id.clone(),
                     response.output_item_ids(),
                     request.request_body.clone(),
                 );
+                let mut state = state;
+                state.continuation_metadata = continuation_metadata(&request.request_body);
                 let usage = response.usage();
+                for item in output_items {
+                    yield ProviderRunEvent::OutputItemDone(item);
+                }
                 yield ProviderRunEvent::Completed {
                     content: response.into_content(),
                     state: Some(state),

--- a/app/ai-chat/src/llm/provider/openai.rs
+++ b/app/ai-chat/src/llm/provider/openai.rs
@@ -27,6 +27,7 @@ use nom::{
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value as JsonValue};
+use std::collections::HashMap;
 use toml::Value;
 use tracing::{Level, event};
 
@@ -384,6 +385,17 @@ struct OpenAIUsage {
     total_tokens: Option<u64>,
 }
 
+#[derive(Default)]
+struct OpenAIResponseStreamState {
+    call_ids_by_item_id: HashMap<String, String>,
+    pending_tool_calls_by_item_id: HashMap<String, PendingOpenAIToolCall>,
+}
+
+struct PendingOpenAIToolCall {
+    name: String,
+    arguments: serde_json::Value,
+}
+
 impl OutputAnnotation {
     fn into_citation(self) -> Option<UrlCitation> {
         if self.annotation_type != "url_citation" {
@@ -405,6 +417,17 @@ impl OpenAIOutputItem {
 
     fn call_id(&self) -> Option<String> {
         self.call_id.clone().or_else(|| self.id.clone())
+    }
+
+    fn explicit_call_id(&self) -> Option<&str> {
+        self.call_id.as_deref()
+    }
+
+    fn is_function_call(&self) -> bool {
+        matches!(
+            self.item_type.as_deref(),
+            Some("function_call" | "custom_tool_call")
+        )
     }
 
     fn output_item(&self) -> Option<LlmOutputItem> {
@@ -472,6 +495,50 @@ impl OpenAIOutputItem {
             tool_name: self.name.clone().unwrap_or_default(),
             arguments: parse_openai_arguments(self.arguments.as_ref()),
         }
+    }
+}
+
+impl OpenAIResponseStreamState {
+    fn record_output_item(&mut self, item: &OpenAIOutputItem) -> Vec<ProviderRunEvent> {
+        if !item.is_function_call() {
+            return Vec::new();
+        }
+        let (Some(item_id), Some(call_id)) = (item.id.as_deref(), item.explicit_call_id()) else {
+            return Vec::new();
+        };
+
+        self.call_ids_by_item_id
+            .insert(item_id.to_string(), call_id.to_string());
+        self.pending_tool_calls_by_item_id
+            .remove(item_id)
+            .map(|pending| {
+                vec![ProviderRunEvent::ToolCallRequested(LlmToolCall {
+                    call_id: call_id.to_string(),
+                    name: pending.name,
+                    arguments: pending.arguments,
+                })]
+            })
+            .unwrap_or_default()
+    }
+
+    fn tool_call_requested(
+        &mut self,
+        item_id: String,
+        name: String,
+        arguments: String,
+    ) -> Vec<ProviderRunEvent> {
+        let arguments = parse_openai_argument_string(&arguments);
+        if let Some(call_id) = self.call_ids_by_item_id.get(&item_id) {
+            return vec![ProviderRunEvent::ToolCallRequested(LlmToolCall {
+                call_id: call_id.clone(),
+                name,
+                arguments,
+            })];
+        }
+
+        self.pending_tool_calls_by_item_id
+            .insert(item_id, PendingOpenAIToolCall { name, arguments });
+        Vec::new()
     }
 }
 
@@ -743,7 +810,16 @@ fn parse_response_stream_event(message: &str) -> AiChatResult<Option<ProviderRun
     Ok(parse_response_stream_events(message)?.into_iter().next())
 }
 
+#[cfg(test)]
 fn parse_response_stream_events(message: &str) -> AiChatResult<Vec<ProviderRunEvent>> {
+    let mut state = OpenAIResponseStreamState::default();
+    parse_response_stream_events_with_state(message, &mut state)
+}
+
+fn parse_response_stream_events_with_state(
+    message: &str,
+    state: &mut OpenAIResponseStreamState,
+) -> AiChatResult<Vec<ProviderRunEvent>> {
     let event = serde_json::from_str::<OpenAIResponseStreamEvent>(message)?;
     match event {
         OpenAIResponseStreamEvent::ResponseCreated { response }
@@ -758,20 +834,27 @@ fn parse_response_stream_events(message: &str) -> AiChatResult<Vec<ProviderRunEv
         OpenAIResponseStreamEvent::ResponseOutputItemAdded { item }
             if item.item_type.as_deref() == Some("reasoning") =>
         {
-            let mut events = vec![ProviderRunEvent::ThinkingStarted];
+            let mut events = state.record_output_item(&item);
+            events.push(ProviderRunEvent::ThinkingStarted);
             if let Some(item) = item.output_item() {
                 events.push(ProviderRunEvent::OutputItemAdded(item));
             }
             Ok(events)
         }
-        OpenAIResponseStreamEvent::ResponseOutputItemAdded { item } => Ok(item
-            .output_item()
-            .map(|item| vec![ProviderRunEvent::OutputItemAdded(item)])
-            .unwrap_or_default()),
-        OpenAIResponseStreamEvent::ResponseOutputItemDone { item } => Ok(item
-            .output_item()
-            .map(|item| vec![ProviderRunEvent::OutputItemDone(item)])
-            .unwrap_or_default()),
+        OpenAIResponseStreamEvent::ResponseOutputItemAdded { item } => {
+            let mut events = state.record_output_item(&item);
+            if let Some(item) = item.output_item() {
+                events.push(ProviderRunEvent::OutputItemAdded(item));
+            }
+            Ok(events)
+        }
+        OpenAIResponseStreamEvent::ResponseOutputItemDone { item } => {
+            let mut events = state.record_output_item(&item);
+            if let Some(item) = item.output_item() {
+                events.push(ProviderRunEvent::OutputItemDone(item));
+            }
+            Ok(events)
+        }
         OpenAIResponseStreamEvent::ResponseReasoningSummaryTextDelta { delta } => {
             Ok(vec![ProviderRunEvent::ReasoningSummaryDelta(delta)])
         }
@@ -782,11 +865,7 @@ fn parse_response_stream_events(message: &str) -> AiChatResult<Vec<ProviderRunEv
             item_id,
             name,
             arguments,
-        } => Ok(vec![ProviderRunEvent::ToolCallRequested(LlmToolCall {
-            call_id: item_id,
-            name,
-            arguments: parse_openai_argument_string(&arguments),
-        })]),
+        } => Ok(state.tool_call_requested(item_id, name, arguments)),
         OpenAIResponseStreamEvent::ResponseCompleted { response } => {
             let state = ProviderRunState::new(
                 OpenAIProvider.name(),
@@ -1172,6 +1251,7 @@ impl Provider for OpenAIProvider {
                     .await?;
                 let response = response.error_for_status()?;
                 let mut es = response.bytes_stream().eventsource();
+                let mut stream_state = OpenAIResponseStreamState::default();
                 while let Some(event) = es.next().await {
                     match event {
                         Ok(message) => {
@@ -1179,7 +1259,10 @@ impl Provider for OpenAIProvider {
                             if message == "[DONE]" {
                                 break;
                             } else {
-                                for mut event in parse_response_stream_events(&message)? {
+                                for mut event in parse_response_stream_events_with_state(
+                                    &message,
+                                    &mut stream_state,
+                                )? {
                                     if let ProviderRunEvent::Completed { state: Some(state), .. } = &mut event {
                                         state.request_body = request.request_body.clone();
                                         state.continuation_metadata =

--- a/app/ai-chat/src/llm/provider/openai/tests.rs
+++ b/app/ai-chat/src/llm/provider/openai/tests.rs
@@ -1,9 +1,10 @@
 use super::{
     ExtSettingControl, HostedTool, ModelCapabilities, OpenAIProvider, OpenAIRequestTemplate,
-    Provider, ProviderModel, REASONING_EFFORT_KEY, REASONING_HIGH, REASONING_LOW, REASONING_MEDIUM,
-    REASONING_NONE, REASONING_SUMMARY_AUTO, REASONING_XHIGH, ReasoningConfig, ReasoningEffort,
-    ResponsesCreateResponse, classify_model, normalize_base_url, parse_response_stream_event,
-    parse_response_stream_events,
+    OpenAIResponseStreamState, Provider, ProviderModel, REASONING_EFFORT_KEY, REASONING_HIGH,
+    REASONING_LOW, REASONING_MEDIUM, REASONING_NONE, REASONING_SUMMARY_AUTO, REASONING_XHIGH,
+    ReasoningConfig, ReasoningEffort, ResponsesCreateResponse, classify_model, normalize_base_url,
+    parse_response_stream_event, parse_response_stream_events,
+    parse_response_stream_events_with_state,
 };
 use crate::{
     database::{Content, Role},
@@ -658,15 +659,47 @@ fn reasoning_output_item_added_starts_thinking() -> anyhow::Result<()> {
 
 #[test]
 fn function_call_arguments_done_yields_tool_call() -> anyhow::Result<()> {
-    let update = parse_response_stream_event(
-        r#"{"type":"response.function_call_arguments.done","item_id":"call_1","name":"lookup","arguments":"{\"q\":\"rust\"}"}"#,
+    let mut state = OpenAIResponseStreamState::default();
+    parse_response_stream_events_with_state(
+        r#"{"type":"response.output_item.added","item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"lookup","arguments":"","status":"in_progress"}}"#,
+        &mut state,
+    )?;
+    let updates = parse_response_stream_events_with_state(
+        r#"{"type":"response.function_call_arguments.done","item_id":"fc_1","name":"lookup","arguments":"{\"q\":\"rust\"}"}"#,
+        &mut state,
     )?;
     assert!(matches!(
-        update,
+        updates.first(),
         Some(ProviderRunEvent::ToolCallRequested(call))
             if call.call_id == "call_1"
                 && call.name == "lookup"
                 && call.arguments == json!({ "q": "rust" })
+    ));
+    Ok(())
+}
+
+#[test]
+fn function_call_arguments_done_waits_for_call_id_mapping() -> anyhow::Result<()> {
+    let mut state = OpenAIResponseStreamState::default();
+    let updates = parse_response_stream_events_with_state(
+        r#"{"type":"response.function_call_arguments.done","item_id":"fc_1","name":"lookup","arguments":"{\"q\":\"rust\"}"}"#,
+        &mut state,
+    )?;
+    assert!(updates.is_empty());
+
+    let updates = parse_response_stream_events_with_state(
+        r#"{"type":"response.output_item.done","item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"lookup","arguments":"{\"q\":\"rust\"}","status":"completed"}}"#,
+        &mut state,
+    )?;
+    assert!(matches!(
+        updates.as_slice(),
+        [
+            ProviderRunEvent::ToolCallRequested(requested),
+            ProviderRunEvent::OutputItemDone(LlmOutputItem::ToolCall(done)),
+        ] if requested.call_id == "call_1"
+            && requested.name == "lookup"
+            && requested.arguments == json!({ "q": "rust" })
+            && done.call_id == "call_1"
     ));
     Ok(())
 }

--- a/app/ai-chat/src/llm/provider/openai/tests.rs
+++ b/app/ai-chat/src/llm/provider/openai/tests.rs
@@ -3,10 +3,14 @@ use super::{
     Provider, ProviderModel, REASONING_EFFORT_KEY, REASONING_HIGH, REASONING_LOW, REASONING_MEDIUM,
     REASONING_NONE, REASONING_SUMMARY_AUTO, REASONING_XHIGH, ReasoningConfig, ReasoningEffort,
     ResponsesCreateResponse, classify_model, normalize_base_url, parse_response_stream_event,
+    parse_response_stream_events,
 };
 use crate::{
     database::{Content, Role},
-    llm::{ExtSettingOption, LlmAttachmentRef, LlmContentPart, LlmInputItem, ProviderRunEvent},
+    llm::{
+        ExtSettingOption, LlmAttachmentRef, LlmContentPart, LlmInputItem, LlmOutputItem,
+        ProviderRunEvent, ProviderRunState,
+    },
 };
 use serde_json::json;
 
@@ -58,12 +62,7 @@ fn default_template_uses_model_stream_capability() -> anyhow::Result<()> {
     )?;
     assert_eq!(template.model, "gpt-5");
     assert!(template.stream);
-    assert_eq!(
-        template.tools,
-        Some(vec![HostedTool {
-            tool_type: "web_search".to_string(),
-        }])
-    );
+    assert_eq!(template.tools, Some(vec![HostedTool::new("web_search")]));
     Ok(())
 }
 
@@ -162,16 +161,66 @@ fn request_body_maps_text_input_items() -> anyhow::Result<()> {
     )?;
 
     assert_eq!(request_body["input"][0]["role"], "developer");
-    assert_eq!(request_body["input"][0]["content"], "system prompt");
+    assert_eq!(
+        request_body["input"][0]["content"][0],
+        json!({ "type": "input_text", "text": "system prompt" })
+    );
     assert_eq!(request_body["input"][1]["role"], "user");
-    assert_eq!(request_body["input"][1]["content"], "hello");
+    assert_eq!(
+        request_body["input"][1]["content"][0],
+        json!({ "type": "input_text", "text": "hello" })
+    );
     assert_eq!(request_body["input"][2]["role"], "assistant");
-    assert_eq!(request_body["input"][2]["content"], "previous answer");
+    assert_eq!(
+        request_body["input"][2]["content"][0],
+        json!({ "type": "input_text", "text": "previous answer" })
+    );
     Ok(())
 }
 
 #[test]
-fn request_body_rejects_non_text_input_parts() {
+fn request_body_maps_image_and_file_input_parts() -> anyhow::Result<()> {
+    let request_body = OpenAIProvider.request_body(
+        &json!({
+            "model": "gpt-4o",
+            "stream": false
+        }),
+        vec![LlmInputItem::User {
+            content: vec![
+                LlmContentPart::Text("describe".to_string()),
+                LlmContentPart::ImageRef(LlmAttachmentRef {
+                    id: "https://example.com/image.png".to_string(),
+                    mime_type: Some("image/png".to_string()),
+                    name: None,
+                }),
+                LlmContentPart::ImageRef(LlmAttachmentRef {
+                    id: "file-img-1".to_string(),
+                    mime_type: Some("image/png".to_string()),
+                    name: None,
+                }),
+                LlmContentPart::FileRef(LlmAttachmentRef {
+                    id: "file-doc-1".to_string(),
+                    mime_type: Some("application/pdf".to_string()),
+                    name: Some("doc.pdf".to_string()),
+                }),
+            ],
+        }],
+    )?;
+
+    assert_eq!(
+        request_body["input"][0]["content"],
+        json!([
+            { "type": "input_text", "text": "describe" },
+            { "type": "input_image", "image_url": "https://example.com/image.png", "detail": "auto" },
+            { "type": "input_image", "file_id": "file-img-1", "detail": "auto" },
+            { "type": "input_file", "file_id": "file-doc-1" }
+        ])
+    );
+    Ok(())
+}
+
+#[test]
+fn request_body_rejects_unsupported_input_parts() {
     let err = OpenAIProvider
         .request_body(
             &json!({
@@ -179,16 +228,75 @@ fn request_body_rejects_non_text_input_parts() {
                 "stream": false
             }),
             vec![LlmInputItem::User {
-                content: vec![LlmContentPart::ImageRef(LlmAttachmentRef {
-                    id: "image-1".to_string(),
-                    mime_type: Some("image/png".to_string()),
+                content: vec![LlmContentPart::AudioRef(LlmAttachmentRef {
+                    id: "audio-1".to_string(),
+                    mime_type: Some("audio/wav".to_string()),
                     name: None,
                 })],
             }],
         )
-        .expect_err("non-text input should be rejected");
+        .expect_err("audio input should be rejected");
 
-    assert!(err.to_string().contains("unsupported LLM input item"));
+    assert!(
+        err.to_string()
+            .contains("unsupported OpenAI Responses input item: audio content")
+    );
+}
+
+#[test]
+fn request_body_includes_previous_response_id_from_state() -> anyhow::Result<()> {
+    let request_body = OpenAIProvider.request_body_with_state(
+        &json!({
+            "model": "gpt-4o",
+            "stream": false
+        }),
+        vec![LlmInputItem::from_role_text(Role::User, "next")],
+        Some(ProviderRunState::new(
+            "OpenAI",
+            Some("resp_1".to_string()),
+            vec!["msg_1".to_string()],
+            json!({ "model": "gpt-4o" }),
+        )),
+    )?;
+
+    assert_eq!(request_body["previous_response_id"], "resp_1");
+    assert_eq!(request_body["input"].as_array().unwrap().len(), 1);
+    Ok(())
+}
+
+#[test]
+fn request_body_preserves_responses_specific_template_fields() -> anyhow::Result<()> {
+    let request_body = OpenAIProvider.request_body(
+        &json!({
+            "model": "gpt-4o",
+            "stream": false,
+            "include": ["web_search_call.results"],
+            "text": { "format": { "type": "json_object" } },
+            "tool_choice": "auto",
+            "parallel_tool_calls": true,
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "lookup",
+                    "parameters": { "type": "object" },
+                    "strict": true
+                }
+            ]
+        }),
+        vec![LlmInputItem::from_role_text(Role::User, "hello")],
+    )?;
+
+    assert_eq!(request_body["include"], json!(["web_search_call.results"]));
+    assert_eq!(
+        request_body["text"],
+        json!({ "format": { "type": "json_object" } })
+    );
+    assert_eq!(request_body["tool_choice"], "auto");
+    assert_eq!(request_body["parallel_tool_calls"], true);
+    assert_eq!(request_body["tools"][0]["type"], "function");
+    assert_eq!(request_body["tools"][0]["name"], "lookup");
+    assert_eq!(request_body["tools"][0]["strict"], true);
+    Ok(())
 }
 
 #[test]
@@ -448,6 +556,67 @@ fn responses_create_response_extracts_web_search_citations() {
 }
 
 #[test]
+fn responses_create_response_maps_output_items() {
+    let response = serde_json::from_value::<ResponsesCreateResponse>(json!({
+        "id": "resp_1",
+        "output": [
+            {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "content": [{ "type": "output_text", "text": "hello", "annotations": [] }]
+            },
+            {
+                "id": "rs_1",
+                "type": "reasoning",
+                "summary": [{ "type": "summary_text", "text": "thinking" }]
+            },
+            {
+                "id": "fc_1",
+                "type": "function_call",
+                "call_id": "call_1",
+                "name": "lookup",
+                "arguments": "{\"q\":\"rust\"}"
+            },
+            {
+                "id": "mcp_1",
+                "type": "mcp_call",
+                "status": "completed"
+            }
+        ]
+    }))
+    .expect("response");
+
+    let items = response.output_items();
+    assert_eq!(items.len(), 4);
+    assert!(matches!(
+        &items[0],
+        LlmOutputItem::Message {
+            role: Role::Assistant,
+            content
+        } if content == &vec![LlmContentPart::Text("hello".to_string())]
+    ));
+    assert!(matches!(
+        &items[1],
+        LlmOutputItem::Reasoning { summary } if summary.as_deref() == Some("thinking")
+    ));
+    assert!(matches!(
+        &items[2],
+        LlmOutputItem::ToolCall(call)
+            if call.call_id == "call_1"
+                && call.name == "lookup"
+                && call.arguments == json!({ "q": "rust" })
+    ));
+    assert!(matches!(
+        &items[3],
+        LlmOutputItem::HostedToolCall(call)
+            if call.call_id == "mcp_1"
+                && call.tool_type == "mcp_call"
+                && call.status.as_deref() == Some("completed")
+    ));
+}
+
+#[test]
 fn response_completed_event_yields_complete_update() -> anyhow::Result<()> {
     let update = parse_response_stream_event(
         r#"{"type":"response.completed","response":{"output":[{"type":"message","content":[{"type":"output_text","text":"done","annotations":[{"type":"url_citation","title":"Example","url":"https://example.com","start_index":0,"end_index":4}]}]}]}}"#,
@@ -474,6 +643,46 @@ fn reasoning_output_item_added_starts_thinking() -> anyhow::Result<()> {
         r#"{"type":"response.output_item.added","item":{"type":"reasoning","summary":[]}}"#,
     )?;
     assert_eq!(update, Some(ProviderRunEvent::ThinkingStarted));
+
+    let updates = parse_response_stream_events(
+        r#"{"type":"response.output_item.added","item":{"type":"reasoning","summary":[]}}"#,
+    )?;
+    assert_eq!(updates.len(), 2);
+    assert!(matches!(updates[0], ProviderRunEvent::ThinkingStarted));
+    assert!(matches!(
+        updates[1],
+        ProviderRunEvent::OutputItemAdded(LlmOutputItem::Reasoning { .. })
+    ));
+    Ok(())
+}
+
+#[test]
+fn function_call_arguments_done_yields_tool_call() -> anyhow::Result<()> {
+    let update = parse_response_stream_event(
+        r#"{"type":"response.function_call_arguments.done","item_id":"call_1","name":"lookup","arguments":"{\"q\":\"rust\"}"}"#,
+    )?;
+    assert!(matches!(
+        update,
+        Some(ProviderRunEvent::ToolCallRequested(call))
+            if call.call_id == "call_1"
+                && call.name == "lookup"
+                && call.arguments == json!({ "q": "rust" })
+    ));
+    Ok(())
+}
+
+#[test]
+fn output_item_done_yields_function_call_item() -> anyhow::Result<()> {
+    let update = parse_response_stream_event(
+        r#"{"type":"response.output_item.done","item":{"id":"fc_1","type":"function_call","call_id":"call_1","name":"lookup","arguments":"{\"q\":\"rust\"}","status":"completed"}}"#,
+    )?;
+    assert!(matches!(
+        update,
+        Some(ProviderRunEvent::OutputItemDone(LlmOutputItem::ToolCall(call)))
+            if call.call_id == "call_1"
+                && call.name == "lookup"
+                && call.arguments == json!({ "q": "rust" })
+    ));
     Ok(())
 }
 

--- a/app/ai-chat/src/llm/run_persistence.rs
+++ b/app/ai-chat/src/llm/run_persistence.rs
@@ -135,7 +135,7 @@ impl ProviderRunPersistenceAccumulator {
     }
 }
 
-fn persisted_provider_settings_snapshot(
+pub(crate) fn persisted_provider_settings_snapshot(
     provider_name: &str,
     config: &AiChatConfig,
 ) -> Option<serde_json::Value> {
@@ -157,6 +157,17 @@ fn persisted_provider_settings_snapshot(
     }
 
     (!snapshot.is_empty()).then(|| serde_json::Value::Object(snapshot))
+}
+
+pub(crate) fn provider_run_request_context_key(
+    request_body: &serde_json::Value,
+) -> serde_json::Value {
+    let mut context_key = request_body.clone();
+    if let Some(context_key) = context_key.as_object_mut() {
+        context_key.remove("input");
+        context_key.remove("previous_response_id");
+    }
+    context_key
 }
 
 fn safe_provider_setting_value(value: &serde_json::Value) -> serde_json::Value {
@@ -191,7 +202,9 @@ mod tests {
         state::AiChatConfig,
     };
 
-    use super::{ProviderRunPersistenceAccumulator, ProviderRunRequest};
+    use super::{
+        ProviderRunPersistenceAccumulator, ProviderRunRequest, provider_run_request_context_key,
+    };
 
     fn request() -> ProviderRunRequest {
         ProviderRunRequest::new(
@@ -309,5 +322,31 @@ httpProxy = "http://proxy-user:proxy-pass@127.0.0.1:7890"
         assert!(!serialized.contains("proxy-user"));
         assert!(!serialized.contains("proxy-pass"));
         Ok(())
+    }
+
+    #[test]
+    fn request_context_key_ignores_input_and_previous_response_id() {
+        let left = provider_run_request_context_key(&serde_json::json!({
+            "model": "gpt-4o",
+            "stream": false,
+            "previous_response_id": "resp_1",
+            "input": [{ "role": "user", "content": "old" }],
+            "tools": [{ "type": "web_search_preview" }]
+        }));
+        let right = provider_run_request_context_key(&serde_json::json!({
+            "model": "gpt-4o",
+            "stream": false,
+            "input": [{ "role": "user", "content": "new" }],
+            "tools": [{ "type": "web_search_preview" }]
+        }));
+        let different = provider_run_request_context_key(&serde_json::json!({
+            "model": "gpt-4o",
+            "stream": true,
+            "input": [{ "role": "user", "content": "old" }],
+            "tools": [{ "type": "web_search_preview" }]
+        }));
+
+        assert_eq!(left, right);
+        assert_ne!(left, different);
     }
 }


### PR DESCRIPTION
## Summary

- Implements the #143 OpenAI Responses adapter stage for `ai-chat`.
- Affected app: `ai-chat`.

## Motivation

- Move OpenAI onto the shared run/request abstraction from #137 while using #141 persisted run state for compatible Responses continuation.
- Keep OpenAI-specific Responses schema inside the OpenAI adapter instead of leaking it through provider-neutral core types.

## Changes

- Adds optional provider run state plumbing for request construction, with OpenAI using compatible state to emit `previous_response_id`.
- Updates contextual conversation and temporary chat flows to trim prior OpenAI history after the latest compatible assistant response, with full-transcript fallback for incompatible or non-contextual modes.
- Converts OpenAI request input to Responses content/item arrays for text, image refs, file refs, tool outputs, and item refs; unsupported audio/generic attachments now fail explicitly.
- Expands OpenAI response and stream parsing for message, reasoning, hosted tool, function-call, and MCP-related output items, including function-call argument completion as `ToolCallRequested`.
- Updates #137 development notes with #143 completion status and validation commands.
- No database migration is included; #141 run state, output item, and attachment persistence are reused.

## Validation

- [ ] `cargo build`
- [ ] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
cargo fmt
cargo test -p ai-chat llm::provider::openai -- --nocapture
cargo test -p ai-chat features::home::tabs::conversation_panel -- --nocapture
cargo test -p ai-chat features::temporary::detail -- --nocapture
cargo test -p ai-chat database::service -- --nocapture
cargo test -p ai-chat database::migrations -- --nocapture
cargo clippy -p ai-chat --all-targets --all-features -- -D warnings
git diff --check

All commands above passed.

Full `cargo build`, full `cargo test`, and manual app verification were not run for this adapter-only stage.
```

## Risks

- OpenAI request snapshots now store Responses content arrays instead of plain text content for new runs, so resend/migration tests were updated around that body shape.
- OpenAI continuation is intentionally conservative and falls back to full transcript unless provider, mode, model snapshot, and persisted response state all match.
- This PR persists adapter-visible tool/MCP output items, but intentionally does not add tool execution, MCP configuration, approval UI, or capability-gated controls.

## Related Issues

- Closes #143
- Related to #137
