### PR TITLE
[ai-chat] Migrate Ollama onto shared LLM abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "app-theme",
  "async-compat",
  "async-stream",
+ "base64 0.22.1",
  "dhat",
  "diesel",
  "dirs-next",

--- a/app/ai-chat/Cargo.toml
+++ b/app/ai-chat/Cargo.toml
@@ -64,6 +64,7 @@ window-ext = { workspace = true }
 platform-ext = { workspace = true }
 rust-embed = { version = "8.11.0", features = ["interpolate-folder-path"] }
 anyhow = "1.0.102"
+base64 = "0.22.1"
 tray-icon = { version = "0.24.0", default-features = false, features = [
   "common-controls-v6",
 ] }

--- a/app/ai-chat/docs/dev/issue-137-llm-abstractions.md
+++ b/app/ai-chat/docs/dev/issue-137-llm-abstractions.md
@@ -22,7 +22,7 @@ Delete it before the final merge to `main`, unless the remaining content is prom
 | #139 | `codex/issue-139-provider-runtime` | Run-based provider trait and events | Merged to integration via PR #149; GitHub issue still open |
 | #141 | `codex/issue-141-llm-persistence` | Run state, output items, tools, attachments persistence | Merged to integration via PR #150; GitHub issue still open |
 | #143 | `codex/issue-143-openai-responses-abstraction` | OpenAI Responses migration on shared abstraction | Merged to integration via PR #151; GitHub issue still open |
-| #144 | `codex/issue-144-ollama-shared-abstraction` | Ollama migration on shared abstraction | Pending |
+| #144 | `codex/issue-144-ollama-shared-abstraction` | Ollama migration on shared abstraction | Implemented on child branch; pending integration PR |
 | #140 | `codex/issue-140-capability-gating` | Template, shortcut, and UI capability gating | Pending |
 
 ## Issue Sync Snapshot
@@ -35,7 +35,8 @@ Last synchronized: 2026-05-21.
 - #139 remains open on GitHub, but PR #149 merged `codex/issue-139-provider-runtime` into `codex/issue-137-llm-abstractions`.
 - #141 remains open on GitHub, but PR #150 merged `codex/issue-141-llm-persistence` into `codex/issue-137-llm-abstractions`.
 - #143 remains open on GitHub, but PR #151 merged `codex/issue-143-openai-responses-abstraction` into `codex/issue-137-llm-abstractions`.
-- #144 and #140 remain open and pending behind the OpenAI adapter stage.
+- #144 is implemented on `codex/issue-144-ollama-shared-abstraction` and pending integration PR back into `codex/issue-137-llm-abstractions`; GitHub issue still open.
+- #140 remains open and pending behind the Ollama adapter stage.
 
 ## Current Architecture Facts
 
@@ -46,7 +47,7 @@ Last synchronized: 2026-05-21.
 - `ProviderModel` now holds provider-neutral `ModelCapabilities` instead of the old streaming-only `ProviderModelCapability`.
 - `ModelCapabilities` covers text input/output, streaming, image/file/audio input, image generation, tool calling, hosted web search, remote MCP, reasoning, structured output, stateful response continuation, and provider-specific typed extensions.
 - OpenAI model classification now emits typed capabilities for Responses API usage, reasoning effort options, hosted web search, structured output, and stateful response continuation.
-- Ollama `/api/show` metadata now maps into typed capabilities and an `OllamaModelCapabilities` extension for raw capabilities, family data, thinking mode, and local web tools.
+- Ollama `/api/show` metadata now maps into typed capabilities and an `OllamaModelCapabilities` extension for raw capabilities, family data, thinking mode, local web tools, and vision image input.
 - `Provider` now builds `ProviderRunRequest` values from typed input items and streams provider-neutral `ProviderRunEvent` values.
 - `ProviderRunRequest` keeps the provider request JSON snapshot so existing `messages.send_content` resend behavior remains compatible.
 - `ProviderRunEvent` replaces `FetchUpdate` and covers thinking start, reasoning summary delta, text delta, output item added/done, tool call/result, MCP approval request, usage update, completed, and failed states.
@@ -55,7 +56,9 @@ Last synchronized: 2026-05-21.
 - `messages.content` stores rendered message content; `messages.send_content` stores the request body snapshot used for resend.
 - OpenAI uses `/v1/responses`, reasoning effort, reasoning summaries, hosted web search citations, provider-neutral output item events, and persisted `previous_response_id` continuation when compatible run state is available.
 - OpenAI adapter-specific Responses request fields such as `include`, `text`, `tool_choice`, `tools`, and `parallel_tool_calls` remain inside the OpenAI provider schema rather than the generic provider trait.
-- Ollama has provider-specific thinking and experimental web search/fetch behavior that must not be forced into OpenAI-shaped types.
+- Ollama has provider-specific thinking, image input, and experimental web search/fetch behavior that must not be forced into OpenAI-shaped types.
+- Ollama image input accepts raw base64 or `data:image/...;base64,...` references only; URL, file-id, local-path, file, audio, and generic attachment inputs remain explicitly unsupported.
+- Ollama run events now emit provider-neutral output item, tool call/result, usage, and completion data while keeping `ProviderRunState.run_id` empty and avoiding OpenAI-style continuation semantics.
 
 ## Shared Design Decisions
 
@@ -208,8 +211,25 @@ The current implementation keeps request persistence additive: existing provider
   - `cargo test -p ai-chat database::migrations -- --nocapture`
   - `cargo clippy -p ai-chat --all-targets --all-features -- -D warnings`
 
+### #144 Ollama Shared Abstraction Migration
+
+- Mapped Ollama `vision` capability to generic `ModelCapabilities.image_input` without exposing OpenAI-only hosted web search, remote MCP, or stateful continuation settings.
+- Kept Ollama thinking and experimental local web search/fetch as provider-specific extension behavior.
+- Migrated Ollama input conversion beyond single-text messages: normal messages support multi-part text joined with blank lines and base64/data-URL image inputs; text-only tool results map to Ollama `role: "tool"` messages.
+- Unsupported URL images, OpenAI file ids, local paths, files, audio, generic attachments, and item references fail explicitly instead of being silently coerced.
+- Ollama stream and non-stream responses now emit provider-neutral output item events, tool call/result events, token usage with Ollama timing metadata, and completed content.
+- Ollama run state remains additive and compatibility-oriented: no provider run id, no output item ids for continuation, and no OpenAI-shaped `previous_response_id` behavior.
+- Validation run:
+  - `cargo fmt`
+  - `cargo test -p ai-chat llm::provider::ollama`
+  - `cargo test -p ai-chat llm::provider`
+  - `cargo test -p ai-chat llm::run_persistence`
+  - `cargo test -p ai-chat features::home::tabs::conversation_panel`
+  - `cargo test -p ai-chat features::temporary::detail`
+  - `cargo clippy -p ai-chat --all-targets --all-features -- -D warnings`
+
 ## Next Child Issue Constraints
 
-Next child issue is #144.
+Next child issue is #140.
 
-#144 should migrate Ollama onto the shared abstraction and verify the core types are not OpenAI-shaped.
+#140 should add template, shortcut, and UI capability gating on top of the shared OpenAI and Ollama capability model.

--- a/app/ai-chat/src/llm/provider/ollama.rs
+++ b/app/ai-chat/src/llm/provider/ollama.rs
@@ -43,6 +43,12 @@ const THINK_MEDIUM: &str = "medium";
 const THINK_HIGH: &str = "high";
 const THINKING_OPTIONS: &[&str] = &[THINK_LOW, THINK_MEDIUM, THINK_HIGH];
 const WEB_SEARCH_TOOLTIP_KEY: &str = "tooltip-ollama-web-search-help";
+const USAGE_DURATION_METADATA_KEYS: &[&str] = &[
+    "total_duration",
+    "load_duration",
+    "prompt_eval_duration",
+    "eval_duration",
+];
 
 fn default_base_url() -> String {
     "http://localhost:11434".to_string()
@@ -831,6 +837,75 @@ impl OllamaProvider {
         content
     }
 
+    fn aggregate_usage(
+        accumulated: Option<ProviderUsage>,
+        round: Option<ProviderUsage>,
+    ) -> Option<ProviderUsage> {
+        match (accumulated, round) {
+            (None, None) => None,
+            (Some(usage), None) | (None, Some(usage)) => Some(usage),
+            (Some(accumulated), Some(round)) => {
+                let input_tokens =
+                    Self::sum_optional_u64(accumulated.input_tokens, round.input_tokens);
+                let output_tokens =
+                    Self::sum_optional_u64(accumulated.output_tokens, round.output_tokens);
+                let total_tokens = Self::sum_optional_u64(
+                    accumulated.total_tokens,
+                    round.total_tokens.or_else(|| {
+                        match (round.input_tokens, round.output_tokens) {
+                            (Some(input), Some(output)) => Some(input + output),
+                            _ => None,
+                        }
+                    }),
+                )
+                .or_else(|| match (input_tokens, output_tokens) {
+                    (Some(input), Some(output)) => Some(input + output),
+                    _ => None,
+                });
+                let mut usage = ProviderUsage::new(input_tokens, output_tokens, total_tokens);
+                usage.metadata =
+                    Self::aggregate_usage_metadata(&accumulated.metadata, &round.metadata);
+                Some(usage)
+            }
+        }
+    }
+
+    fn sum_optional_u64(left: Option<u64>, right: Option<u64>) -> Option<u64> {
+        match (left, right) {
+            (Some(left), Some(right)) => Some(left + right),
+            (Some(value), None) | (None, Some(value)) => Some(value),
+            (None, None) => None,
+        }
+    }
+
+    fn aggregate_usage_metadata(
+        accumulated: &serde_json::Value,
+        round: &serde_json::Value,
+    ) -> serde_json::Value {
+        let mut metadata = serde_json::Map::new();
+        if let Some(done_reason) = round
+            .get("done_reason")
+            .or_else(|| accumulated.get("done_reason"))
+            .cloned()
+        {
+            metadata.insert("done_reason".to_string(), done_reason);
+        }
+        for key in USAGE_DURATION_METADATA_KEYS {
+            if let Some(value) = Self::sum_optional_u64(
+                accumulated.get(key).and_then(serde_json::Value::as_u64),
+                round.get(key).and_then(serde_json::Value::as_u64),
+            ) {
+                metadata.insert((*key).to_string(), json!(value));
+            }
+        }
+
+        if metadata.is_empty() {
+            serde_json::Value::Null
+        } else {
+            serde_json::Value::Object(metadata)
+        }
+    }
+
     fn ensure_tool_call_ids(tool_calls: &mut [OllamaToolCall]) {
         for (index, tool_call) in tool_calls.iter_mut().enumerate() {
             if tool_call.id.trim().is_empty() {
@@ -992,6 +1067,7 @@ impl Provider for OllamaProvider {
             let mut request = OllamaStoredRequest::deserialize(&request.request_body)?;
             let mut final_citations = Vec::new();
             let mut accumulated_reasoning = String::new();
+            let mut accumulated_usage = None;
 
             loop {
                 let chat_request = OllamaChatRequest {
@@ -1070,8 +1146,11 @@ impl Provider for OllamaProvider {
                 for event in Self::output_item_done_events(&round.message) {
                     yield event;
                 }
-                if let Some(usage) = round.usage.clone() {
-                    yield ProviderRunEvent::UsageUpdated(usage);
+                if round.usage.is_some() {
+                    accumulated_usage = Self::aggregate_usage(accumulated_usage, round.usage.clone());
+                    if let Some(usage) = accumulated_usage.clone() {
+                        yield ProviderRunEvent::UsageUpdated(usage);
+                    }
                 }
 
                 if request.web_search && !round.message.tool_calls.is_empty() {
@@ -1108,7 +1187,7 @@ impl Provider for OllamaProvider {
                 yield ProviderRunEvent::Completed {
                     content,
                     state: Some(ProviderRunState::new(self.name(), None, Vec::new(), request_body.clone())),
-                    usage: round.usage,
+                    usage: accumulated_usage,
                 };
                 break;
             }

--- a/app/ai-chat/src/llm/provider/ollama.rs
+++ b/app/ai-chat/src/llm/provider/ollama.rs
@@ -13,6 +13,7 @@ use crate::{
     },
     state::AiChatConfig,
 };
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use futures::{FutureExt, StreamExt, future::BoxFuture, stream::BoxStream};
 use gpui::App;
 use reqwest::Client;
@@ -652,10 +653,8 @@ impl OllamaProvider {
         if value.is_empty() {
             return None;
         }
-        value
-            .chars()
-            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '+' | '/' | '='))
-            .then_some(value)
+        STANDARD.decode(value.as_bytes()).ok()?;
+        Some(value)
     }
 
     fn unsupported_input(kind: &str) -> AiChatError {

--- a/app/ai-chat/src/llm/provider/ollama.rs
+++ b/app/ai-chat/src/llm/provider/ollama.rs
@@ -5,11 +5,11 @@ use super::{
     normalized_or_default,
 };
 use crate::{
-    database::{Content, UrlCitation},
+    database::{Content, Role, UrlCitation},
     errors::{AiChatError, AiChatResult},
     llm::{
-        LlmContentPart, LlmInputItem, LlmToolCall, LlmToolResult, ProviderRunEvent,
-        ProviderRunRequest, ProviderRunState,
+        LlmAttachmentRef, LlmContentPart, LlmInputItem, LlmOutputItem, LlmToolCall, LlmToolResult,
+        ProviderRunEvent, ProviderRunRequest, ProviderRunState, ProviderUsage,
     },
     state::AiChatConfig,
 };
@@ -231,10 +231,14 @@ struct OllamaStoredRequest {
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
 struct OllamaChatMessage {
+    #[serde(default)]
     role: String,
+    #[serde(default)]
     content: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     thinking: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    images: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     tool_calls: Vec<OllamaToolCall>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -260,6 +264,20 @@ struct OllamaChatResponse {
     message: OllamaChatMessage,
     #[serde(default)]
     done: bool,
+    #[serde(default)]
+    done_reason: String,
+    #[serde(default)]
+    total_duration: Option<u64>,
+    #[serde(default)]
+    load_duration: Option<u64>,
+    #[serde(default)]
+    prompt_eval_count: Option<u64>,
+    #[serde(default)]
+    prompt_eval_duration: Option<u64>,
+    #[serde(default)]
+    eval_count: Option<u64>,
+    #[serde(default)]
+    eval_duration: Option<u64>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -344,6 +362,49 @@ struct WebFetchResponse {
 
 struct RoundResult {
     message: OllamaChatMessage,
+    usage: Option<ProviderUsage>,
+}
+
+impl OllamaChatResponse {
+    fn usage(&self) -> Option<ProviderUsage> {
+        let has_usage_metadata = !self.done_reason.trim().is_empty()
+            || self.total_duration.is_some()
+            || self.load_duration.is_some()
+            || self.prompt_eval_duration.is_some()
+            || self.eval_duration.is_some();
+        if self.prompt_eval_count.is_none() && self.eval_count.is_none() && !has_usage_metadata {
+            return None;
+        }
+
+        let total_tokens = match (self.prompt_eval_count, self.eval_count) {
+            (Some(input), Some(output)) => Some(input + output),
+            _ => None,
+        };
+        let mut usage = ProviderUsage::new(self.prompt_eval_count, self.eval_count, total_tokens);
+        let mut metadata = serde_json::Map::new();
+        if !self.done_reason.trim().is_empty() {
+            metadata.insert(
+                "done_reason".to_string(),
+                serde_json::Value::String(self.done_reason.clone()),
+            );
+        }
+        if let Some(value) = self.total_duration {
+            metadata.insert("total_duration".to_string(), json!(value));
+        }
+        if let Some(value) = self.load_duration {
+            metadata.insert("load_duration".to_string(), json!(value));
+        }
+        if let Some(value) = self.prompt_eval_duration {
+            metadata.insert("prompt_eval_duration".to_string(), json!(value));
+        }
+        if let Some(value) = self.eval_duration {
+            metadata.insert("eval_duration".to_string(), json!(value));
+        }
+        if !metadata.is_empty() {
+            usage.metadata = serde_json::Value::Object(metadata);
+        }
+        Some(usage)
+    }
 }
 
 impl OllamaProvider {
@@ -405,6 +466,12 @@ impl OllamaProvider {
             .iter()
             .any(|capability| capability == "tools");
         let mut capabilities = ModelCapabilities::text_streaming();
+        if raw_capabilities
+            .iter()
+            .any(|capability| capability == "vision")
+        {
+            capabilities.image_input = Some(super::ImageInputCapability { max_images: None });
+        }
         capabilities.reasoning = Self::thinking_capability(&raw_capabilities, &family, &families)
             .map(|_| super::ReasoningCapability {
                 default_effort: super::ReasoningEffort::Medium,
@@ -505,18 +572,94 @@ impl OllamaProvider {
     }
 
     fn to_ollama_message(item: LlmInputItem) -> AiChatResult<OllamaChatMessage> {
-        let (role, content) = item.single_text()?;
-        Ok(OllamaChatMessage {
-            role: match role {
-                "system" | "developer" => "system",
-                "user" => "user",
-                "assistant" => "assistant",
-                role => role,
+        let (role, content, tool_call_id) = match item {
+            LlmInputItem::System { content } => ("system", content, None),
+            LlmInputItem::Developer { content } => ("system", content, None),
+            LlmInputItem::User { content } => ("user", content, None),
+            LlmInputItem::Assistant { content } => ("assistant", content, None),
+            LlmInputItem::ToolResult(result) => ("tool", result.content, Some(result.call_id)),
+            LlmInputItem::ItemReference { .. } => {
+                return Err(Self::unsupported_input("item reference"));
             }
-            .to_string(),
-            content: content.to_string(),
+        };
+        let allow_images = tool_call_id.is_none();
+        let (content, images) = Self::content_parts(content, allow_images)?;
+        Ok(OllamaChatMessage {
+            role: role.to_string(),
+            content,
+            images,
+            tool_call_id: tool_call_id.unwrap_or_default(),
             ..Default::default()
         })
+    }
+
+    fn content_parts(
+        content: Vec<LlmContentPart>,
+        allow_images: bool,
+    ) -> AiChatResult<(String, Vec<String>)> {
+        if content.is_empty() {
+            return Err(Self::unsupported_input("empty content"));
+        }
+
+        let mut text_parts = Vec::new();
+        let mut images = Vec::new();
+        for part in content {
+            match part {
+                LlmContentPart::Text(text) => text_parts.push(text),
+                LlmContentPart::ImageRef(attachment) if allow_images => {
+                    images.push(Self::ollama_image_data(attachment)?);
+                }
+                LlmContentPart::ImageRef(_) => {
+                    return Err(Self::unsupported_input("image tool result"));
+                }
+                LlmContentPart::FileRef(_) => return Err(Self::unsupported_input("file content")),
+                LlmContentPart::AudioRef(_) => {
+                    return Err(Self::unsupported_input("audio content"));
+                }
+                LlmContentPart::AttachmentRef(_) => {
+                    return Err(Self::unsupported_input("generic attachment content"));
+                }
+            }
+        }
+
+        if text_parts.is_empty() && images.is_empty() {
+            return Err(Self::unsupported_input("empty content"));
+        }
+        Ok((text_parts.join("\n\n"), images))
+    }
+
+    fn ollama_image_data(attachment: LlmAttachmentRef) -> AiChatResult<String> {
+        let id = attachment.id.trim();
+        if let Some((header, data)) = id.split_once(',') {
+            let header = header.to_ascii_lowercase();
+            if header.starts_with("data:image/") && header.split(';').any(|part| part == "base64") {
+                return Self::raw_base64_image_data(data)
+                    .ok_or_else(|| Self::unsupported_input("invalid image data URL"));
+            }
+            return Err(Self::unsupported_input("unsupported image data URL"));
+        }
+
+        Self::raw_base64_image_data(id).ok_or_else(|| {
+            Self::unsupported_input("image input must be raw base64 or an image data URL")
+        })
+    }
+
+    fn raw_base64_image_data(value: &str) -> Option<String> {
+        let value = value
+            .chars()
+            .filter(|ch| !ch.is_ascii_whitespace())
+            .collect::<String>();
+        if value.is_empty() {
+            return None;
+        }
+        value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '+' | '/' | '='))
+            .then_some(value)
+    }
+
+    fn unsupported_input(kind: &str) -> AiChatError {
+        AiChatError::StreamError(format!("unsupported Ollama input item: {kind}"))
     }
 
     fn tool_definitions() -> Vec<OllamaToolDefinition> {
@@ -688,6 +831,107 @@ impl OllamaProvider {
         content.citations = citations;
         content
     }
+
+    fn ensure_tool_call_ids(tool_calls: &mut [OllamaToolCall]) {
+        for (index, tool_call) in tool_calls.iter_mut().enumerate() {
+            if tool_call.id.trim().is_empty() {
+                tool_call.id = format!("ollama-tool-{index}");
+            }
+        }
+    }
+
+    fn provider_tool_result(message: &OllamaChatMessage) -> LlmToolResult {
+        LlmToolResult {
+            call_id: message.tool_call_id.clone(),
+            content: vec![LlmContentPart::text(message.content.clone())],
+        }
+    }
+
+    fn output_item_done_events(message: &OllamaChatMessage) -> Vec<ProviderRunEvent> {
+        let mut events = Vec::new();
+        if !message.thinking.trim().is_empty() {
+            events.push(ProviderRunEvent::OutputItemDone(LlmOutputItem::Reasoning {
+                summary: Some(message.thinking.clone()),
+            }));
+        }
+        if !message.content.is_empty() {
+            events.push(ProviderRunEvent::OutputItemDone(LlmOutputItem::Message {
+                role: Self::output_role(&message.role),
+                content: vec![LlmContentPart::text(message.content.clone())],
+            }));
+        }
+        for tool_call in &message.tool_calls {
+            events.push(ProviderRunEvent::OutputItemDone(LlmOutputItem::ToolCall(
+                Self::provider_tool_call(tool_call),
+            )));
+        }
+        events
+    }
+
+    fn output_role(role: &str) -> Role {
+        match role {
+            "system" | "developer" => Role::Developer,
+            "user" => Role::User,
+            "assistant" | "" => Role::Assistant,
+            _ => Role::Assistant,
+        }
+    }
+
+    fn apply_stream_response(
+        event: OllamaChatResponse,
+        round_message: &mut OllamaChatMessage,
+        accumulated_reasoning: &mut String,
+        emitted_thinking_started: &mut bool,
+    ) -> (Vec<ProviderRunEvent>, Option<ProviderUsage>, bool) {
+        let mut events = Vec::new();
+        if !event.message.thinking.is_empty() {
+            if !*emitted_thinking_started {
+                events.push(ProviderRunEvent::ThinkingStarted);
+                *emitted_thinking_started = true;
+            }
+            accumulated_reasoning.push_str(&event.message.thinking);
+            events.push(ProviderRunEvent::ReasoningSummaryDelta(
+                event.message.thinking.clone(),
+            ));
+            round_message.thinking.push_str(&event.message.thinking);
+        }
+        if !event.message.content.is_empty() {
+            events.push(ProviderRunEvent::TextDelta(event.message.content.clone()));
+            round_message.content.push_str(&event.message.content);
+        }
+        if !event.message.images.is_empty() {
+            round_message.images.extend(event.message.images.clone());
+        }
+        if !event.message.tool_calls.is_empty() {
+            round_message.tool_calls = event.message.tool_calls.clone();
+            Self::ensure_tool_call_ids(&mut round_message.tool_calls);
+            for tool_call in &round_message.tool_calls {
+                events.push(ProviderRunEvent::ToolCallRequested(
+                    Self::provider_tool_call(tool_call),
+                ));
+            }
+        }
+        if !event.message.role.is_empty() {
+            round_message.role = event.message.role.clone();
+        }
+        let usage = event.done.then(|| event.usage()).flatten();
+        (events, usage, event.done)
+    }
+
+    fn apply_stream_response_line(
+        line: &str,
+        round_message: &mut OllamaChatMessage,
+        accumulated_reasoning: &mut String,
+        emitted_thinking_started: &mut bool,
+    ) -> AiChatResult<(Vec<ProviderRunEvent>, Option<ProviderUsage>, bool)> {
+        let event = serde_json::from_str::<OllamaChatResponse>(line)?;
+        Ok(Self::apply_stream_response(
+            event,
+            round_message,
+            accumulated_reasoning,
+            emitted_thinking_started,
+        ))
+    }
 }
 
 impl Provider for OllamaProvider {
@@ -765,10 +1009,12 @@ impl Provider for OllamaProvider {
                     .await?;
                 let response = error_for_status_with_ollama_message(response, "chat request").await?;
 
-                let round = if !chat_request.stream {
+                let mut round = if !chat_request.stream {
                     let response = response.json::<OllamaChatResponse>().await?;
+                    let usage = response.usage();
                     RoundResult {
                         message: response.message,
+                        usage,
                     }
                 } else {
                     let mut round_message = OllamaChatMessage {
@@ -779,6 +1025,7 @@ impl Provider for OllamaProvider {
                     let mut stream = response.bytes_stream();
                     let mut emitted_thinking_started = false;
                     let mut done_received = false;
+                    let mut usage = None;
 
                     while !done_received {
                         let Some(chunk) = stream.next().await else {
@@ -795,30 +1042,19 @@ impl Provider for OllamaProvider {
                                 continue;
                             }
 
-                            let event = serde_json::from_str::<OllamaChatResponse>(line)?;
-                            if !event.message.thinking.is_empty() {
-                                if !emitted_thinking_started {
-                                    yield ProviderRunEvent::ThinkingStarted;
-                                    emitted_thinking_started = true;
-                                }
-                                accumulated_reasoning.push_str(&event.message.thinking);
-                                yield ProviderRunEvent::ReasoningSummaryDelta(event.message.thinking.clone());
-                                round_message.thinking.push_str(&event.message.thinking);
+                            let (events, event_usage, done) = Self::apply_stream_response_line(
+                                line,
+                                &mut round_message,
+                                &mut accumulated_reasoning,
+                                &mut emitted_thinking_started,
+                            )?;
+                            for event in events {
+                                yield event;
                             }
-                            if !event.message.content.is_empty() {
-                                yield ProviderRunEvent::TextDelta(event.message.content.clone());
-                                round_message.content.push_str(&event.message.content);
+                            if let Some(event_usage) = event_usage {
+                                usage = Some(event_usage);
                             }
-                            if !event.message.tool_calls.is_empty() {
-                                round_message.tool_calls = event.message.tool_calls.clone();
-                                for tool_call in &round_message.tool_calls {
-                                    yield ProviderRunEvent::ToolCallRequested(Self::provider_tool_call(tool_call));
-                                }
-                            }
-                            if !event.message.role.is_empty() {
-                                round_message.role = event.message.role;
-                            }
-                            if event.done {
+                            if done {
                                 done_received = true;
                                 break;
                             }
@@ -827,8 +1063,17 @@ impl Provider for OllamaProvider {
 
                     RoundResult {
                         message: round_message,
+                        usage,
                     }
                 };
+
+                Self::ensure_tool_call_ids(&mut round.message.tool_calls);
+                for event in Self::output_item_done_events(&round.message) {
+                    yield event;
+                }
+                if let Some(usage) = round.usage.clone() {
+                    yield ProviderRunEvent::UsageUpdated(usage);
+                }
 
                 if request.web_search && !round.message.tool_calls.is_empty() {
                     let mut tool_calls = round.message.tool_calls.clone();
@@ -841,10 +1086,9 @@ impl Provider for OllamaProvider {
                         Self::execute_tools(&client, &settings.base_url, &mut tool_calls).await?;
                     final_citations.extend(citations);
                     for message in &tool_messages {
-                        yield ProviderRunEvent::ToolResultReceived(LlmToolResult {
-                            call_id: message.tool_call_id.clone(),
-                            content: vec![LlmContentPart::text(message.content.clone())],
-                        });
+                        let tool_result = Self::provider_tool_result(message);
+                        yield ProviderRunEvent::ToolResultReceived(tool_result.clone());
+                        yield ProviderRunEvent::OutputItemDone(LlmOutputItem::ToolResult(tool_result));
                     }
                     request.messages.push(OllamaChatMessage {
                         role: "assistant".to_string(),
@@ -865,7 +1109,7 @@ impl Provider for OllamaProvider {
                 yield ProviderRunEvent::Completed {
                     content,
                     state: Some(ProviderRunState::new(self.name(), None, Vec::new(), request_body.clone())),
-                    usage: None,
+                    usage: round.usage,
                 };
                 break;
             }

--- a/app/ai-chat/src/llm/provider/ollama/tests.rs
+++ b/app/ai-chat/src/llm/provider/ollama/tests.rs
@@ -379,7 +379,9 @@ fn request_body_maps_multipart_text_and_image_input() -> anyhow::Result<()> {
 fn request_body_rejects_unsupported_image_refs() {
     for id in [
         "https://example.com/image.png",
+        "abc123",
         "file-img-1",
+        "/tmp/image",
         "/tmp/image.png",
     ] {
         let err = OllamaProvider

--- a/app/ai-chat/src/llm/provider/ollama/tests.rs
+++ b/app/ai-chat/src/llm/provider/ollama/tests.rs
@@ -8,7 +8,7 @@ use crate::{
     database::{Role, UrlCitation},
     llm::{
         ExtSettingItem, LlmAttachmentRef, LlmContentPart, LlmInputItem, LlmOutputItem,
-        LlmToolResult, ProviderRunEvent,
+        LlmToolResult, ProviderRunEvent, ProviderUsage,
     },
 };
 use serde_json::json;
@@ -663,6 +663,34 @@ fn non_stream_response_maps_output_items_and_usage() -> anyhow::Result<()> {
     assert_eq!(usage.metadata["prompt_eval_duration"], 40);
     assert_eq!(usage.metadata["eval_duration"], 60);
     Ok(())
+}
+
+#[test]
+fn aggregate_usage_sums_multiple_chat_rounds() {
+    let mut first = ProviderUsage::new(Some(3), Some(2), Some(5));
+    first.metadata = json!({
+        "done_reason": "tool_calls",
+        "total_duration": 100,
+        "load_duration": 10,
+        "prompt_eval_duration": 30
+    });
+    let mut second = ProviderUsage::new(Some(7), Some(11), Some(18));
+    second.metadata = json!({
+        "done_reason": "stop",
+        "total_duration": 300,
+        "load_duration": 20,
+        "eval_duration": 90
+    });
+
+    let usage = OllamaProvider::aggregate_usage(Some(first), Some(second)).expect("usage");
+    assert_eq!(usage.input_tokens, Some(10));
+    assert_eq!(usage.output_tokens, Some(13));
+    assert_eq!(usage.total_tokens, Some(23));
+    assert_eq!(usage.metadata["done_reason"], "stop");
+    assert_eq!(usage.metadata["total_duration"], 400);
+    assert_eq!(usage.metadata["load_duration"], 30);
+    assert_eq!(usage.metadata["prompt_eval_duration"], 30);
+    assert_eq!(usage.metadata["eval_duration"], 90);
 }
 
 #[test]

--- a/app/ai-chat/src/llm/provider/ollama/tests.rs
+++ b/app/ai-chat/src/llm/provider/ollama/tests.rs
@@ -1,12 +1,15 @@
 use super::{
-    ExtSettingControl, ModelCapabilities, OllamaChatMessage, OllamaModelCapabilities,
-    OllamaProvider, OllamaStoredRequest, OllamaThinkingCapability, Provider, ProviderModel,
-    THINK_HIGH, THINK_KEY, THINK_LOW, THINK_MEDIUM, WEB_SEARCH_KEY, WEB_SEARCH_TOOLTIP_KEY,
-    should_bypass_proxy,
+    ExtSettingControl, ModelCapabilities, OllamaChatMessage, OllamaChatResponse,
+    OllamaModelCapabilities, OllamaProvider, OllamaStoredRequest, OllamaThinkingCapability,
+    Provider, ProviderModel, THINK_HIGH, THINK_KEY, THINK_LOW, THINK_MEDIUM, WEB_SEARCH_KEY,
+    WEB_SEARCH_TOOLTIP_KEY, should_bypass_proxy,
 };
 use crate::{
-    database::Role,
-    llm::{ExtSettingItem, LlmInputItem},
+    database::{Role, UrlCitation},
+    llm::{
+        ExtSettingItem, LlmAttachmentRef, LlmContentPart, LlmInputItem, LlmOutputItem,
+        LlmToolResult, ProviderRunEvent,
+    },
 };
 use serde_json::json;
 
@@ -118,6 +121,10 @@ fn show_response_maps_to_typed_capabilities() -> anyhow::Result<()> {
 
     assert!(capabilities.supports_streaming());
     assert!(capabilities.tool_calling.is_some());
+    assert!(capabilities.image_input.is_none());
+    assert!(!capabilities.hosted_web_search);
+    assert!(!capabilities.remote_mcp);
+    assert!(!capabilities.stateful_response_continuation);
     let reasoning = capabilities.reasoning.expect("reasoning capability");
     assert!(reasoning.summaries);
     assert_eq!(
@@ -141,6 +148,28 @@ fn show_response_maps_to_typed_capabilities() -> anyhow::Result<()> {
             "tools".to_string(),
         ]
     );
+    Ok(())
+}
+
+#[test]
+fn show_response_maps_vision_to_image_input_capability() -> anyhow::Result<()> {
+    let show = serde_json::from_value::<super::OllamaShowResponse>(json!({
+        "details": {
+            "family": "llava",
+            "families": ["llama", "clip"]
+        },
+        "capabilities": ["completion", "vision"]
+    }))?;
+    let capabilities = OllamaProvider::capabilities_from_show(&show);
+
+    assert_eq!(
+        capabilities.image_input,
+        Some(super::super::ImageInputCapability { max_images: None })
+    );
+    assert!(capabilities.tool_calling.is_none());
+    assert!(capabilities.reasoning.is_none());
+    assert!(!capabilities.hosted_web_search);
+    assert!(!capabilities.stateful_response_continuation);
     Ok(())
 }
 
@@ -311,6 +340,72 @@ fn request_body_maps_system_item_to_system() -> anyhow::Result<()> {
 }
 
 #[test]
+fn request_body_maps_multipart_text_and_image_input() -> anyhow::Result<()> {
+    let request = OllamaProvider.request_body(
+        &json!({
+            "model": "llava",
+            "stream": true
+        }),
+        vec![LlmInputItem::User {
+            content: vec![
+                LlmContentPart::text("describe"),
+                LlmContentPart::text("focus on the text"),
+                LlmContentPart::ImageRef(LlmAttachmentRef {
+                    id: "data:image/png;base64,aGVsbG8=".to_string(),
+                    mime_type: Some("image/png".to_string()),
+                    name: None,
+                }),
+                LlmContentPart::ImageRef(LlmAttachmentRef {
+                    id: "iVBORw0KGgo=".to_string(),
+                    mime_type: Some("image/png".to_string()),
+                    name: None,
+                }),
+            ],
+        }],
+    )?;
+    let request = serde_json::from_value::<OllamaStoredRequest>(request)?;
+
+    assert_eq!(request.messages.len(), 1);
+    assert_eq!(request.messages[0].role, "user");
+    assert_eq!(request.messages[0].content, "describe\n\nfocus on the text");
+    assert_eq!(
+        request.messages[0].images,
+        vec!["aGVsbG8=".to_string(), "iVBORw0KGgo=".to_string()]
+    );
+    Ok(())
+}
+
+#[test]
+fn request_body_rejects_unsupported_image_refs() {
+    for id in [
+        "https://example.com/image.png",
+        "file-img-1",
+        "/tmp/image.png",
+    ] {
+        let err = OllamaProvider
+            .request_body(
+                &json!({
+                    "model": "llava",
+                    "stream": true
+                }),
+                vec![LlmInputItem::User {
+                    content: vec![LlmContentPart::ImageRef(LlmAttachmentRef {
+                        id: id.to_string(),
+                        mime_type: Some("image/png".to_string()),
+                        name: None,
+                    })],
+                }],
+            )
+            .expect_err("unsupported image ref should be rejected");
+
+        assert!(
+            err.to_string()
+                .contains("unsupported Ollama input item: image input must be raw base64")
+        );
+    }
+}
+
+#[test]
 fn request_body_rejects_non_text_input_parts() {
     let err = OllamaProvider
         .request_body(
@@ -330,7 +425,76 @@ fn request_body_rejects_non_text_input_parts() {
         )
         .expect_err("non-text input should be rejected");
 
-    assert!(err.to_string().contains("unsupported LLM input item"));
+    assert!(
+        err.to_string()
+            .contains("unsupported Ollama input item: image input must be raw base64")
+    );
+}
+
+#[test]
+fn request_body_maps_text_tool_result() -> anyhow::Result<()> {
+    let request = OllamaProvider.request_body(
+        &json!({
+            "model": "qwen3",
+            "stream": true
+        }),
+        vec![LlmInputItem::ToolResult(LlmToolResult {
+            call_id: "call-1".to_string(),
+            content: vec![
+                LlmContentPart::text("first"),
+                LlmContentPart::text("second"),
+            ],
+        })],
+    )?;
+    let request = serde_json::from_value::<OllamaStoredRequest>(request)?;
+
+    assert_eq!(request.messages.len(), 1);
+    assert_eq!(request.messages[0].role, "tool");
+    assert_eq!(request.messages[0].content, "first\n\nsecond");
+    assert_eq!(request.messages[0].tool_call_id, "call-1");
+    Ok(())
+}
+
+#[test]
+fn request_body_rejects_item_reference_and_non_text_tool_result() {
+    let item_reference_error = OllamaProvider
+        .request_body(
+            &json!({
+                "model": "qwen3",
+                "stream": true
+            }),
+            vec![LlmInputItem::ItemReference {
+                item_id: "item-1".to_string(),
+            }],
+        )
+        .expect_err("item references should be rejected");
+    assert!(
+        item_reference_error
+            .to_string()
+            .contains("unsupported Ollama input item: item reference")
+    );
+
+    let tool_result_error = OllamaProvider
+        .request_body(
+            &json!({
+                "model": "qwen3",
+                "stream": true
+            }),
+            vec![LlmInputItem::ToolResult(LlmToolResult {
+                call_id: "call-1".to_string(),
+                content: vec![LlmContentPart::ImageRef(LlmAttachmentRef {
+                    id: "aGVsbG8=".to_string(),
+                    mime_type: Some("image/png".to_string()),
+                    name: None,
+                })],
+            })],
+        )
+        .expect_err("image tool results should be rejected");
+    assert!(
+        tool_result_error
+            .to_string()
+            .contains("unsupported Ollama input item: image tool result")
+    );
 }
 
 #[test]
@@ -346,6 +510,177 @@ fn merge_content_does_not_duplicate_streamed_reasoning() {
     );
     assert_eq!(content.text, "final answer");
     assert_eq!(content.reasoning_summary.as_deref(), Some("abc"));
+}
+
+#[test]
+fn merge_content_preserves_local_tool_citations() {
+    let content = OllamaProvider::merge_content(
+        &OllamaChatMessage {
+            content: "final answer".to_string(),
+            ..Default::default()
+        },
+        vec![UrlCitation {
+            title: Some("Result".to_string()),
+            url: "https://example.com".to_string(),
+            start_index: None,
+            end_index: None,
+        }],
+        None,
+    );
+
+    assert_eq!(content.text, "final answer");
+    assert_eq!(content.citations.len(), 1);
+    assert_eq!(content.citations[0].url, "https://example.com");
+}
+
+#[test]
+fn stream_response_line_maps_ndjson_events_and_usage() -> anyhow::Result<()> {
+    let mut round_message = OllamaChatMessage {
+        role: "assistant".to_string(),
+        ..Default::default()
+    };
+    let mut reasoning = String::new();
+    let mut emitted_thinking_started = false;
+
+    let (events, usage, done) = OllamaProvider::apply_stream_response_line(
+        r#"{"message":{"thinking":"plan "},"done":false}"#,
+        &mut round_message,
+        &mut reasoning,
+        &mut emitted_thinking_started,
+    )?;
+    assert_eq!(
+        events,
+        vec![
+            ProviderRunEvent::ThinkingStarted,
+            ProviderRunEvent::ReasoningSummaryDelta("plan ".to_string())
+        ]
+    );
+    assert!(usage.is_none());
+    assert!(!done);
+
+    let (events, usage, done) = OllamaProvider::apply_stream_response_line(
+        r#"{"message":{"content":"answer"},"done":false}"#,
+        &mut round_message,
+        &mut reasoning,
+        &mut emitted_thinking_started,
+    )?;
+    assert_eq!(
+        events,
+        vec![ProviderRunEvent::TextDelta("answer".to_string())]
+    );
+    assert!(usage.is_none());
+    assert!(!done);
+
+    let (events, usage, done) = OllamaProvider::apply_stream_response_line(
+        r#"{"message":{"tool_calls":[{"function":{"name":"web_search","arguments":{"query":"rust"}}}]},"done":false}"#,
+        &mut round_message,
+        &mut reasoning,
+        &mut emitted_thinking_started,
+    )?;
+    assert!(matches!(
+        events.as_slice(),
+        [ProviderRunEvent::ToolCallRequested(call)]
+            if call.call_id == "ollama-tool-0"
+                && call.name == "web_search"
+                && call.arguments == json!({"query": "rust"})
+    ));
+    assert!(usage.is_none());
+    assert!(!done);
+
+    let (events, usage, done) = OllamaProvider::apply_stream_response_line(
+        r#"{"done":true,"done_reason":"stop","prompt_eval_count":3,"eval_count":5,"total_duration":900}"#,
+        &mut round_message,
+        &mut reasoning,
+        &mut emitted_thinking_started,
+    )?;
+    assert!(events.is_empty());
+    let usage = usage.expect("final usage");
+    assert_eq!(usage.input_tokens, Some(3));
+    assert_eq!(usage.output_tokens, Some(5));
+    assert_eq!(usage.total_tokens, Some(8));
+    assert_eq!(usage.metadata["done_reason"], "stop");
+    assert_eq!(usage.metadata["total_duration"], 900);
+    assert!(done);
+
+    let output_events = OllamaProvider::output_item_done_events(&round_message);
+    assert!(matches!(
+        output_events.as_slice(),
+        [
+            ProviderRunEvent::OutputItemDone(LlmOutputItem::Reasoning { summary: Some(summary) }),
+            ProviderRunEvent::OutputItemDone(LlmOutputItem::Message { role: Role::Assistant, content }),
+            ProviderRunEvent::OutputItemDone(LlmOutputItem::ToolCall(call)),
+        ] if summary == "plan "
+            && content == &vec![LlmContentPart::text("answer")]
+            && call.call_id == "ollama-tool-0"
+    ));
+    Ok(())
+}
+
+#[test]
+fn non_stream_response_maps_output_items_and_usage() -> anyhow::Result<()> {
+    let response = serde_json::from_value::<OllamaChatResponse>(json!({
+        "message": {
+            "role": "assistant",
+            "content": "final answer",
+            "thinking": "reasoning summary",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "function": {
+                        "name": "web_fetch",
+                        "arguments": { "url": "https://example.com" }
+                    }
+                }
+            ]
+        },
+        "done": true,
+        "done_reason": "stop",
+        "prompt_eval_count": 4,
+        "prompt_eval_duration": 40,
+        "eval_count": 6,
+        "eval_duration": 60
+    }))?;
+
+    let events = OllamaProvider::output_item_done_events(&response.message);
+    assert!(matches!(
+        events.as_slice(),
+        [
+            ProviderRunEvent::OutputItemDone(LlmOutputItem::Reasoning { summary: Some(summary) }),
+            ProviderRunEvent::OutputItemDone(LlmOutputItem::Message { role: Role::Assistant, content }),
+            ProviderRunEvent::OutputItemDone(LlmOutputItem::ToolCall(call)),
+        ] if summary == "reasoning summary"
+            && content == &vec![LlmContentPart::text("final answer")]
+            && call.call_id == "call-1"
+            && call.name == "web_fetch"
+    ));
+
+    let usage = response.usage().expect("usage");
+    assert_eq!(usage.input_tokens, Some(4));
+    assert_eq!(usage.output_tokens, Some(6));
+    assert_eq!(usage.total_tokens, Some(10));
+    assert_eq!(usage.metadata["prompt_eval_duration"], 40);
+    assert_eq!(usage.metadata["eval_duration"], 60);
+    Ok(())
+}
+
+#[test]
+fn tool_result_output_item_uses_provider_neutral_type() {
+    let message = OllamaChatMessage {
+        role: "tool".to_string(),
+        content: r#"{"results":[]}"#.to_string(),
+        tool_call_id: "call-1".to_string(),
+        ..Default::default()
+    };
+    let tool_result = OllamaProvider::provider_tool_result(&message);
+
+    assert_eq!(tool_result.call_id, "call-1");
+    assert_eq!(
+        ProviderRunEvent::OutputItemDone(LlmOutputItem::ToolResult(tool_result)),
+        ProviderRunEvent::OutputItemDone(LlmOutputItem::ToolResult(LlmToolResult {
+            call_id: "call-1".to_string(),
+            content: vec![LlmContentPart::text(r#"{"results":[]}"#)],
+        }))
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Migrate `ai-chat` Ollama provider onto the shared provider-neutral LLM abstraction.
- Affected app: `ai-chat`.

## Motivation

- Completes child issue #144 under the #137 LLM abstraction integration branch.
- Keeps Ollama behavior provider-native while verifying the shared core is not shaped around OpenAI Responses semantics.

## Changes

- Maps Ollama `vision` model metadata to generic `ModelCapabilities.image_input` while keeping Ollama `thinking` and local web tools in the Ollama provider extension.
- Expands Ollama input conversion to support multipart text, raw base64/data-URL image inputs, and text-only tool results.
- Emits provider-neutral output item, tool call/result, usage, and completion events for Ollama streaming and non-streaming responses.
- Keeps unsupported URL/file-id/local-path image refs, files, audio, generic attachments, and item references as explicit adapter errors.
- Updates the #137 coordination document with #144 status, validation, and next child issue context.

## Validation

- [ ] `cargo build`
- [ ] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
Passed:
- cargo fmt
- cargo test -p ai-chat llm::provider::ollama
- cargo test -p ai-chat llm::provider
- cargo test -p ai-chat llm::run_persistence
- cargo test -p ai-chat features::home::tabs::conversation_panel
- cargo test -p ai-chat features::temporary::detail
- cargo clippy -p ai-chat --all-targets --all-features -- -D warnings
- git diff --check

Not run:
- cargo build
- full cargo test
- manual Ollama app verification

This child PR is scoped to adapter conversion/parser/run-event unit coverage and targets the #137 integration branch.
```

## Risks

- Ollama image input is intentionally limited to raw base64 or `data:image/...;base64,...`; URL, file id, and local path resolution remain future work.
- UI capability gating and upload entry points remain for #140.
- Local web search/fetch remains Ollama-specific and is not modeled as OpenAI hosted tools.

## Related Issues

- Closes #144
- Related to #137
