### PR TITLE
docs(ai-chat): define ai-chat2 fresh model plan

### DIFF
--- a/app/ai-chat/docs/dev/fresh-database-schema.md
+++ b/app/ai-chat/docs/dev/fresh-database-schema.md
@@ -1,0 +1,1168 @@
+# ai-chat 全新数据库模型
+
+本文档是 issue #155 的设计源文档。它定义全新的 SQLite 数据库模型、规范化的 Rust 数据模型、所有 app 自有 JSON payload 的 Rust 类型、provider 单次调用和未来 agent runtime 之间的边界，以及在 `app/ai-chat2` 和独立 crates 中落地的重构策略。
+
+设计原则是 SQLite-first，但不是把所有细节都拆成关系表。稳定身份、排序、状态和高频查询字段使用列；复杂的 transcript 和 runtime payload 使用 SQL `JSON` 列，但每个 JSON 列都必须由明确的 Rust 类型拥有。
+
+## 核心原则
+
+- 项目就是一个真实存在的文件夹。scratch / 无项目对话也必须由 app 创建真实 scratch 文件夹，并写入 `projects` 行。
+- 每个对话都必须属于一个项目，不存在 `project_id = NULL` 的对话。
+- 所有对话都是 contextual。全新模型没有 `contextual` / `single` / `assistant-only` mode。
+- 删除模板概念。保存下来的系统/开发者指令叫 `prompts`，UI 中使用“提示词”。
+- 快捷键绑定提示词、provider/model、输入来源和动作，不再绑定 template 或 mode。
+- provider 模型列表采用“设置页手动刷新 + 启动时读缓存”的方式。不要每次启动都访问 provider API。
+- fresh model 不直接塞回旧 `app/ai-chat`。落地方式是新建 `app/ai-chat2` 和一组可复用 crates，旧 app 保持可用，后续按边界迁移。
+- `app/ai-chat2` 必须是薄 GPUI shell。领域模型、数据库、provider adapter、agent runtime 不应继续堆在 app 目录里。
+- v1-v6 数据库都是 legacy 存储。不要覆盖旧库，也不要要求完整自动迁移。
+- `ProviderRunRequest`、`ProviderRunEvent`、`ProviderRunState` 只保留为低层 provider-step adapter 边界，不是持久化的 canonical transcript model。
+- provider request JSON 只存放在 `provider_steps`，作为 debug/replay snapshot，不作为聊天历史。
+- 对话展示、上下文重建、导出、重发的热路径只能读取 `conversation_items`。`agent_runs`、`provider_steps`、`tool_invocations`、`approval_decisions`、`usage_events` 是执行索引、恢复索引或统计索引，不能成为 timeline 渲染必须 join 的来源。
+- app 自有结构化 payload 列必须使用 SQL `JSON`，不能用 `TEXT` 列保存 JSON 字符串。SQLite 的运行时 affinity 不是把 JSON 建模为 TEXT 的理由，migration、Diesel schema 和 repository API 都必须表达为 JSON。
+- 二进制附件数据不能存进 message text，也不能塞进 JSON payload。数据库只保存 metadata、引用、路径和 hash。
+
+## 参考实现取舍
+
+本设计不是照搬任何一个应用。参考结论如下：
+
+| 应用 | 观察到的存储方式 | 可借鉴点 | 不直接采用的点 |
+| --- | --- | --- | --- |
+| Zed | Agent thread 内容存成一个 typed JSON document，并以 zstd 压缩后放在 `threads.data BLOB`；列表需要的 `summary`、`updated_at`、`created_at`、`folder_paths` 等保留为列。新的 sidebar metadata 另有 `sidebar_threads` 表。 | 热路径避免把一条对话拆成很多表；列表查询只读 metadata；项目路径和 thread metadata 面向 UI 反规范化。 | 不把 ai-chat transcript 整体压成单个 BLOB，因为我们需要 item 级搜索、streaming 增量写入和部分恢复。 |
+| Codex | Canonical session 是 append-only rollout JSONL；SQLite `threads` 表保存 `rollout_path`、`cwd`、title、preview、tokens、git、archive 等索引字段；dynamic tools、spawn edges 这类需要独立查询的关系才单独建表。 | “日志为真相，数据库为索引”的边界；thread 归属真实 `cwd`；启动时可从 canonical log backfill metadata index。 | ai-chat 仍使用 SQLite-first，不把 canonical transcript 放到外部 JSONL 文件；但 `conversation_items` 必须保持 append-only log 的形状。 |
+| pi | Session 按 cwd 编码后存到 `~/.pi/agent/sessions/<encoded-cwd>/*.jsonl`；文件首行为 session header，后续 entry 有 `id`、`parentId`、`type`，通过当前 leaf 回溯构建 LLM context；compaction、model change、label、custom entry 都是一等 entry。 | 项目/目录组织对话是正确方向；append-only typed entries 比多表 join 更适合 transcript；context reconstruction 应由 canonical entry path 得到。 | 不照搬文件夹 JSONL 作为主存储；不把扩展数据变成无限制 payload，app 自有 JSON 仍必须有 Rust 类型。 |
+| Alma | 大量 agent-app 数据都进入 SQLite，并把 thread/message、agent run、tool、provider/model cache、usage、memory 等边界拆开。 | provider/model cache、usage、MCP/OAuth、agent execution 与 transcript 分离是正确的产品边界。 | 不复制 Alma 的 JSON-like text 列、chat message payload shape 或过度规范化表设计；它不能作为唯一参考。 |
+
+因此 ai-chat 采用混合模型：SQLite 管理事务、索引和设置；`conversation_items.payload_json` 是 append-only typed transcript document；其他表只服务列表、恢复、统计、设置和调试。
+
+## 并行应用和 crate 拆分策略
+
+这次重构不应继续在旧 `app/ai-chat` 内做大范围原地替换。旧 app 已经混合了 legacy database、旧 messages schema、provider compatibility、template/mode 兼容逻辑和 UI 状态；直接在里面改会让 lint、迁移和回归验证被历史债务拖住。
+
+推荐采用并行 app 重写：
+
+```text
+app/ai-chat/              # 现有应用，保持可运行和可回退
+app/ai-chat2/             # 新应用，薄 GPUI shell，只做窗口、路由、UI 状态组合
+crates/ai-chat-core/      # 领域数据契约：project、conversation item、content、prompt、run/tool 类型
+crates/ai-chat-db/        # fresh SQLite schema、migrations、typed repositories
+crates/ai-chat-provider/  # provider-neutral trait、capabilities、OpenAI/Ollama 等 adapter
+crates/ai-chat-agent/     # agent loop、tool registry、approval、continuation、cancel/retry
+```
+
+拆分边界：
+
+- `ai-chat-core` 不依赖 GPUI、Diesel、HTTP client 或具体 provider。它只定义可序列化的数据契约和核心不变量。
+- `ai-chat-db` 依赖 `ai-chat-core`，负责 SQL `JSON` typed roundtrip、migration、repository transaction 和 FTS 更新。
+- `ai-chat-provider` 依赖 `ai-chat-core`，负责把 canonical context 转换到 provider wire format，并把 provider stream 转回 provider-neutral events。
+- `ai-chat-agent` 依赖 `ai-chat-core`、`ai-chat-provider` 和 repository traits，负责多步 loop、tool execution、approval 和写入 canonical items。
+- `app/ai-chat2` 依赖这些 crates，但不拥有长期业务模型。UI 只消费 repository/agent API 和 `ai-chat-core` 类型。
+
+迁移策略：
+
+- #155 只固定文档、schema、Rust 数据契约和 issue 重排。
+- #156 先 scaffold `ai-chat-core` 和 `ai-chat-db`，并让 fresh database bootstrap 和 repository tests 可以独立通过；可同时创建最小 `app/ai-chat2` 壳，但不要求迁移 UI。
+- #157 把 provider-neutral trait、capabilities、adapter 边界沉淀到 `ai-chat-provider`。
+- #158 在 `ai-chat-agent` 中实现 agent loop 和持久化写入。
+- #159 再让 `app/ai-chat2` 使用新 crates 渲染项目、对话、timeline、tool、approval 和多模态内容。
+- 旧 `app/ai-chat` 在迁移期间作为 legacy app 保持可用。legacy database 的读取、导出、导入或只读浏览策略必须显式实现，不能默默接入 fresh store。
+- 不预设“全部迁完后必须合并回 `app/ai-chat`”。如果拆出的 crates 是清晰边界，应保留它们；最终可以让 `app/ai-chat2` 替换旧 app，也可以让旧 app 逐步改为使用这些 crates。
+
+这样做的目标不是多建目录，而是把大范围重构拆成可独立 lint、test 和 review 的边界。每个 crate 应能用 focused `cargo test -p ...` 验证自身，不被旧 app 的无关 lint 债务阻塞。
+
+## ID 和时间约定
+
+- 全新表使用 app 生成的 `TEXT` id。实现时应统一一种格式，例如 UUID v7 或 ULID。
+- 初始版本采用线性 append-only timeline。对话内的人类可见顺序使用 `(conversation_id, seq)`，`seq` 单调递增。
+- pi 式 `parentId` / leaf context tree 可作为未来 branching/edit-history 能力，但不进入 #155-#159 的第一阶段。如果产品需要同一对话内 fork、可回溯编辑或多 leaf 并存，应先增加 `conversation_branches`、`parent_item_id` 或 `revision_of_item_id` 等字段，再实现 UI；第一阶段的编辑、重试或分叉应追加新 item 或新建 conversation。
+- agent run 内的 provider step 顺序使用 `(agent_run_id, seq)`。
+- 时间统一使用 UTC ISO-8601 字符串，除非 repository 层明确统一到另一个 Diesel SQLite 时间编码。
+- 打开数据库后必须启用 `PRAGMA foreign_keys = ON`。
+
+## 表总览
+
+| 表 | 作用 | 关键列 | JSON payload 类型 |
+| --- | --- | --- | --- |
+| `schema_migrations` | 数据库内部 migration ledger | `name TEXT PRIMARY KEY`, `executed_at TEXT NOT NULL` | 无 |
+| `schema_metadata` | 随数据库携带的 schema/app 元信息 | `id TEXT PRIMARY KEY DEFAULT 'default'`, `schema_version INTEGER`, app 版本列 | `SchemaMetadataPayload` |
+| `projects` | 真实文件夹项目，包含 scratch 项目 | `id`, `path UNIQUE`, `display_name`, `kind`, 时间戳 | `ProjectMetadata` |
+| `conversations` | 对话元数据，每个对话必须属于一个项目 | `id`, `project_id`, `title`, `status`, `last_item_seq`, 时间戳 | `ConversationMetadata`, `ConversationSettingsSnapshot` |
+| `conversation_items` | append-only canonical contextual timeline；热路径只读此表 | `id`, `conversation_id`, `seq`, 可选 run/step/tool correlation id, `kind`, `status`, 时间戳 | `ConversationItemPayload` |
+| `conversation_item_fts` | 对 item 文本做全文搜索 | FTS5: `item_id`, `conversation_id`, `content` | 无 |
+| `attachments` | 文件、图片、音频、生成产物的元数据 | `id`, `conversation_id`, `kind`, `storage_kind`, path/URI/provider 字段, `sha256` | `AttachmentMetadata` |
+| `agent_runs` | 一次用户触发的 agent loop summary 和恢复索引 | `id`, `conversation_id`, `status`, timing 列 | `AgentRunInput`, `AgentRunOutput`, `RunErrorPayload` |
+| `provider_steps` | provider 调用 debug/replay snapshot 和 continuation state 索引 | `id`, `agent_run_id`, `seq`, `provider_id`, `model_id`, `status`, timing 列 | `ProviderStepRequestSnapshot`, `ProviderStepResponseSnapshot`, `ProviderRunStateSnapshot`, `RunSettingsSnapshot`, `RunErrorPayload` |
+| `tool_invocations` | local / MCP / provider-hosted tool 执行索引 | `id`, `agent_run_id`, 可选 `provider_step_id`, `call_id`, `source`, `tool_name`, `status`, timing 列 | `ToolInvocationInput`, `ToolInvocationOutput`, `RunErrorPayload` |
+| `approval_decisions` | pending approval 恢复索引 | `id`, `tool_invocation_id UNIQUE`, `status`, requested/decided/expires 时间 | `ApprovalRequestPayload`, `ApprovalDecisionPayload` |
+| `usage_events` | 可派生的 provider-step 用量统计索引 | `id`, `provider_step_id`, `provider_id`, `model_id`, `date_key`, token 列 | `ProviderUsageSnapshot` |
+| `prompts` | 保存的系统/开发者提示词 | `id`, `name UNIQUE`, `enabled`, `sort_order`, 时间戳 | `PromptContent` |
+| `shortcuts` | 全局快捷键绑定 | `id`, `hotkey UNIQUE`, 可选 `prompt_id`, `provider_id`, `model_id`, `input_source`, `enabled` | `ShortcutAction`, `RunSettingsSnapshot` |
+| `providers` | provider 配置实例 | `id`, `kind`, `display_name`, `enabled`, 时间戳 | `ProviderSettingsPayload`, `ProviderSecretRefs` |
+| `provider_models` | 用户手动刷新后保存的模型列表 | `id`, `provider_id`, `model_id`, `fetched_at`, `UNIQUE(provider_id, model_id)` | `ModelCapabilitiesSnapshot`, `ProviderModelMetadata` |
+| `app_settings` | app 全局设置 | `id TEXT PRIMARY KEY DEFAULT 'default'` | `AppSettingsPayload` |
+
+## 表关系
+
+下面是外键/索引关系，不是 UI 渲染路径。正常打开对话、渲染 timeline、导出和构建 provider input 时，repository 必须只查询 `conversation_items` 并按 `seq` 排序；不得为了展示 tool call、tool result、approval、usage 或 reasoning 再 join 执行表。
+
+```text
+projects 1 -> N conversations
+conversations 1 -> N conversation_items
+conversations 1 -> N attachments
+conversations 1 -> N agent_runs
+agent_runs 1 -> N provider_steps
+agent_runs 1 -> N tool_invocations
+provider_steps 1 -> N usage_events
+tool_invocations 0/1 -> 1 approval_decisions
+providers 1 -> N provider_models
+prompts 0/1 -> N conversations
+prompts 0/1 -> N shortcuts
+```
+
+历史行必须在必要时保存 prompt、provider、model、capability 和 run settings 的反规范化 snapshot。删除或编辑 prompt/provider 不能破坏旧对话。
+
+推荐热路径查询形状：
+
+```sql
+SELECT id, seq, kind, status, agent_run_id, provider_step_id, tool_invocation_id, provider_item_id, payload_json, search_text, created_at, updated_at
+FROM conversation_items
+WHERE conversation_id = ?
+ORDER BY seq ASC;
+```
+
+执行表只在这些场景读取：恢复未完成 run、查看 debug/replay snapshot、列出 pending approval、计算 usage rollup、诊断 provider/tool 失败。为避免多表 join 成为产品主路径，`ConversationItemPayload` 必须复制足够的展示和上下文信息；这些有意的反规范化是 schema 约束，不是临时优化。
+
+## 表定义细节
+
+### `schema_migrations`
+
+记录全新 store 已执行的 migration。
+
+必要列：
+
+- `name TEXT PRIMARY KEY`
+- `executed_at TEXT NOT NULL`
+
+### `schema_metadata`
+
+存储数据库内部兼容信息。文件名可以区分 legacy 存储和全新存储，但 schema 兼容性必须从本表和 `schema_migrations` 读取。
+
+必要列：
+
+- `id TEXT PRIMARY KEY DEFAULT 'default'`
+- `schema_version INTEGER NOT NULL`
+- `created_app_version TEXT`
+- `last_opened_app_version TEXT`
+- `payload_json JSON NOT NULL DEFAULT '{}'`
+- `created_at TEXT NOT NULL`
+- `updated_at TEXT NOT NULL`
+
+`payload_json` 类型：`SchemaMetadataPayload`。
+
+### `projects`
+
+项目是 canonical real folder path。
+
+必要列：
+
+- `id TEXT PRIMARY KEY`
+- `path TEXT NOT NULL UNIQUE`
+- `display_name TEXT NOT NULL`
+- `kind TEXT NOT NULL CHECK (kind IN ('normal', 'scratch'))`
+- `metadata_json JSON NOT NULL DEFAULT '{}'`
+- `created_at TEXT NOT NULL`
+- `updated_at TEXT NOT NULL`
+- `last_opened_at TEXT`
+
+`metadata_json` 类型：`ProjectMetadata`。
+
+### `conversations`
+
+对话属于项目，并且永远是 contextual。
+
+必要列：
+
+- `id TEXT PRIMARY KEY`
+- `project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE`
+- `title TEXT NOT NULL`
+- `status TEXT NOT NULL CHECK (status IN ('active', 'archived', 'deleted'))`
+- `prompt_id TEXT REFERENCES prompts(id) ON DELETE SET NULL`
+- `default_provider_id TEXT REFERENCES providers(id) ON DELETE SET NULL`
+- `default_model_id TEXT`
+- `last_item_seq INTEGER NOT NULL DEFAULT 0`
+- `metadata_json JSON NOT NULL DEFAULT '{}'`
+- `settings_snapshot_json JSON NOT NULL DEFAULT '{}'`
+- `created_at TEXT NOT NULL`
+- `updated_at TEXT NOT NULL`
+- `archived_at TEXT`
+- `deleted_at TEXT`
+
+JSON 类型：
+
+- `metadata_json`: `ConversationMetadata`
+- `settings_snapshot_json`: `ConversationSettingsSnapshot`
+
+### `conversation_items`
+
+这是 canonical timeline/context source。展示、导出、重发、contextual history、编辑、provider input reconstruction 都必须读这个表，不能读 provider request snapshot，也不能为了 timeline 展示去 join run/tool/provider-step 表。
+
+它采用 Codex/pi 式 append-only log 思路，但落在 SQLite `JSON` 列里。每个 item 的 `payload_json` 必须完整描述用户可见和 provider-context 所需的信息：
+
+- `ToolCall` 必须包含 tool source、tool name、call id、arguments 和足够展示的状态信息。
+- `ToolResult` 必须包含输出内容、错误状态、structured output 和附件引用。
+- `ApprovalRequest` / `ApprovalDecision` 必须包含可恢复和可展示的审批摘要。
+- `Status` / `Error` 必须包含 timeline 需要显示的进度、失败、取消或重试信息。
+- usage 如果要出现在 timeline 中，应写入对应 item payload；`usage_events` 只服务统计查询。
+
+执行表中的 `agent_run_id`、`provider_step_id`、`tool_invocation_id` 是 correlation id。它们允许 debug 和恢复时定位执行记录，但不是读取 item payload 的前置条件。
+
+必要列：
+
+- `id TEXT PRIMARY KEY`
+- `conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE`
+- `seq INTEGER NOT NULL`
+- `kind TEXT NOT NULL`
+- `status TEXT NOT NULL`
+- `agent_run_id TEXT REFERENCES agent_runs(id) ON DELETE SET NULL`
+- `provider_step_id TEXT REFERENCES provider_steps(id) ON DELETE SET NULL`
+- `tool_invocation_id TEXT REFERENCES tool_invocations(id) ON DELETE SET NULL`
+- `provider_item_id TEXT`
+- `payload_json JSON NOT NULL`
+- `search_text TEXT NOT NULL DEFAULT ''`
+- `created_at TEXT NOT NULL`
+- `updated_at TEXT NOT NULL`
+- `UNIQUE(conversation_id, seq)`
+
+`payload_json` 类型：`ConversationItemPayload`。
+
+`kind` 和 `status` 列是 payload discriminant 的查询索引副本。repository 层必须保证它们和 `payload_json` 保持一致。
+
+### `conversation_item_fts`
+
+基于 `conversation_items.search_text` 的 FTS5 搜索表。
+
+建议声明：
+
+```sql
+CREATE VIRTUAL TABLE conversation_item_fts USING fts5(
+    item_id UNINDEXED,
+    conversation_id UNINDEXED,
+    content
+);
+```
+
+repository 代码必须在写入 item 的同一个事务里更新 FTS 表。
+
+### `attachments`
+
+附件可以被输入项、assistant 输出、tool result、生成文件和 provider file reference 共享。二进制字节在 app attachment store 或外部/provider storage 中，数据库只保存引用和元数据。
+
+必要列：
+
+- `id TEXT PRIMARY KEY`
+- `conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE`
+- `kind TEXT NOT NULL CHECK (kind IN ('image', 'file', 'audio', 'attachment'))`
+- `storage_kind TEXT NOT NULL CHECK (storage_kind IN ('local_file', 'external_uri', 'provider_file', 'generated_file'))`
+- `mime_type TEXT`
+- `name TEXT`
+- `path TEXT`
+- `external_uri TEXT`
+- `provider_id TEXT REFERENCES providers(id) ON DELETE SET NULL`
+- `provider_file_id TEXT`
+- `sha256 TEXT`
+- `size_bytes INTEGER`
+- `metadata_json JSON NOT NULL DEFAULT '{}'`
+- `created_at TEXT NOT NULL`
+- `updated_at TEXT NOT NULL`
+
+`metadata_json` 类型：`AttachmentMetadata`。
+
+### `agent_runs`
+
+agent run 是一次用户触发的 loop summary，可能包含多次 provider step、tool invocation、approval、retry 和 continuation。它用于恢复、取消、重试和诊断，不是 transcript 的 canonical source。
+
+必要列：
+
+- `id TEXT PRIMARY KEY`
+- `conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE`
+- `trigger_kind TEXT NOT NULL CHECK (trigger_kind IN ('user', 'shortcut', 'resume', 'retry'))`
+- `status TEXT NOT NULL`
+- `input_json JSON NOT NULL`
+- `output_json JSON`
+- `error_json JSON`
+- `created_at TEXT NOT NULL`
+- `started_at TEXT`
+- `completed_at TEXT`
+- `updated_at TEXT NOT NULL`
+
+JSON 类型：
+
+- `input_json`: `AgentRunInput`
+- `output_json`: `AgentRunOutput`
+- `error_json`: `RunErrorPayload`
+
+### `provider_steps`
+
+provider step 是对一个 provider/model 的一次调用索引。provider request/response snapshot 只应该出现在这里，用于 debug、replay 和 continuation；用户可见的 provider 输出必须已经写入 `conversation_items`。
+
+必要列：
+
+- `id TEXT PRIMARY KEY`
+- `agent_run_id TEXT NOT NULL REFERENCES agent_runs(id) ON DELETE CASCADE`
+- `seq INTEGER NOT NULL`
+- `provider_id TEXT NOT NULL REFERENCES providers(id)`
+- `model_id TEXT NOT NULL`
+- `status TEXT NOT NULL`
+- `request_snapshot_json JSON NOT NULL`
+- `response_snapshot_json JSON`
+- `state_snapshot_json JSON`
+- `settings_snapshot_json JSON NOT NULL`
+- `error_json JSON`
+- `created_at TEXT NOT NULL`
+- `started_at TEXT`
+- `completed_at TEXT`
+- `updated_at TEXT NOT NULL`
+- `UNIQUE(agent_run_id, seq)`
+
+JSON 类型：
+
+- `request_snapshot_json`: `ProviderStepRequestSnapshot`
+- `response_snapshot_json`: `ProviderStepResponseSnapshot`
+- `state_snapshot_json`: `ProviderRunStateSnapshot`
+- `settings_snapshot_json`: `RunSettingsSnapshot`
+- `error_json`: `RunErrorPayload`
+
+### `tool_invocations`
+
+tool invocation 是执行索引。provider output item 可以请求 tool，但 timeline 中展示 tool 请求、审批、结果和错误时必须读取 `conversation_items.payload_json`；本表用于恢复 pending/running tool、重试和诊断。
+
+必要列：
+
+- `id TEXT PRIMARY KEY`
+- `agent_run_id TEXT NOT NULL REFERENCES agent_runs(id) ON DELETE CASCADE`
+- `provider_step_id TEXT REFERENCES provider_steps(id) ON DELETE SET NULL`
+- `call_id TEXT NOT NULL`
+- `source TEXT NOT NULL CHECK (source IN ('local', 'mcp', 'provider_hosted'))`
+- `namespace TEXT`
+- `server_id TEXT`
+- `tool_name TEXT NOT NULL`
+- `status TEXT NOT NULL`
+- `input_json JSON NOT NULL`
+- `output_json JSON`
+- `error_json JSON`
+- `created_at TEXT NOT NULL`
+- `started_at TEXT`
+- `completed_at TEXT`
+- `updated_at TEXT NOT NULL`
+
+JSON 类型：
+
+- `input_json`: `ToolInvocationInput`
+- `output_json`: `ToolInvocationOutput`
+- `error_json`: `RunErrorPayload`
+
+### `approval_decisions`
+
+审批状态与 tool invocation 分离，方便在不解析所有 transcript item 的情况下列出和恢复 pending approval。审批请求和决策仍必须作为 `conversation_items` 写入，保证 timeline 不依赖 join。
+
+必要列：
+
+- `id TEXT PRIMARY KEY`
+- `tool_invocation_id TEXT NOT NULL UNIQUE REFERENCES tool_invocations(id) ON DELETE CASCADE`
+- `status TEXT NOT NULL CHECK (status IN ('pending', 'approved', 'denied', 'expired', 'canceled'))`
+- `request_json JSON NOT NULL`
+- `decision_json JSON`
+- `requested_at TEXT NOT NULL`
+- `decided_at TEXT`
+- `expires_at TEXT`
+
+JSON 类型：
+
+- `request_json`: `ApprovalRequestPayload`
+- `decision_json`: `ApprovalDecisionPayload`
+
+### `usage_events`
+
+用量记录采用 provider-step 粒度。conversation 和每日 rollup 从该表计算。它是统计索引；timeline 中展示的 usage snapshot 必须已经进入 `conversation_items`。
+
+必要列：
+
+- `id TEXT PRIMARY KEY`
+- `provider_step_id TEXT NOT NULL REFERENCES provider_steps(id) ON DELETE CASCADE`
+- `conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE`
+- `provider_id TEXT NOT NULL REFERENCES providers(id)`
+- `model_id TEXT NOT NULL`
+- `date_key TEXT NOT NULL`
+- `input_tokens INTEGER NOT NULL DEFAULT 0`
+- `output_tokens INTEGER NOT NULL DEFAULT 0`
+- `cached_input_tokens INTEGER NOT NULL DEFAULT 0`
+- `cache_write_input_tokens INTEGER NOT NULL DEFAULT 0`
+- `reasoning_tokens INTEGER NOT NULL DEFAULT 0`
+- `total_tokens INTEGER NOT NULL DEFAULT 0`
+- `usage_json JSON NOT NULL`
+- `created_at TEXT NOT NULL`
+
+`usage_json` 类型：`ProviderUsageSnapshot`。
+
+### `prompts`
+
+prompts 替代 templates。它们保存可复用的 system/developer 指令，不保存示例式模板。
+
+必要列：
+
+- `id TEXT PRIMARY KEY`
+- `name TEXT NOT NULL UNIQUE`
+- `content_json JSON NOT NULL`
+- `enabled INTEGER NOT NULL DEFAULT 1`
+- `sort_order INTEGER NOT NULL DEFAULT 0`
+- `created_at TEXT NOT NULL`
+- `updated_at TEXT NOT NULL`
+
+`content_json` 类型：`PromptContent`。
+
+### `shortcuts`
+
+shortcuts 不再保存 mode 或 template id。
+
+必要列：
+
+- `id TEXT PRIMARY KEY`
+- `hotkey TEXT NOT NULL UNIQUE`
+- `enabled INTEGER NOT NULL DEFAULT 1`
+- `prompt_id TEXT REFERENCES prompts(id) ON DELETE SET NULL`
+- `provider_id TEXT REFERENCES providers(id) ON DELETE SET NULL`
+- `model_id TEXT`
+- `input_source TEXT NOT NULL CHECK (input_source IN ('selection_or_clipboard', 'screenshot'))`
+- `action_json JSON NOT NULL`
+- `settings_snapshot_json JSON NOT NULL DEFAULT '{}'`
+- `created_at TEXT NOT NULL`
+- `updated_at TEXT NOT NULL`
+
+JSON 类型：
+
+- `action_json`: `ShortcutAction`
+- `settings_snapshot_json`: `RunSettingsSnapshot`
+
+### `providers`
+
+provider 行描述配置过的 provider 实例。secret 必须存成 keychain reference 或其他 secret reference，不能复制到 snapshot。
+
+必要列：
+
+- `id TEXT PRIMARY KEY`
+- `kind TEXT NOT NULL`
+- `display_name TEXT NOT NULL`
+- `enabled INTEGER NOT NULL DEFAULT 1`
+- `settings_json JSON NOT NULL DEFAULT '{}'`
+- `secret_refs_json JSON NOT NULL DEFAULT '{}'`
+- `created_at TEXT NOT NULL`
+- `updated_at TEXT NOT NULL`
+
+JSON 类型：
+
+- `settings_json`: `ProviderSettingsPayload`
+- `secret_refs_json`: `ProviderSecretRefs`
+
+### `provider_models`
+
+model 行由 provider 设置中的手动刷新写入。
+
+必要列：
+
+- `id TEXT PRIMARY KEY`
+- `provider_id TEXT NOT NULL REFERENCES providers(id) ON DELETE CASCADE`
+- `model_id TEXT NOT NULL`
+- `display_name TEXT`
+- `capabilities_json JSON NOT NULL`
+- `metadata_json JSON NOT NULL DEFAULT '{}'`
+- `fetched_at TEXT NOT NULL`
+- `created_at TEXT NOT NULL`
+- `updated_at TEXT NOT NULL`
+- `UNIQUE(provider_id, model_id)`
+
+JSON 类型：
+
+- `capabilities_json`: `ModelCapabilitiesSnapshot`
+- `metadata_json`: `ProviderModelMetadata`
+
+### `app_settings`
+
+不属于项目、对话、provider 或快捷键的全局 app 设置。
+
+必要列：
+
+- `id TEXT PRIMARY KEY DEFAULT 'default'`
+- `settings_json JSON NOT NULL DEFAULT '{}'`
+- `created_at TEXT NOT NULL`
+- `updated_at TEXT NOT NULL`
+
+`settings_json` 类型：`AppSettingsPayload`。
+
+## 类型化 JSON 规则
+
+每个 app 自有 JSON payload 都必须有 Rust 类型。repository API 必须接收和返回这些 Rust 类型，不能暴露裸 `serde_json::Value`。
+
+默认 serde 形态：
+
+```rust
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct SomePayload {
+    // fields
+}
+```
+
+payload discriminant 使用 tagged enum：
+
+```rust
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) enum ConversationItemPayload {
+    Message { role: TranscriptRole, content: Vec<ContentPart> },
+    Reasoning { text: String, summary: Option<String> },
+    ToolCall(ToolCallItem),
+    ToolResult(ToolResultItem),
+    ApprovalRequest(ApprovalRequestItem),
+    ApprovalDecision(ApprovalDecisionItem),
+    Status(StatusItem),
+    Error(RunErrorPayload),
+}
+```
+
+开放 provider/tool 数据只能藏在有名字的 wrapper 后面：
+
+```rust
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ProviderRawPayload {
+    pub(crate) provider_kind: String,
+    pub(crate) value: serde_json::Value,
+}
+```
+
+repository-facing 类型中不要出现匿名 `serde_json::Value` 字段。
+
+## JSON 列和 Rust 类型映射
+
+| 表列 | Rust 类型 |
+| --- | --- |
+| `schema_metadata.payload_json` | `SchemaMetadataPayload` |
+| `projects.metadata_json` | `ProjectMetadata` |
+| `conversations.metadata_json` | `ConversationMetadata` |
+| `conversations.settings_snapshot_json` | `ConversationSettingsSnapshot` |
+| `conversation_items.payload_json` | `ConversationItemPayload` |
+| `attachments.metadata_json` | `AttachmentMetadata` |
+| `agent_runs.input_json` | `AgentRunInput` |
+| `agent_runs.output_json` | `AgentRunOutput` |
+| `agent_runs.error_json` | `RunErrorPayload` |
+| `provider_steps.request_snapshot_json` | `ProviderStepRequestSnapshot` |
+| `provider_steps.response_snapshot_json` | `ProviderStepResponseSnapshot` |
+| `provider_steps.state_snapshot_json` | `ProviderRunStateSnapshot` |
+| `provider_steps.settings_snapshot_json` | `RunSettingsSnapshot` |
+| `provider_steps.error_json` | `RunErrorPayload` |
+| `tool_invocations.input_json` | `ToolInvocationInput` |
+| `tool_invocations.output_json` | `ToolInvocationOutput` |
+| `tool_invocations.error_json` | `RunErrorPayload` |
+| `approval_decisions.request_json` | `ApprovalRequestPayload` |
+| `approval_decisions.decision_json` | `ApprovalDecisionPayload` |
+| `usage_events.usage_json` | `ProviderUsageSnapshot` |
+| `prompts.content_json` | `PromptContent` |
+| `shortcuts.action_json` | `ShortcutAction` |
+| `shortcuts.settings_snapshot_json` | `RunSettingsSnapshot` |
+| `providers.settings_json` | `ProviderSettingsPayload` |
+| `providers.secret_refs_json` | `ProviderSecretRefs` |
+| `provider_models.capabilities_json` | `ModelCapabilitiesSnapshot` |
+| `provider_models.metadata_json` | `ProviderModelMetadata` |
+| `app_settings.settings_json` | `AppSettingsPayload` |
+
+## 规范 Rust 类型草图
+
+以下类型定义的是数据契约。具体模块位置由 #156 和 #157 决定，但数据契约变化必须同步更新本文档。
+
+```rust
+pub(crate) type ProjectId = String;
+pub(crate) type ConversationId = String;
+pub(crate) type ConversationItemId = String;
+pub(crate) type AttachmentId = String;
+pub(crate) type AgentRunId = String;
+pub(crate) type ProviderStepId = String;
+pub(crate) type ToolInvocationId = String;
+pub(crate) type ApprovalDecisionId = String;
+pub(crate) type ProviderId = String;
+pub(crate) type PromptId = String;
+pub(crate) type ProviderModelId = String;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum TranscriptRole {
+    System,
+    Developer,
+    User,
+    Assistant,
+    Tool,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) enum ContentPart {
+    Text { text: String },
+    Image { attachment_id: AttachmentId },
+    File { attachment_id: AttachmentId },
+    Audio { attachment_id: AttachmentId },
+    Attachment { attachment_id: AttachmentId },
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) enum AttachmentSource {
+    LocalFile { path: String },
+    ExternalUri { uri: String },
+    ProviderFile { provider_id: ProviderId, file_id: String },
+    GeneratedFile { path: String },
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct AttachmentMetadata {
+    pub(crate) source: AttachmentSource,
+    pub(crate) width: Option<u32>,
+    pub(crate) height: Option<u32>,
+    pub(crate) duration_ms: Option<u64>,
+    pub(crate) preview_attachment_id: Option<AttachmentId>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) enum ConversationItemPayload {
+    Message { role: TranscriptRole, content: Vec<ContentPart> },
+    Reasoning { text: String, summary: Option<String> },
+    ToolCall(ToolCallItem),
+    ToolResult(ToolResultItem),
+    ApprovalRequest(ApprovalRequestItem),
+    ApprovalDecision(ApprovalDecisionItem),
+    Status(StatusItem),
+    Error(RunErrorPayload),
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ToolCallItem {
+    pub(crate) tool_invocation_id: Option<ToolInvocationId>,
+    pub(crate) call_id: String,
+    pub(crate) source: ToolSource,
+    pub(crate) name: String,
+    pub(crate) arguments: ToolArguments,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ToolResultItem {
+    pub(crate) tool_invocation_id: Option<ToolInvocationId>,
+    pub(crate) call_id: String,
+    pub(crate) content: Vec<ContentPart>,
+    pub(crate) is_error: bool,
+    pub(crate) structured_output: Option<StructuredOutput>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) enum ToolSource {
+    Local,
+    Mcp { server_id: String },
+    ProviderHosted { provider_id: ProviderId },
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ToolArguments {
+    pub(crate) value: serde_json::Value,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct StructuredOutput {
+    pub(crate) value: serde_json::Value,
+}
+```
+
+### 状态类型
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AgentRunStatus {
+    Queued,
+    Running,
+    WaitingForApproval,
+    Completed,
+    Failed,
+    Canceled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ProviderStepStatus {
+    Queued,
+    Running,
+    Completed,
+    Failed,
+    Canceled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ToolInvocationStatus {
+    Requested,
+    AwaitingApproval,
+    Running,
+    Succeeded,
+    Failed,
+    Denied,
+    Canceled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ApprovalStatus {
+    Pending,
+    Approved,
+    Denied,
+    Expired,
+    Canceled,
+}
+```
+
+### 运行时类型
+
+```rust
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct AgentRunInput {
+    pub(crate) user_item_id: ConversationItemId,
+    pub(crate) prompt_snapshot: Option<PromptContent>,
+    pub(crate) provider_id: ProviderId,
+    pub(crate) model_id: ProviderModelId,
+    pub(crate) settings_snapshot: RunSettingsSnapshot,
+    pub(crate) max_steps: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct AgentRunOutput {
+    pub(crate) final_item_id: Option<ConversationItemId>,
+    pub(crate) stopped_reason: AgentStoppedReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AgentStoppedReason {
+    Completed,
+    MaxSteps,
+    Canceled,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) enum AgentRunEvent {
+    Started { agent_run_id: AgentRunId },
+    ProviderStepStarted { provider_step_id: ProviderStepId },
+    ProviderStepEvent { provider_step_id: ProviderStepId, event: ProviderStepEvent },
+    ToolInvocationRequested { tool_invocation_id: ToolInvocationId },
+    ApprovalRequested { approval_decision_id: ApprovalDecisionId },
+    ToolInvocationFinished { tool_invocation_id: ToolInvocationId },
+    Completed { output: AgentRunOutput },
+    Failed { error: RunErrorPayload },
+    Canceled,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct AgentRunState {
+    pub(crate) agent_run_id: AgentRunId,
+    pub(crate) status: AgentRunStatus,
+    pub(crate) current_step_id: Option<ProviderStepId>,
+    pub(crate) pending_tool_ids: Vec<ToolInvocationId>,
+}
+```
+
+### Provider 调用步骤类型
+
+```rust
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ProviderStepRequestSnapshot {
+    pub(crate) provider_id: ProviderId,
+    pub(crate) model_id: ProviderModelId,
+    pub(crate) input_item_ids: Vec<ConversationItemId>,
+    pub(crate) request_body: ProviderRawPayload,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ProviderStepResponseSnapshot {
+    pub(crate) provider_run_id: Option<String>,
+    pub(crate) output_item_ids: Vec<String>,
+    pub(crate) response_body: Option<ProviderRawPayload>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ProviderRunStateSnapshot {
+    pub(crate) provider_id: ProviderId,
+    pub(crate) provider_run_id: Option<String>,
+    pub(crate) output_item_ids: Vec<String>,
+    pub(crate) continuation: Option<ProviderRawPayload>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) enum ProviderStepEvent {
+    OutputItemStarted { provider_item_id: Option<String>, item: ConversationItemPayload },
+    TextDelta { provider_item_id: Option<String>, text: String },
+    ReasoningDelta { provider_item_id: Option<String>, text: String },
+    OutputItemCompleted { provider_item_id: Option<String>, item: ConversationItemPayload },
+    ToolCallRequested { call: ToolCallItem },
+    UsageUpdated { usage: ProviderUsageSnapshot },
+    Completed { state: Option<ProviderRunStateSnapshot> },
+    Failed { error: RunErrorPayload },
+}
+```
+
+### 设置、Provider 和模型类型
+
+```rust
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct RunSettingsSnapshot {
+    pub(crate) prompt: Option<PromptContent>,
+    pub(crate) provider_id: ProviderId,
+    pub(crate) model_id: ProviderModelId,
+    pub(crate) model_capabilities: ModelCapabilitiesSnapshot,
+    pub(crate) provider_settings: ProviderSettingsPayload,
+    pub(crate) tool_policy: ToolPolicySnapshot,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct PromptContent {
+    pub(crate) messages: Vec<PromptMessage>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct PromptMessage {
+    pub(crate) role: TranscriptRole,
+    pub(crate) content: Vec<ContentPart>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ProviderSettingsPayload {
+    pub(crate) provider_kind: String,
+    pub(crate) fields: Vec<ProviderSettingFieldValue>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ProviderSecretRefs {
+    pub(crate) refs: Vec<ProviderSecretRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ModelCapabilitiesSnapshot {
+    pub(crate) text_input: bool,
+    pub(crate) text_output: bool,
+    pub(crate) streaming: bool,
+    pub(crate) image_input: Option<ImageInputCapabilitySnapshot>,
+    pub(crate) file_input: Option<FileInputCapabilitySnapshot>,
+    pub(crate) audio_input: bool,
+    pub(crate) image_generation: bool,
+    pub(crate) tool_calling: Option<ToolCallingCapabilitySnapshot>,
+    pub(crate) hosted_web_search: bool,
+    pub(crate) remote_mcp: bool,
+    pub(crate) reasoning: Option<ReasoningCapabilitySnapshot>,
+    pub(crate) structured_output: bool,
+    pub(crate) stateful_response_continuation: bool,
+    pub(crate) extension: ProviderCapabilityExtensionSnapshot,
+}
+```
+
+### 元数据和错误 payload 类型
+
+```rust
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct SchemaMetadataPayload {
+    pub(crate) store_kind: String,
+    pub(crate) legacy_policy: LegacyStorePolicy,
+    pub(crate) feature_flags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum LegacyStorePolicy {
+    Ignore,
+    BackupOnly,
+    ReadOnly,
+    ManualImport,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ProjectMetadata {
+    pub(crate) scratch_reason: Option<String>,
+    pub(crate) git_root: Option<String>,
+    pub(crate) last_active_conversation_id: Option<ConversationId>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ConversationMetadata {
+    pub(crate) summary: Option<String>,
+    pub(crate) tags: Vec<String>,
+    pub(crate) pinned: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ConversationSettingsSnapshot {
+    pub(crate) prompt: Option<PromptContent>,
+    pub(crate) provider_id: Option<ProviderId>,
+    pub(crate) model_id: Option<ProviderModelId>,
+    pub(crate) model_capabilities: Option<ModelCapabilitiesSnapshot>,
+    pub(crate) tool_policy: ToolPolicySnapshot,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct RunErrorPayload {
+    pub(crate) code: String,
+    pub(crate) message: String,
+    pub(crate) retryable: bool,
+    pub(crate) provider: Option<String>,
+    pub(crate) raw: Option<ProviderRawPayload>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct StatusItem {
+    pub(crate) label: String,
+    pub(crate) message: Option<String>,
+}
+```
+
+### Tool、审批、用量和快捷键 payload 类型
+
+```rust
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ToolInvocationInput {
+    pub(crate) source: ToolSource,
+    pub(crate) namespace: Option<String>,
+    pub(crate) tool_name: String,
+    pub(crate) call_id: String,
+    pub(crate) arguments: ToolArguments,
+    pub(crate) approval_policy: ToolApprovalPolicy,
+    pub(crate) execution_policy: ToolExecutionPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ToolInvocationOutput {
+    pub(crate) content: Vec<ContentPart>,
+    pub(crate) structured_output: Option<StructuredOutput>,
+    pub(crate) raw_output: Option<ProviderRawPayload>,
+    pub(crate) is_error: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ToolApprovalPolicy {
+    Never,
+    OnRequest,
+    Always,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ToolExecutionPolicy {
+    Foreground,
+    Background,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ApprovalRequestItem {
+    pub(crate) approval_decision_id: ApprovalDecisionId,
+    pub(crate) tool_invocation_id: ToolInvocationId,
+    pub(crate) request: ApprovalRequestPayload,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ApprovalDecisionItem {
+    pub(crate) approval_decision_id: ApprovalDecisionId,
+    pub(crate) decision: ApprovalDecisionPayload,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ApprovalRequestPayload {
+    pub(crate) reason: String,
+    pub(crate) tool_source: ToolSource,
+    pub(crate) tool_name: String,
+    pub(crate) arguments_preview: String,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ApprovalDecisionPayload {
+    pub(crate) approved: bool,
+    pub(crate) decided_by: String,
+    pub(crate) reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ProviderUsageSnapshot {
+    pub(crate) input_tokens: u64,
+    pub(crate) output_tokens: u64,
+    pub(crate) cached_input_tokens: u64,
+    pub(crate) cache_write_input_tokens: u64,
+    pub(crate) reasoning_tokens: u64,
+    pub(crate) total_tokens: u64,
+    pub(crate) metadata: Option<ProviderRawPayload>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) enum ShortcutAction {
+    OpenTemporaryConversation,
+    SendToConversation { conversation_id: Option<ConversationId> },
+}
+```
+
+### Provider 设置和能力 snapshot 类型
+
+```rust
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ToolPolicySnapshot {
+    pub(crate) approval_policy: ToolApprovalPolicy,
+    pub(crate) enabled_sources: Vec<ToolSource>,
+    pub(crate) max_steps: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ProviderSettingFieldValue {
+    pub(crate) key: String,
+    pub(crate) value: ProviderSettingValue,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) enum ProviderSettingValue {
+    String { value: String },
+    Bool { value: bool },
+    Number { value: f64 },
+    Object { value: ProviderRawPayload },
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ProviderSecretRef {
+    pub(crate) key: String,
+    pub(crate) storage: String,
+    pub(crate) ref_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ImageInputCapabilitySnapshot {
+    pub(crate) max_images: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct FileInputCapabilitySnapshot {
+    pub(crate) max_files: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ToolCallingCapabilitySnapshot {
+    pub(crate) parallel_tool_calls: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ReasoningCapabilitySnapshot {
+    pub(crate) default_effort: String,
+    pub(crate) efforts: Vec<String>,
+    pub(crate) summaries: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "provider", rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) enum ProviderCapabilityExtensionSnapshot {
+    None,
+    OpenAi { responses_api: bool, raw: Option<ProviderRawPayload> },
+    Ollama { raw_capabilities: Vec<String>, family: String, raw: Option<ProviderRawPayload> },
+    Other { raw: ProviderRawPayload },
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ProviderModelMetadata {
+    pub(crate) display_name: Option<String>,
+    pub(crate) family: Option<String>,
+    pub(crate) raw: Option<ProviderRawPayload>,
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct AppSettingsPayload {
+    pub(crate) language: Option<String>,
+    pub(crate) theme: Option<String>,
+    pub(crate) default_project_id: Option<ProjectId>,
+}
+```
+
+`ModelCapabilitiesSnapshot` 对应现有 `ModelCapabilities` 概念。provider-specific capability 字段继续放在 typed provider extension 内。
+
+## Provider 和 Agent 边界
+
+provider adapter 边界是一轮 provider 调用：
+
+- 从 typed context 构建 provider-specific request。
+- 流式返回 provider-step events。
+- 返回 provider continuation state 和 usage。
+- 保存 provider request/response snapshots 供 debug 和 replay。
+
+agent runtime 边界是多步 loop：
+
+- 选择 context 和 prompt snapshots。
+- 启动 provider steps。
+- 执行 local、MCP 或 provider-hosted tools。
+- 请求并应用审批。
+- 处理 retry、cancel、continuation 和 max-step guard。
+- 写入 canonical conversation items，并按需更新执行/恢复/统计索引表。
+
+provider adapter 不应长期拥有 local tool execution。如果 provider 暴露 hosted tool，adapter 可以把它报告为 `ToolSource::ProviderHosted`；local 和 MCP execution 属于 `AgentRuntime`。
+
+## 迁移和验证预期
+
+#155 只做文档和设计。
+
+#156 实现必须验证：
+
+- 创建 fresh database 并读取内部 schema version。
+- migration bootstrap 可重复执行。
+- foreign keys 和 cascade 行为。
+- conversation item 排序和 `last_item_seq` 更新。
+- 每个 JSON 列的 typed JSON roundtrip。
+- FTS 索引、删除和更新行为。
+- provider model 手动刷新后的持久化。
+- legacy v1-v6 存储与全新存储共存且不会被覆盖。

--- a/app/ai-chat/docs/dev/issue-137-llm-abstractions.md
+++ b/app/ai-chat/docs/dev/issue-137-llm-abstractions.md
@@ -1,84 +1,99 @@
-# Issue #137 LLM Abstraction Coordination
+# Issue #137 LLM 抽象协调文档
 
-This is a temporary coordination document for the `ai-chat` LLM abstraction work tracked by issue #137.
-It is the cross-conversation source of truth while the integration branch is active.
-Delete it before the final merge to `main`, unless the remaining content is promoted into long-lived developer documentation.
+本文档是 `ai-chat` issue #137 LLM 抽象工作的临时协调文档。
+在集成分支活跃期间，它是跨会话的事实来源。
+最终合入 `main` 前应删除本文档，除非剩余内容被提升为长期开发文档。
 
-## Branch Strategy
+## 分支策略
 
-- Integration branch: `codex/issue-137-llm-abstractions`
-- Child issue branches must be created from the integration branch.
-- Child issue pull requests should target `codex/issue-137-llm-abstractions`, not `main`.
-- The integration branch must remain buildable after each child issue merge.
-- After #138, #142, and #139 stabilize the shared abstraction, open a staged PR from the integration branch to `main` to reduce branch drift.
+- 集成分支：`codex/issue-137-llm-abstractions`
+- 子 issue 分支必须从集成分支创建。
+- 子 issue PR 应该指向 `codex/issue-137-llm-abstractions`，不要直接指向 `main`。
+- 每个子 issue 合入后，集成分支必须保持可构建。
+- #138、#142、#139 稳定共享抽象后，再从集成分支分阶段向 `main` 开 PR，以减少长期分支漂移。
 
-## Issue And Branch Map
+## Issue 和分支映射
 
-| Issue | Branch | Purpose | Status |
+| Issue | 分支 | 目的 | 状态 |
 | --- | --- | --- | --- |
-| #137 | `codex/issue-137-llm-abstractions` | Parent integration work | Active |
-| #138 | `codex/issue-138-model-capabilities` | Provider-neutral model capability types | Merged to integration via PR #147; GitHub issue still open |
-| #142 | `codex/issue-142-llm-items` | Typed input, content, and output items | Merged to integration via PR #148; GitHub issue still open |
-| #139 | `codex/issue-139-provider-runtime` | Run-based provider trait and events | Merged to integration via PR #149; GitHub issue still open |
-| #141 | `codex/issue-141-llm-persistence` | Run state, output items, tools, attachments persistence | Merged to integration via PR #150; GitHub issue still open |
-| #143 | `codex/issue-143-openai-responses-abstraction` | OpenAI Responses migration on shared abstraction | Merged to integration via PR #151; GitHub issue still open |
-| #144 | `codex/issue-144-ollama-shared-abstraction` | Ollama migration on shared abstraction | Merged to integration via PR #152; GitHub issue still open |
-| #140 | `codex/issue-140-capability-gating` | Template, shortcut, and UI capability gating | Merged to integration via PR #153; GitHub issue still open |
-| #154 | `codex/issue-154-typed-message-content` | Consolidate typed message content model | Pending |
+| #137 | `codex/issue-137-llm-abstractions` | 父级集成工作 | 活跃 |
+| #138 | `codex/issue-138-model-capabilities` | provider-neutral 模型能力类型 | 已通过 PR #147 合入集成分支；GitHub issue 仍未关闭 |
+| #142 | `codex/issue-142-llm-items` | typed input、content、output items | 已通过 PR #148 合入集成分支；GitHub issue 仍未关闭 |
+| #139 | `codex/issue-139-provider-runtime` | 基于 run 的 provider trait 和 events | 已通过 PR #149 合入集成分支；GitHub issue 仍未关闭 |
+| #141 | `codex/issue-141-llm-persistence` | run state、output items、tools、attachments persistence | 已通过 PR #150 合入集成分支；GitHub issue 仍未关闭 |
+| #143 | `codex/issue-143-openai-responses-abstraction` | 在共享抽象上迁移 OpenAI Responses | 已通过 PR #151 合入集成分支；GitHub issue 仍未关闭 |
+| #144 | `codex/issue-144-ollama-shared-abstraction` | 在共享抽象上迁移 Ollama | 已通过 PR #152 合入集成分支；GitHub issue 仍未关闭 |
+| #140 | `codex/issue-140-capability-gating` | template、shortcut、UI capability gating | 已通过 PR #153 合入集成分支；GitHub issue 仍未关闭 |
+| #154 | `codex/issue-154-typed-message-content` | 合并 typed message content model | 已被 fresh database 方向取代；除非重新定义 scope，否则只保留为上下文 |
+| #155 | `codex/issue-155-ai-chat2-crate-split` | 固定 `ai-chat2` 并行重构、crate 拆分、fresh database 和 typed data model | 待处理 |
+| #156 | `codex/issue-156-fresh-db-bootstrap` | scaffold `ai-chat-core` / `ai-chat-db`，实现 fresh database bootstrap 和 typed repositories | 待处理 |
+| #157 | `codex/issue-157-provider-runtime-crate` | 抽出 `ai-chat-provider`，沉淀 provider-neutral trait、capabilities 和 adapter 边界 | 待处理 |
+| #158 | `codex/issue-158-agent-runtime-persistence` | 建立 `ai-chat-agent`，实现 agent loop、tool/approval runtime 和持久化写入 | 待处理 |
+| #159 | `codex/issue-159-ai-chat2-ui` | 在 `app/ai-chat2` 渲染项目、对话、多步 reasoning、tool、approval、多模态 timeline | 待处理 |
 
-## Issue Sync Snapshot
+## Issue 同步快照
 
-Last synchronized: 2026-05-22.
+最后同步时间：2026-05-23。
 
-- #137 remains open and is the parent tracking issue. Its comments record the child issue list and the integration branch/document workflow.
-- #138 remains open on GitHub, but PR #147 merged `codex/issue-138-model-capabilities` into `codex/issue-137-llm-abstractions`.
-- #142 remains open on GitHub, but PR #148 merged `codex/issue-142-llm-items` into `codex/issue-137-llm-abstractions`.
-- #139 remains open on GitHub, but PR #149 merged `codex/issue-139-provider-runtime` into `codex/issue-137-llm-abstractions`.
-- #141 remains open on GitHub, but PR #150 merged `codex/issue-141-llm-persistence` into `codex/issue-137-llm-abstractions`.
-- #143 remains open on GitHub, but PR #151 merged `codex/issue-143-openai-responses-abstraction` into `codex/issue-137-llm-abstractions`.
-- #144 remains open on GitHub, but PR #152 merged `codex/issue-144-ollama-shared-abstraction` into `codex/issue-137-llm-abstractions`.
-- #140 remains open on GitHub, but PR #153 merged `codex/issue-140-capability-gating` into `codex/issue-137-llm-abstractions`.
-- #154 is a new follow-up from PR #153 review. It remains open and should consolidate typed message content so rendered content, edited content, sent content, export, resend, and contextual history derive from one provider-neutral source of truth.
+- #137 仍未关闭，是父级跟踪 issue。它的评论记录了子 issue 列表、集成分支和文档工作流。
+- #138 仍未关闭，但 PR #147 已把 `codex/issue-138-model-capabilities` 合入 `codex/issue-137-llm-abstractions`。
+- #142 仍未关闭，但 PR #148 已把 `codex/issue-142-llm-items` 合入 `codex/issue-137-llm-abstractions`。
+- #139 仍未关闭，但 PR #149 已把 `codex/issue-139-provider-runtime` 合入 `codex/issue-137-llm-abstractions`。
+- #141 仍未关闭，但 PR #150 已把 `codex/issue-141-llm-persistence` 合入 `codex/issue-137-llm-abstractions`。
+- #143 仍未关闭，但 PR #151 已把 `codex/issue-143-openai-responses-abstraction` 合入 `codex/issue-137-llm-abstractions`。
+- #144 仍未关闭，但 PR #152 已把 `codex/issue-144-ollama-shared-abstraction` 合入 `codex/issue-137-llm-abstractions`。
+- #140 仍未关闭，但 PR #153 已把 `codex/issue-140-capability-gating` 合入 `codex/issue-137-llm-abstractions`。
+- #154 来自 PR #153 review follow-up。它原本想在当前 `messages` schema 内合并 typed message content，但这个方向对 agent/multimodal 路线太受限。
+- 当前首选方向是设计 fresh ai-chat database schema，不再继续在旧 `messages.content` / `send_content` / `input_content_parts` 模型上叠 migration 和兼容逻辑。
+- #155 已更新为：同时确定 `ai-chat2` 并行重构、crate 拆分、fresh database schema 和 typed data model。
+- #156 已更新为：先 scaffold `ai-chat-core` / `ai-chat-db`，实现 fresh database bootstrap 和 typed repositories；可建最小 `app/ai-chat2` 壳，不迁移 UI。
+- #157 已更新为：抽出 `ai-chat-provider`，把 provider-neutral trait、capabilities、OpenAI/Ollama adapter 边界从旧 app 债务中隔离出来。
+- #158 已更新为：建立 `ai-chat-agent`，实现 agent loop、tool registry、approval、continuation、cancel/retry，并写入 fresh persistence。
+- #159 已更新为：让 `app/ai-chat2` 使用新 crates 渲染项目、对话、timeline、tool、approval 和多模态内容。
+- 2026-05-23 已读取并更新 GitHub #137、#155-#159。#137 正文已指向 `ai-chat2` 并行重构和新的子 issue 序列；#155-#159 title/body 已按“后续 Issue 调整提案”同步。
 
-## Current Architecture Facts
+## 当前架构事实
 
-- `llm::Message` has been replaced by provider-neutral typed input/output item vocabulary.
-- `LlmInputItem` and `LlmContentPart` now represent request-side LLM data before provider wire conversion.
-- `LlmOutputItem` now reserves provider-neutral output vocabulary for follow-up runtime and persistence work.
-- Conversation panel and temporary/shortcut flows now share the same typed history builder.
-- `ProviderModel` now holds provider-neutral `ModelCapabilities` instead of the old streaming-only `ProviderModelCapability`.
-- `ModelCapabilities` covers text input/output, streaming, image/file/audio input, image generation, tool calling, hosted web search, remote MCP, reasoning, structured output, stateful response continuation, and provider-specific typed extensions.
-- OpenAI model classification now emits typed capabilities for Responses API usage, reasoning effort options, hosted web search, structured output, and stateful response continuation.
-- Ollama `/api/show` metadata now maps into typed capabilities and an `OllamaModelCapabilities` extension for raw capabilities, family data, thinking mode, local web tools, and vision image input.
-- `Provider` now builds `ProviderRunRequest` values from typed input items and streams provider-neutral `ProviderRunEvent` values.
-- `ProviderRunRequest` keeps the provider request JSON snapshot so existing `messages.send_content` resend behavior remains compatible.
-- `ProviderRunEvent` replaces `FetchUpdate` and covers thinking start, reasoning summary delta, text delta, output item added/done, tool call/result, MCP approval request, usage update, completed, and failed states.
-- `ProviderRunState` and `ProviderUsage` are available for provider response/run metadata, output item ids, continuation metadata, and token usage, and #141 persists them additively for assistant messages.
-- `message_run_states`, `message_output_items`, and `message_attachments` now persist provider run state, output item events, usage, and attachment metadata additively without changing `messages.content` or `messages.send_content`.
-- `messages.content` stores rendered message content; `messages.send_content` stores the request body snapshot used for resend.
-- `messages.input_content_parts` stores provider-neutral user input parts for future contextual history; old migrated messages default to an empty list and fall back to rendered text.
-- The coexistence of `messages.content` and `messages.input_content_parts` is now tracked by #154 as a temporary double-source model that should be consolidated.
-- OpenAI uses `/v1/responses`, reasoning effort, reasoning summaries, hosted web search citations, provider-neutral output item events, and persisted `previous_response_id` continuation when compatible run state is available.
-- OpenAI adapter-specific Responses request fields such as `include`, `text`, `tool_choice`, `tools`, and `parallel_tool_calls` remain inside the OpenAI provider schema rather than the generic provider trait.
-- Ollama has provider-specific thinking, image input, and experimental web search/fetch behavior that must not be forced into OpenAI-shaped types.
-- Ollama image input accepts raw base64 or `data:image/...;base64,...` references only; URL, file-id, local-path, file, audio, and generic attachment inputs remain explicitly unsupported.
-- Ollama run events now emit provider-neutral output item, tool call/result, usage, and completion data while keeping `ProviderRunState.run_id` empty and avoiding OpenAI-style continuation semantics.
-- `CapabilityRequirement` records provider-neutral feature requirements for templates and UI gating.
-- `conversation_templates.required_capabilities` lives in the unmerged v6 schema and defaults old migrated templates to an empty list.
-- Chat and shortcut UI now surface template/model compatibility through `ModelCapabilities::missing_requirements` rather than provider metadata or ad hoc JSON.
-- Screenshot shortcuts send PNG data URL image input when the selected model supports `image_input`; otherwise they keep the existing OCR text fallback.
+- `llm::Message` 已替换为 provider-neutral typed input/output item 词汇。
+- `LlmInputItem` 和 `LlmContentPart` 表示 provider wire conversion 之前的 request-side LLM data。
+- `LlmOutputItem` 为后续 runtime 和 persistence 保留 provider-neutral output 词汇。
+- conversation panel 和 temporary/shortcut flows 现在共享同一个 typed history builder。
+- `ProviderModel` 使用 provider-neutral `ModelCapabilities`，不再使用旧 streaming-only `ProviderModelCapability`。
+- `ModelCapabilities` 覆盖 text input/output、streaming、image/file/audio input、image generation、tool calling、hosted web search、remote MCP、reasoning、structured output、stateful response continuation，以及 provider-specific typed extensions。
+- OpenAI model classification 现在输出 Responses API、reasoning effort、hosted web search、structured output、stateful response continuation 等 typed capabilities。
+- Ollama `/api/show` metadata 现在映射到 typed capabilities，并通过 `OllamaModelCapabilities` extension 保留 raw capabilities、family data、thinking mode、local web tools、vision image input。
+- `Provider` 现在从 typed input items 构建 `ProviderRunRequest`，并流式输出 provider-neutral `ProviderRunEvent`。
+- `ProviderRunRequest` 保留 provider request JSON snapshot，以兼容现有 `messages.send_content` resend 行为。
+- `ProviderRunEvent` 替代 `FetchUpdate`，覆盖 thinking start、reasoning summary delta、text delta、output item added/done、tool call/result、MCP approval request、usage update、completed、failed。
+- `ProviderRunState` 和 `ProviderUsage` 可表示 provider response/run metadata、output item ids、continuation metadata、token usage，#141 以 additive 方式把它们持久化到 assistant messages。
+- `message_run_states`、`message_output_items`、`message_attachments` 现在 additive 地持久化 provider run state、output item events、usage、attachment metadata，不改变 `messages.content` 或 `messages.send_content`。
+- `messages.content` 保存 rendered message content；`messages.send_content` 保存用于 resend 的 request body snapshot。
+- `messages.input_content_parts` 保存 provider-neutral user input parts，给未来 contextual history 使用；旧 migrated messages 默认空列表，并 fallback 到 rendered text。
+- `messages.content`、`messages.send_content`、`messages.input_content_parts` 并存的模型现在视为 legacy compatibility model。不要在这个形状上构建 agent runtime 或新的 multimodal persistence。
+- OpenAI 使用 `/v1/responses`、reasoning effort、reasoning summaries、hosted web search citations、provider-neutral output item events，并在 compatible run state 可用时使用 persisted `previous_response_id` continuation。
+- OpenAI adapter-specific Responses request 字段，例如 `include`、`text`、`tool_choice`、`tools`、`parallel_tool_calls`，必须留在 OpenAI provider schema 内，不要进入 generic provider trait。
+- Ollama 有 provider-specific thinking、image input、experimental web search/fetch 行为，不能强行套成 OpenAI 形状。
+- Ollama image input 只接受 raw base64 或 `data:image/...;base64,...` reference；URL、file-id、local-path、file、audio、generic attachment input 都明确不支持。
+- Ollama run events 现在输出 provider-neutral output item、tool call/result、usage、completion data，同时保持 `ProviderRunState.run_id` 为空，避免 OpenAI-style continuation semantics。
+- `CapabilityRequirement` 记录 templates 和 UI gating 所需的 provider-neutral feature requirements。
+- `conversation_templates.required_capabilities` 位于尚未合入的 v6 schema 内，旧 migrated templates 默认空列表。
+- Chat 和 shortcut UI 通过 `ModelCapabilities::missing_requirements` 展示 template/model compatibility，而不是读取 provider metadata 或 ad hoc JSON。
+- Screenshot shortcuts 在 selected model 支持 `image_input` 时发送 PNG data URL image input，否则保留现有 OCR text fallback。
 
-## Shared Design Decisions
+## 共享设计决策
 
-- The new LLM abstraction must be provider-neutral first. OpenAI Responses should be one adapter, not the shape of the core model.
-- Provider/model capabilities must be represented with typed Rust structures, not only string metadata or arbitrary JSON.
-- Provider-specific features should live in provider extension types that are attached to the generic model/provider metadata.
-- The UI, templates, and shortcut flows should ask the generic capability model whether a feature is available.
-- Existing pure-text conversations, templates, shortcuts, resend behavior, OpenAI, and Ollama must keep working during the migration.
+- 新 LLM 抽象必须先 provider-neutral。OpenAI Responses 只是一个 adapter，不是 core model 的形状。
+- Provider/model capabilities 必须使用 typed Rust structures 表达，不能只用 string metadata 或任意 JSON。
+- Provider-specific features 应该放在 provider extension types 中，并挂在 generic model/provider metadata 上。
+- UI、templates、shortcut flows 应该询问 generic capability model 某个 feature 是否可用。
+- 迁移期间，现有 pure-text conversations、templates、shortcuts、resend behavior、OpenAI、Ollama 必须继续工作。
+- 新 agent 和 multimodal persistence 应围绕 `app/ai-chat2`、fresh database 和独立 crates 设计，不要求把 legacy ai-chat stores 完整迁移。
+- Legacy databases 不能被覆盖。如果保留 legacy support，它必须是显式策略：backup、read-only viewer、manual export，或 manual import。不要要求完整自动迁移到新的 agent schema。
+- Fresh database versioning 必须存在数据库内部。不要只通过 `history_v6.sqlite3` 这类文件名表达当前 schema version。
 
-## Implemented Capability Vocabulary
+## 已实现的能力词汇
 
-Issue #138 established these Rust capability types:
+Issue #138 建立了以下 Rust 能力类型：
 
 - `ModelCapabilities`
 - `ReasoningCapability`
@@ -91,53 +106,189 @@ Issue #138 established these Rust capability types:
 - `OllamaModelCapabilities`
 - `OllamaThinkingCapability`
 
-The current implementation keeps request execution behavior unchanged: OpenAI and Ollama still produce the same provider request JSON shape, but capability gating inside provider/template code now reads typed model capabilities instead of ad hoc JSON metadata or streaming-only enum state.
+当前实现保持请求执行行为不变：OpenAI 和 Ollama 仍产生相同的 provider request JSON shape，但 provider/template 代码中的 capability gating 已改为读取 typed model capabilities，不再读取 ad hoc JSON metadata 或 streaming-only enum state。
 
-## Implemented Runtime Vocabulary
+## 已实现的运行时词汇
 
-Issue #139 established these Rust runtime types:
+Issue #139 建立了以下 Rust 运行时类型：
 
 - `ProviderRunRequest`
 - `ProviderRunEvent`
 - `ProviderRunState`
 - `ProviderUsage`
 
-The current implementation keeps request persistence additive: existing provider request JSON remains the compatibility snapshot for `messages.send_content`, while new runtime code uses `ProviderRunRequest` and `ProviderRunEvent` internally. OpenAI and Ollama still own their own wire/request conversion inside provider adapters.
+当前实现保持 request persistence 为 additive：现有 provider request JSON 仍作为 `messages.send_content` 的兼容 snapshot；新的 runtime 代码内部使用 `ProviderRunRequest` 和 `ProviderRunEvent`。OpenAI 和 Ollama 仍在各自 provider adapter 内负责 wire/request conversion。
 
-## Provider Extension Rules
+## Provider 扩展规则
 
-- Generic code may inspect common capabilities.
-- Provider adapters may inspect provider-specific extension data.
-- OpenAI-only concepts such as Responses output item ids, hosted tools, and remote MCP details must not become required fields for every provider.
-- Ollama-only concepts such as `think` values and experimental local web search/fetch must remain expressible without pretending they are OpenAI tools.
+- Generic code 可以检查 common capabilities。
+- Provider adapter 可以检查 provider-specific extension data。
+- OpenAI-only 概念，例如 Responses output item ids、hosted tools、remote MCP details，不能变成所有 provider 的 required fields。
+- Ollama-only 概念，例如 `think` values 和 experimental local web search/fetch，必须能表达出来，但不要伪装成 OpenAI tools。
 
-## Persistence Direction
+## Persistence 方向
 
-- Persistence changes should preserve old `messages.content` and `messages.send_content` compatibility.
-- New run state should be additive first, so older conversations can still load and resend.
-- Future persistence must be able to store provider response/run state, output items, tool calls, MCP approval state, attachments metadata, usage, model, and settings snapshots.
-- Do not store binary attachment data directly inside message text.
+- 当前 v6 tables 足以支持 provider-run compatibility，但不是完整 agent 行为的目标 schema。
+- 下一阶段 persistence 应该在 `ai-chat-db` crate 中为 `app/ai-chat2` 创建 fresh database，不要继续扩展旧 `messages` table model。
+- Fresh schema 应让 provider-neutral transcript items 成为 display、edit、export、resend、contextual history、provider input reconstruction 的 canonical source of truth。
+- `send_content` 风格的 provider request JSON 只保留为 provider step 上的 debug/replay snapshot，不作为 chat history。
+- Fresh schema 必须保存 provider response/run state、output items、reasoning items、tool calls、tool results、MCP approval state、attachments metadata、usage、model、settings snapshots、provider-specific continuation metadata。
+- 不要求从 v1-v6 history stores 完整自动迁移。如果旧数据仍要可访问，应实现明确的 legacy path，例如 backup-only retention、read-only legacy browsing、manual export/import。
+- 不要把 binary attachment data 存到 message text 中。
 
-## Validation Expectations
+## 全新数据库和并行重构方向
 
-- Every child issue should run `cargo fmt` if it changes Rust files.
-- Every child issue should run targeted tests for the changed subsystem.
-- Integration-stage PRs to `main` must run:
+#155 的事实来源是 `app/ai-chat/docs/dev/fresh-database-schema.md`。
+
+高层决策：
+
+- 新模型通过 `app/ai-chat2` 和独立 crates 落地，不在旧 `app/ai-chat` 内做原地大重构。旧 app 保持可运行，用作 legacy path。
+- `app/ai-chat2` 是薄 GPUI shell。领域模型、fresh database、provider adapter、agent runtime 分别进入 `ai-chat-core`、`ai-chat-db`、`ai-chat-provider`、`ai-chat-agent`。
+- #156 优先创建 `ai-chat-core` 和 `ai-chat-db`，让 schema bootstrap 和 typed repository tests 独立通过；UI 迁移留给 #159。
+- 使用 SQLite-first fresh store，typed JSON payload 必须落到 SQL `JSON` 列。每个 app 自有 JSON 列必须映射到一个具名 Rust 类型，并使用严格 serde 解码；不要使用 `TEXT` 列保存 JSON 字符串。
+- 项目就是实际文件夹。scratch 或 no-project chats 必须使用 app 创建的 scratch folder，并写入 `projects` 行。
+- `conversation_items` 是 canonical contextual timeline。Display、edit、export、resend、provider input reconstruction 必须读取它，并且不能为了渲染 tool/reasoning/approval/usage 再 join 执行表。
+- 第一阶段采用线性 append-only timeline：`seq` 是对话内顺序。pi 式 `parentId` / leaf context tree 暂不进入 #155-#159；如果未来需要同一对话内 branching、编辑历史或多 leaf context，应先扩展 schema，再做 UI。
+- fresh model 移除 folders、templates、conversation modes。保存的指令是 `prompts`；所有 conversations 都是 contextual。
+- `ProviderRunRequest`、`ProviderRunEvent`、`ProviderRunState` 保持为低层 provider-step adapter boundary。持久化 canonical transcript 是 `conversation_items`；`agent_runs`、`provider_steps`、`tool_invocations`、approvals、usage 是执行、恢复、统计或调试索引。
+- Provider request JSON 只保存在 `provider_steps`，作为 debug/replay snapshot，不作为 chat history。
+- Provider models 在 settings 中手动刷新，启动时读取 cached `provider_models` rows。
+- Legacy v1-v6 stores 必须保持 intact。Legacy access 必须显式实现，不能要求完整自动迁移。
+
+## app 和 crate 边界
+
+推荐目标结构：
+
+```text
+app/ai-chat/              # 现有 legacy app，迁移期保持可运行
+app/ai-chat2/             # 新 GPUI app shell，只组合 UI、窗口、路由和状态
+crates/ai-chat-core/      # 领域数据契约和核心不变量
+crates/ai-chat-db/        # fresh SQLite schema、migrations、typed repositories
+crates/ai-chat-provider/  # provider-neutral trait、capabilities、OpenAI/Ollama adapter
+crates/ai-chat-agent/     # agent loop、tool registry、approval、continuation、cancel/retry
+```
+
+边界约束：
+
+- `ai-chat-core` 不能依赖 GPUI、Diesel、HTTP client 或具体 provider。
+- `ai-chat-db` 依赖 `ai-chat-core`，负责 SQL `JSON` typed roundtrip、migration、transaction 和 FTS。
+- `ai-chat-provider` 依赖 `ai-chat-core`，负责 provider wire conversion 和 provider-step events。
+- `ai-chat-agent` 依赖 core/provider/repository traits，负责多步 agent loop 和 canonical item 写入。
+- `app/ai-chat2` 只依赖这些 crates，不重新拥有长期业务模型。
+- 旧 `app/ai-chat` 不在 #156-#159 中被强制迁移；它可以继续承载 legacy UI 和旧数据库访问，直到有明确替代策略。
+
+## 多应用参考说明
+
+#155 必须参考多种 agent/chat 应用，而不是只参考 Alma：
+
+- Zed 的 native agent thread 把整条 thread 存成 typed JSON document，再压缩为 `threads.data BLOB`；列表和 sidebar 只读 `summary`、`updated_at`、`created_at`、`folder_paths`、`sidebar_threads` 等 metadata。可借鉴的是：热路径不要把一条 transcript 拆到很多表里，列表需要的字段应直接列化或反规范化。
+- Codex 的 canonical session 是 append-only rollout JSONL；SQLite `threads` 只保存 `rollout_path`、`cwd`、title、preview、tokens、git、archive 等索引字段，dynamic tools 和 spawn edges 这类独立查询关系才单独建表。可借鉴的是：canonical log 和 metadata index 分层，thread 归属真实 cwd。
+- pi 的 session 按 cwd 组织到 `~/.pi/agent/sessions/<encoded-cwd>/*.jsonl`；session header 后面是 append-only entries，每个 entry 有 `id`、`parentId`、`type`，context 通过当前 leaf 回溯构建。可借鉴的是：项目/目录组织对话、append-only typed entries、compaction/model change/label/custom entry 一等化。
+- Alma 的价值在于把 provider/model cache、usage、MCP/OAuth、agent execution、memory/observability 与 transcript 分离。不能把 Alma 的 JSON-like text 列、chat message payload shape 或过度规范化表设计搬进 ai-chat。
+
+最终取舍：ai-chat 继续 SQLite-first，但采用“typed transcript log + metadata/execution indexes”模型。`conversation_items.payload_json` 是 canonical append-only transcript document；执行表只用于恢复、debug、统计和设置索引，不能成为 UI/context 主路径的 join 依赖。
+
+## 后续 Issue 调整提案
+
+现有 #155-#159 已经创建，并且已在 2026-05-23 按下面的边界同步到 GitHub title/body。后续如果继续拆分或改名，应先更新本文档和 `fresh-database-schema.md`，再同步线上 issue。
+
+### #155 ai-chat2、crate 拆分和 fresh database 设计
+
+标题建议：`[tech] ai-chat: design ai-chat2 crate split and fresh database model`
+
+范围：
+
+- 明确采用 `app/ai-chat2` 并行重构，而不是在旧 `app/ai-chat` 中原地替换全部数据层和 UI。
+- 定义 `ai-chat-core`、`ai-chat-db`、`ai-chat-provider`、`ai-chat-agent`、`app/ai-chat2` 的 ownership boundary。
+- 围绕 projects、canonical conversation items、agent runs、provider steps、tool invocations、approvals、usage events、prompts、shortcuts、providers、provider model caches、app settings、deduplicated attachments 定义新 schema。
+- 在实现前定义每个 app 自有 JSON payload 对应的 Rust 类型。Repository API 中不要留下含糊的 `serde_json::Value` payload。
+- 决定新 database file name 和 bootstrap strategy。新 store 不能覆盖已有 v1-v6 stores。
+- 使用 `schema_migrations` 和 `schema_metadata` 把 schema version 和 migration state 放到 fresh database 内部；文件名不能成为 schema truth。
+- 参考 Zed、Codex、pi、Alma 的共同边界：transcript 热路径应是 typed append-only log；project/cwd/thread metadata 应面向列表查询反规范化；需要独立查询的 execution、provider/model cache、usage、MCP/OAuth、spawn/tool relationships 才单独建索引表。
+- 明确禁止把 timeline 渲染设计成多表 join。tool call/result、reasoning、approval、usage summary 等用户可见内容必须完整写入 `conversation_items.payload_json`。
+- 明确第一阶段使用线性 append-only timeline；branching、edit tree、多个 leaf context 不在 #155-#159 scope 内。
+- 明确 automatic full migration from legacy `messages` schema 不在 scope 内。
+- 定义 legacy data policy：backup-only retention、read-only legacy viewer、manual export/import，或分阶段组合。
+- 产出文档，不改 Rust 代码；schema tests 留给 #156。
+
+### #156 core/db crates、fresh database bootstrap 和 repository layer
+
+标题建议：`[tech] ai-chat: scaffold core/db crates and fresh database repositories`
+
+范围：
+
+- 新增 `crates/ai-chat-core`，放置 canonical Rust 数据契约、typed JSON payload、ID/status enums、prompt/settings/capability snapshots。
+- 新增 `crates/ai-chat-db`，放置 fresh SQLite schema、migrations、Diesel mappings、typed repositories。
+- 可新增最小 `app/ai-chat2` shell 以验证 workspace wiring，但不迁移旧 UI。
+- 增加 fresh database bootstrap path，且不覆盖 legacy v1-v6 stores。
+- Bootstrap 时打开 fresh database，读取 `schema_metadata` 和 `schema_migrations`，再在事务内应用缺失 migrations。
+- 实现 typed repository/service APIs，覆盖 projects、conversations、conversation items、attachments、runs、provider steps、tools、approvals、usage、prompts、shortcuts、providers、provider models、app settings。
+- SQL schema 中 app 自有结构化 payload 使用 `JSON` 列，不使用 `TEXT` 保存 JSON 字符串。
+- 保持旧 database code 隔离为 legacy compatibility code，直到它可以被移除或替换为 read-only/export path。
+- 增加 tests，覆盖 new database creation、internal version detection、repeated idempotent bootstrap、empty first run、transaction boundaries、cascade deletes、item ordering、typed JSON roundtrip、FTS indexing、provider model cache persistence、legacy-store coexistence。
+
+### #157 provider runtime crate
+
+标题建议：`[tech] ai-chat: extract provider-neutral runtime crate for ai-chat2`
+
+范围：
+
+- 新增 `crates/ai-chat-provider`，承载 provider-neutral provider trait、provider-step request/event/state、model capability snapshots 和 adapter conversion。
+- 保持 `Provider` 只负责一次 provider run，不执行 local/MCP tools，不拥有 multi-step loop。
+- 把 OpenAI Responses、Ollama chat/show 等 provider-specific request/stream conversion 留在 adapter 内。
+- provider request/response snapshot 只进入 `provider_steps` debug/replay path，不成为 canonical chat history。
+- provider models 采用设置页手动刷新、保存到 `provider_models`、启动读缓存的策略。
+- 增加 tests，覆盖 capability mapping、unsupported content rejection、provider-specific extension roundtrip、request snapshot redaction boundary。
+
+### #158 agent runtime 和持久化
+
+标题建议：`[tech] ai-chat: implement agent runtime and persistence for ai-chat2`
+
+范围：
+
+- 新增 `crates/ai-chat-agent`，承载 `AgentRunRequest`、`AgentRunEvent`、`AgentRunState`、`AgentStep`、`ToolRegistry`、`ToolDefinition`、`ToolInvocation`、`ToolExecutionPolicy`、`ToolApprovalPolicy`。
+- 实现 multi-step loop、tool execution、MCP/provider-hosted tool reporting、approval、continuation、retry、cancel 和 max-step guard。
+- 持久化每个 agent run、provider step、tool invocation、tool result、approval decision、usage update、retry、cancellation、terminal state。
+- 保存每个 provider step 的 provider request/response snapshots 和 continuation metadata。
+- 同步写入 `conversation_items`，保证 timeline/context/export/resend 不依赖 execution tables join。
+- 让 crash recovery 和 debug inspection 不依赖 rendered message text 重建状态。
+- 增加 tests，覆盖 multi-step tool runs、failed tools、denied approvals、paused/canceled runs、resend/retry behavior。
+
+### #159 ai-chat2 agent 和多模态时间线 UI
+
+标题建议：`[tech] ai-chat: build ai-chat2 project chat and multimodal timeline UI`
+
+范围：
+
+- 在 `app/ai-chat2` 中实现项目优先的导航：项目就是真实文件夹，scratch/no-project 也创建真实 scratch folder。
+- 所有对话都是 contextual；不再提供 `assistant-only`、`single`、`contextual` mode 选项。
+- UI 使用“提示词”管理保存的 system/developer prompts；不再出现 template 概念。
+- 快捷键绑定 prompt、provider/model、input source 和 action，不绑定 template/mode。
+- 从新 transcript model 渲染多个 reasoning blocks、text deltas、tool calls、tool progress、tool results、approvals、generated images/files、retries、usage status。
+- 支持 local tools 和 MCP tools 的 approval prompts。
+- 对不支持的 tool、MCP、image、file、audio、structured output、reasoning modes 保持 capability gating。
+- 分别验证 `app/ai-chat` legacy pure-text behavior 和 `app/ai-chat2` 新 agent timeline behavior。
+
+## 验证预期
+
+- 每个子 issue 如果修改 Rust 文件，都应该运行 `cargo fmt`。
+- 每个子 issue 都应该运行与改动 subsystem 相关的 targeted tests。
+- Integration-stage PR 合入 `main` 前必须运行：
   - `cargo build`
   - `cargo test`
   - `cargo clippy --all-targets --all-features -- -D warnings`
-- UI or shortcut stages must include manual verification notes for old text chat, OpenAI, Ollama, resend, and shortcut flows.
+- UI 或 shortcut 阶段必须包含 manual verification notes，覆盖 old text chat、OpenAI、Ollama、resend、shortcut flows。
 
-## Completed Child Issue Notes
+## 已完成子 Issue 记录
 
-### #138 Provider-Neutral Model Capability Types
+### #138 Provider-neutral 模型能力类型
 
-- Replaced `ProviderModelCapability` with `ModelCapabilities`.
-- Re-exported the new capability vocabulary from `llm.rs` for downstream stages.
-- Migrated OpenAI reasoning/web-search capability checks to typed capabilities.
-- Migrated Ollama thinking/tool capability checks to typed `OllamaModelCapabilities`.
-- Preserved existing OpenAI Responses request body, Ollama chat request body, template replay, streaming, and ext-setting behavior.
-- Validation run:
+- 用 `ModelCapabilities` 替换 `ProviderModelCapability`。
+- 从 `llm.rs` 重新导出新的 capability vocabulary，供后续阶段使用。
+- 把 OpenAI reasoning/web-search capability checks 迁移到 typed capabilities。
+- 把 Ollama thinking/tool capability checks 迁移到 typed `OllamaModelCapabilities`。
+- 保留现有 OpenAI Responses request body、Ollama chat request body、template replay、streaming、ext-setting behavior。
+- 已运行验证：
   - `cargo fmt`
   - `cargo test -p ai-chat llm::provider`
   - `cargo test -p ai-chat llm::preset`
@@ -145,34 +296,34 @@ The current implementation keeps request persistence additive: existing provider
   - `cargo test -p ai-chat components::chat_form::model_select`
   - `cargo test -p ai-chat features::settings::shortcut_settings`
 
-### #142 Provider-Neutral Typed Input And Output Items
+### #142 Provider-neutral typed input 和 output items
 
-- Replaced the public LLM request item shape with provider-neutral `LlmInputItem` and `LlmContentPart` types.
-- Added provider-neutral output vocabulary for message, reasoning, tool call/result, MCP approval, and hosted tool call items.
-- Added a shared history builder for conversation panel and temporary/shortcut flows.
-- Migrated OpenAI and Ollama provider request construction to accept typed input items and translate them inside each adapter.
-- Preserved existing pure-text OpenAI Responses request bodies, Ollama chat request bodies, template replay, resend, and shortcut behavior.
-- Non-text input parts now fail explicitly in current adapters instead of being silently dropped or coerced into text.
-- Left full multimodal, tool output, MCP, stateful continuation, provider run events, and persistence changes to #139, #141, #143, and #144.
-- Validation run:
+- 用 provider-neutral `LlmInputItem` 和 `LlmContentPart` 替换 public LLM request item shape。
+- 增加 provider-neutral output vocabulary，覆盖 message、reasoning、tool call/result、MCP approval、hosted tool call items。
+- 为 conversation panel 和 temporary/shortcut flows 增加共享 history builder。
+- 把 OpenAI 和 Ollama provider request construction 迁移为接受 typed input items，并在 adapter 内部转换。
+- 保留现有 pure-text OpenAI Responses request bodies、Ollama chat request bodies、template replay、resend、shortcut behavior。
+- 非 text input parts 现在会在当前 adapters 中明确失败，不会静默丢弃或强行转成 text。
+- full multimodal、tool output、MCP、stateful continuation、provider run events、persistence 留给 #139、#141、#143、#144。
+- 已运行验证：
   - `cargo fmt`
   - `cargo test -p ai-chat llm::types`
   - `cargo test -p ai-chat llm::provider`
   - `cargo test -p ai-chat features::home::tabs::conversation_panel`
   - `cargo test -p ai-chat features::temporary::detail`
 
-### #139 Run-Based Provider Trait And Events
+### #139 基于 run 的 Provider trait 和事件
 
-- Replaced the old `FetchUpdate` stream path with provider-neutral `ProviderRunEvent`.
-- Added `ProviderRunRequest`, `ProviderRunState`, and `ProviderUsage` as the first-stage runtime abstraction.
-- Changed the `Provider` trait to build run requests with `build_run_request` and execute them with `run`.
-- Kept `Provider::request_body` as a compatibility helper for persisted `messages.send_content` snapshots.
-- Migrated conversation panel and temporary detail streaming consumers to `ProviderRunRunner`.
-- Migrated OpenAI Responses stream parsing into provider-neutral events without exposing OpenAI event names in the core runtime.
-- Added OpenAI parser coverage for completed, failed, incomplete, and top-level error events.
-- Migrated Ollama chat streaming to the same run event vocabulary while keeping its experimental web search/fetch loop provider-local.
-- Left generic app-level tool execution, MCP approval UI, and run-state database persistence to #141, #143, #144, and #140.
-- Validation run:
+- 用 provider-neutral `ProviderRunEvent` 替换旧 `FetchUpdate` stream path。
+- 增加 `ProviderRunRequest`、`ProviderRunState`、`ProviderUsage` 作为第一阶段 runtime abstraction。
+- 把 `Provider` trait 改为通过 `build_run_request` 构建 run request，并通过 `run` 执行。
+- 保留 `Provider::request_body` 作为 persisted `messages.send_content` snapshots 的兼容 helper。
+- 把 conversation panel 和 temporary detail streaming consumers 迁移到 `ProviderRunRunner`。
+- 把 OpenAI Responses stream parsing 迁移到 provider-neutral events，不在 core runtime 暴露 OpenAI event names。
+- 增加 OpenAI parser coverage，覆盖 completed、failed、incomplete、top-level error events。
+- 把 Ollama chat streaming 迁移到同一 run event vocabulary，同时保持 experimental web search/fetch loop 为 provider-local。
+- generic app-level tool execution、MCP approval UI、run-state database persistence 留给 #141、#143、#144、#140。
+- 已运行验证：
   - `cargo fmt`
   - `cargo test -p ai-chat llm::types`
   - `cargo test -p ai-chat llm::provider`
@@ -182,16 +333,16 @@ The current implementation keeps request persistence additive: existing provider
   - `cargo test -p ai-chat features::temporary::detail`
   - `cargo clippy -p ai-chat --all-targets --all-features -- -D warnings`
 
-### #141 LLM Run State, Output Item, Tool, And Attachment Persistence
+### #141 LLM run state、output item、tool 和 attachment 持久化
 
-- Added database v6 and migrates legacy v1-v5 stores into `history_v6.sqlite3`.
-- Preserved `messages.content` and `messages.send_content` as the compatibility surface for display, export, and resend.
-- Added additive run persistence tables for assistant message run state, ordered output item events, and attachment metadata.
-- Added typed message persistence wrappers around `ProviderRunState`, `ProviderUsage`, `LlmOutputItem`, and attachment refs.
-- Conversation streaming now accumulates output item events, tool/MCP events, usage, and completed run state, then persists them with terminal message state.
-- Temporary chat remains in-memory but carries run persistence when saved into a normal conversation.
-- Resending an assistant message clears old run persistence while keeping the existing request body snapshot behavior.
-- Validation run:
+- 增加 database v6，并把 legacy v1-v5 stores 迁移到 `history_v6.sqlite3`。
+- 保留 `messages.content` 和 `messages.send_content` 作为 display、export、resend 的兼容 surface。
+- 增加 additive run persistence tables，用于 assistant message run state、ordered output item events、attachment metadata。
+- 增加围绕 `ProviderRunState`、`ProviderUsage`、`LlmOutputItem`、attachment refs 的 typed message persistence wrappers。
+- Conversation streaming 现在会累积 output item events、tool/MCP events、usage、completed run state，并随 terminal message state 一起持久化。
+- Temporary chat 仍为 in-memory，但保存到 normal conversation 时会携带 run persistence。
+- Resend assistant message 会清除旧 run persistence，同时保留现有 request body snapshot 行为。
+- 已运行验证：
   - `cargo fmt`
   - `cargo test -p ai-chat database::migrations`
   - `cargo test -p ai-chat database::service`
@@ -201,15 +352,15 @@ The current implementation keeps request persistence additive: existing provider
   - `cargo test -p ai-chat`
   - `cargo clippy -p ai-chat --all-targets --all-features -- -D warnings`
 
-### #143 OpenAI Responses Adapter Migration
+### #143 OpenAI Responses adapter 迁移
 
-- Added optional provider run state plumbing so OpenAI can build request bodies with `previous_response_id` while other providers keep existing request construction behavior.
-- Conversation panel and temporary chat now use compatible persisted OpenAI assistant run state in contextual mode, trim history before that response, and fall back to full transcript behavior for non-contextual modes or incompatible state.
-- OpenAI continuation is gated by matching persisted provider/model/run id, non-secret provider settings snapshot, and request context key. The request context key is the Responses request body with `input` and `previous_response_id` removed, so template/tool/reasoning/stream changes prevent stale continuation while input deltas do not.
-- OpenAI request conversion now emits Responses content parts for text, image references, file references, tool results, and item references; unsupported audio or generic attachments fail explicitly.
-- OpenAI stream and response parsing now maps message, reasoning, hosted tool, function-call, and MCP-related output items into provider-neutral events where existing core types can represent them.
-- Function-call argument completion now yields `ToolCallRequested`; this stage intentionally does not add generic tool execution, MCP server configuration, approval UI, or capability-gated controls.
-- Validation run:
+- 增加 optional provider run state plumbing，让 OpenAI 可用 `previous_response_id` 构建 request bodies，其他 provider 保持现有 request construction behavior。
+- Conversation panel 和 temporary chat 在 contextual mode 下会使用 compatible persisted OpenAI assistant run state，裁剪该 response 之前的 history；non-contextual modes 或 incompatible state 会 fallback 到 full transcript behavior。
+- OpenAI continuation 由 persisted provider/model/run id、non-secret provider settings snapshot、request context key 共同 gate。Request context key 是去掉 `input` 和 `previous_response_id` 的 Responses request body，因此 template/tool/reasoning/stream 变化会阻止 stale continuation，而 input delta 不会。
+- OpenAI request conversion 现在输出 Responses content parts，覆盖 text、image references、file references、tool results、item references；unsupported audio 或 generic attachments 会明确失败。
+- OpenAI stream 和 response parsing 把 message、reasoning、hosted tool、function-call、MCP-related output items 映射为现有 core types 可表达的 provider-neutral events。
+- Function-call argument completion 现在输出 `ToolCallRequested`；本阶段刻意不增加 generic tool execution、MCP server configuration、approval UI、capability-gated controls。
+- 已运行验证：
   - `cargo fmt`
   - `cargo test -p ai-chat llm::run_persistence`
   - `cargo test -p ai-chat llm::provider::openai -- --nocapture`
@@ -219,15 +370,15 @@ The current implementation keeps request persistence additive: existing provider
   - `cargo test -p ai-chat database::migrations -- --nocapture`
   - `cargo clippy -p ai-chat --all-targets --all-features -- -D warnings`
 
-### #144 Ollama Shared Abstraction Migration
+### #144 Ollama 共享抽象迁移
 
-- Mapped Ollama `vision` capability to generic `ModelCapabilities.image_input` without exposing OpenAI-only hosted web search, remote MCP, or stateful continuation settings.
-- Kept Ollama thinking and experimental local web search/fetch as provider-specific extension behavior.
-- Migrated Ollama input conversion beyond single-text messages: normal messages support multi-part text joined with blank lines and base64/data-URL image inputs; text-only tool results map to Ollama `role: "tool"` messages.
-- Unsupported URL images, OpenAI file ids, local paths, files, audio, generic attachments, and item references fail explicitly instead of being silently coerced.
-- Ollama stream and non-stream responses now emit provider-neutral output item events, tool call/result events, token usage with Ollama timing metadata, and completed content.
-- Ollama run state remains additive and compatibility-oriented: no provider run id, no output item ids for continuation, and no OpenAI-shaped `previous_response_id` behavior.
-- Validation run:
+- 把 Ollama `vision` capability 映射到 generic `ModelCapabilities.image_input`，不暴露 OpenAI-only hosted web search、remote MCP、stateful continuation settings。
+- 保持 Ollama thinking 和 experimental local web search/fetch 为 provider-specific extension behavior。
+- 把 Ollama input conversion 从 single-text messages 扩展出去：normal messages 支持 multi-part text 以空行 join，并支持 base64/data-URL image inputs；text-only tool results 映射为 Ollama `role: "tool"` messages。
+- Unsupported URL images、OpenAI file ids、local paths、files、audio、generic attachments、item references 会明确失败，不会静默转义。
+- Ollama stream 和 non-stream responses 现在输出 provider-neutral output item events、tool call/result events、带 Ollama timing metadata 的 token usage、completed content。
+- Ollama run state 仍为 additive 和 compatibility-oriented：没有 provider run id，没有 continuation 所需 output item ids，没有 OpenAI-shaped `previous_response_id` 行为。
+- 已运行验证：
   - `cargo fmt`
   - `cargo test -p ai-chat llm::provider::ollama`
   - `cargo test -p ai-chat llm::provider`
@@ -236,17 +387,17 @@ The current implementation keeps request persistence additive: existing provider
   - `cargo test -p ai-chat features::temporary::detail`
   - `cargo clippy -p ai-chat --all-targets --all-features -- -D warnings`
 
-### #140 Capability Gating
+### #140 能力门控
 
-- Added `CapabilityRequirement` and `ModelCapabilities::{supports_requirement, missing_requirements}` as the typed compatibility surface for templates, chat UI, and shortcuts.
-- Extended the existing unmerged v6 template schema with `conversation_templates.required_capabilities JSON NOT NULL DEFAULT '[]'`; v1-v5 migrations backfill old templates with an empty list.
-- Added template create/edit controls for required capabilities and shows compatibility/missing-capability status in template lists, template view dialogs, and the chat template picker.
-- Chat keeps an incompatible selected template visible but disables send and shows the missing capabilities.
-- Shortcut settings show `CapabilityMismatch`, warn during editing when a selected template/model pair is incompatible, and block normal shortcut execution when required capabilities are missing.
-- Shortcut screenshots now send typed `LlmContentPart::ImageRef` PNG data URLs for image-capable models and fall back to the existing OCR text path otherwise.
-- Conversation panel, temporary detail, and chat form now pass the current user input as content parts while preserving ordinary text input as a single text part.
-- Persisted normal and temporary conversation history now carries `input_content_parts` instead of reconstructing context from rendered text or provider-specific request bodies.
-- Validation run:
+- 增加 `CapabilityRequirement` 和 `ModelCapabilities::{supports_requirement, missing_requirements}`，作为 templates、chat UI、shortcuts 的 typed compatibility surface。
+- 扩展尚未合入的 v6 template schema，增加 `conversation_templates.required_capabilities JSON NOT NULL DEFAULT '[]'`；v1-v5 migrations 为旧 templates 回填空列表。
+- 为 template create/edit 增加 required capabilities 控件，并在 template lists、template view dialogs、chat template picker 显示 compatibility/missing-capability 状态。
+- Chat 会保留不可兼容的 selected template 可见，但禁用发送并展示缺失 capabilities。
+- Shortcut settings 显示 `CapabilityMismatch`，编辑时在 selected template/model pair 不兼容时警告，并在 required capabilities 缺失时阻止正常 shortcut execution。
+- Shortcut screenshots 在 image-capable models 下发送 typed `LlmContentPart::ImageRef` PNG data URLs，否则 fallback 到现有 OCR text path。
+- Conversation panel、temporary detail、chat form 现在把当前 user input 作为 content parts 传递，同时保留普通 text input 为单个 text part。
+- Persisted normal 和 temporary conversation history 现在携带 `input_content_parts`，不再从 rendered text 或 provider-specific request bodies 重建 context。
+- 已运行验证：
   - `cargo fmt`
   - `cargo test -p ai-chat llm::types`
   - `cargo test -p ai-chat llm::provider`
@@ -263,8 +414,15 @@ The current implementation keeps request persistence additive: existing provider
   - `cargo test -p ai-chat state::workspace`
   - `cargo clippy -p ai-chat --all-targets --all-features -- -D warnings`
 
-## Next Child Issue Constraints
+## 下一个子 Issue 约束
 
-Next child issue is #154.
+下一个子 issue 是 #155。它不只是数据库表设计，还必须把 `ai-chat2` 并行重构、crate 拆分和后续 issue 重排固定下来。除非明确重新定义 scope，否则 #154 不应作为旧 `messages` table 上的窄补丁继续推进。
 
-#154 should consolidate message content so displayed content, edited content, sent content, exported content, resend behavior, and contextual history all derive from one provider-neutral source of truth. It should keep `messages.send_content` as a provider request snapshot/debug compatibility surface only, not the generic history source.
+- GitHub #155-#159 的 title/body 已与“后续 Issue 调整提案”保持一致；后续修改必须先更新文档再同步线上 issue，避免实现继续沿旧 `app/ai-chat` 原地改造路线推进。
+- #156 应从 `crates/ai-chat-core` 和 `crates/ai-chat-db` 开始，不应先改旧 app UI。
+- 从新的 canonical transcript schema 开始，不要继续迁移旧 `messages.content` / `send_content` / `input_content_parts` 模型。
+- 保持 legacy ai-chat databases 完整。不要覆盖它们，也不要要求完整自动迁移。
+- 实现前先决定 legacy access strategy：backup-only retention、read-only legacy viewer、manual export/import，或分阶段组合。
+- fresh schema version 和 migration ledger 必须存在数据库内部。文件名可以识别 fresh store，但 schema compatibility 必须从 database metadata 判断。
+- 新数据库必须保持 provider-neutral。OpenAI Responses continuation、Ollama local web tools、MCP calls、hosted tools、未来 provider-specific metadata 应通过 typed provider/tool extension points 附加。
+- `Provider` 只负责一次 provider run。Multi-step agent loops、tool execution、approvals、retries、continuation 属于 `AgentRuntime` 和 fresh persistence model。


### PR DESCRIPTION
## Summary

- Added the source-of-truth fresh database and data model design for the `ai-chat2` direction.
- Updated the #137 coordination doc so #155-#159 now map to the `ai-chat2` app plus `ai-chat-core`, `ai-chat-db`, `ai-chat-provider`, and `ai-chat-agent` crates.
- Affected app/crate: `ai-chat` docs.

## Motivation

- #155 is the design handoff for the next phase of the ai-chat agent rewrite.
- The old in-place `app/ai-chat` schema/runtime path is now explicitly replaced by a parallel `app/ai-chat2` and crate-split plan.

## Changes

- Documents the final fresh SQLite table model, table relationships, typed JSON/Rust payload mapping, and provider/agent boundary.
- Records the product decisions to remove folders/templates/modes from the new model, make projects real folders, and use cached provider model refreshes.
- Synchronizes the #137 coordination doc with the updated GitHub issue sequence for #155-#159.
- No Rust code, workspace members, migrations, or legacy app behavior changed.

## Validation

- [ ] `cargo build`
- [ ] `cargo test`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Manual verification completed for the affected docs/issue flow

Validation details:

```text
awk fenced-code-block check on both docs: passed
git diff --check: passed
rg trailing-whitespace check on both docs: no matches
gh issue view 155 --json number,title,body,state,url: confirmed updated #155 scope
gh issue list --state open --limit 100 --json number,title ...: confirmed #155-#159 titles

cargo fmt/test/clippy not run because this issue is documentation-only:
no Rust code, workspace manifest, migration, or generated schema changed.
```

## Risks

- Documentation-only change; the main risk is future implementation drifting from this plan.
- Follow-up implementation must keep #156 scoped to `ai-chat-core` / `ai-chat-db` and avoid starting UI migration early.

## Related Issues

- Closes #155
- Related to #137
