### PR TITLE
[tech] ai-chat-db: clean up SQLite types and constraints

### DIFF
--- a/app/ai-chat/docs/dev/fresh-database-schema.md
+++ b/app/ai-chat/docs/dev/fresh-database-schema.md
@@ -47,24 +47,22 @@ app/ai-chat/              # 现有应用，保持可运行和可回退
 app/ai-chat2/             # 新应用，薄 GPUI shell，只做窗口、路由、UI 状态组合
 crates/ai-chat-core/      # 领域数据契约：project、conversation item、content、prompt、run/tool 类型
 crates/ai-chat-db/        # fresh SQLite schema、migrations、typed repositories
-crates/ai-chat-provider/  # provider-neutral trait、capabilities、OpenAI/Ollama 等 adapter
-crates/ai-chat-agent/     # agent loop、tool registry、approval、continuation、cancel/retry
+crates/ai-chat-agent/     # Rig adapter、agent loop、tool registry、approval、continuation、cancel/retry
 ```
 
 拆分边界：
 
 - `ai-chat-core` 不依赖 GPUI、Diesel、HTTP client 或具体 provider。它只定义可序列化的数据契约和核心不变量。
 - `ai-chat-db` 依赖 `ai-chat-core`，负责 SQL `JSON` typed roundtrip、migration 和 repository transaction。全文搜索/FTS 暂未实现。
-- `ai-chat-provider` 依赖 `ai-chat-core`，负责把 canonical context 转换到 provider wire format，并把 provider stream 转回 provider-neutral events。
-- `ai-chat-agent` 依赖 `ai-chat-core`、`ai-chat-provider` 和 repository traits，负责多步 loop、tool execution、approval 和写入 canonical items。
+- `ai-chat-agent` 依赖 `ai-chat-core` 和 repository traits，负责把 canonical context 转换为 Rig messages、观测 provider step、执行多步 loop、tool execution、approval 和写入 canonical items。
 - `app/ai-chat2` 依赖这些 crates，但不拥有长期业务模型。UI 只消费 repository/agent API 和 `ai-chat-core` 类型。
 
 迁移策略：
 
 - #155 只固定文档、schema、Rust 数据契约和 issue 重排。
 - #156 先 scaffold `ai-chat-core` 和 `ai-chat-db`，并让 fresh database bootstrap 和 repository tests 可以独立通过；可同时创建最小 `app/ai-chat2` 壳，但不要求迁移 UI。
-- #157 把 provider-neutral trait、capabilities、adapter 边界沉淀到 `ai-chat-provider`。
-- #158 在 `ai-chat-agent` 中实现 agent loop 和持久化写入。
+- #157 清理 `ai-chat-db` fresh schema 的 SQLite 时间、布尔和 closed enum/status 类型约束。
+- #158 在 `ai-chat-agent` 中实现 Rig adapter、agent loop 和持久化写入。
 - #159 再让 `app/ai-chat2` 使用新 crates 渲染项目、对话、timeline、tool、approval 和多模态内容。
 - 旧 `app/ai-chat` 在迁移期间作为 legacy app 保持可用。legacy database 的读取、导出、导入或只读浏览策略必须显式实现，不能默默接入 fresh store。
 - 不预设“全部迁完后必须合并回 `app/ai-chat`”。如果拆出的 crates 是清晰边界，应保留它们；最终可以让 `app/ai-chat2` 替换旧 app，也可以让旧 app 逐步改为使用这些 crates。

--- a/app/ai-chat/docs/dev/issue-137-llm-abstractions.md
+++ b/app/ai-chat/docs/dev/issue-137-llm-abstractions.md
@@ -27,7 +27,7 @@
 | #154 | `codex/issue-154-typed-message-content` | 合并 typed message content model | 已被 fresh database 方向取代；除非重新定义 scope，否则只保留为上下文 |
 | #155 | `codex/issue-155-ai-chat2-crate-split` | 固定 `ai-chat2` 并行重构、crate 拆分、fresh database 和 typed data model | 设计文档已通过 PR #160 合入集成分支；GitHub issue 仍未关闭 |
 | #156 | `codex/issue-156-fresh-db-bootstrap` | scaffold `ai-chat-core` / `ai-chat-db`，实现 fresh database bootstrap 和 typed repositories | 已通过 PR #161 合入集成分支；GitHub issue 仍未关闭 |
-| #157 | `codex/issue-157-provider-runtime-crate` | 抽出 `ai-chat-provider`，沉淀 provider-neutral trait、capabilities 和 adapter 边界 | 待处理 |
+| #157 | `codex/issue-157-provider-runtime-crate` | 清理 `ai-chat-db` SQLite 时间、布尔和 closed enum/status 类型约束 | 进行中 |
 | #158 | `codex/issue-158-agent-runtime-persistence` | 建立 `ai-chat-agent`，用 Rig + rmcp 实现 agent loop、file-backed skills、MCP/tool/approval runtime 和持久化写入 | 待处理 |
 | #159 | `codex/issue-159-ai-chat2-ui` | 在 `app/ai-chat2` 渲染项目、对话、多步 reasoning、tool、approval、多模态 timeline | 待处理 |
 
@@ -47,13 +47,14 @@
 - 当前首选方向是设计 fresh ai-chat database schema，不再继续在旧 `messages.content` / `send_content` / `input_content_parts` 模型上叠 migration 和兼容逻辑。
 - #155 已通过 PR #160 把 `ai-chat2` 并行重构、crate 拆分、fresh database schema 和 typed data model 设计合入集成分支；GitHub issue 仍未关闭。
 - #156 已通过 PR #161 把 `codex/issue-156-fresh-db-bootstrap` 合入 `codex/issue-137-llm-abstractions`：新增 `ai-chat-core` / `ai-chat-db`，完成 fresh database bootstrap、typed payload、typed repository、migration ledger 和 legacy-store coexistence tests；未新增 `app/ai-chat2` 壳，全文搜索/FTS 暂未实现。GitHub issue 仍未关闭。
-- #157 已更新为：抽出 `ai-chat-provider`，把 provider-neutral trait、capabilities、OpenAI/Ollama adapter 边界从旧 app 债务中隔离出来。
+- #157 已调整为：清理 `ai-chat-db` fresh schema 的 SQLite 类型表达和约束，包括时间列、布尔列和 closed enum/status `CHECK`。
 - #158 已更新为：建立 `ai-chat-agent`，用 Rig + rmcp 实现 agent loop、file-backed skills、MCP/tool registry、approval、continuation、cancel/retry，并写入 fresh persistence。
 - #159 已更新为：让 `app/ai-chat2` 使用新 crates 渲染项目、对话、timeline、tool、approval 和多模态内容。
 - 2026-05-23 已读取并更新 GitHub #137、#155-#159。#137 正文已指向 `ai-chat2` 并行重构和新的子 issue 序列；#155-#159 title/body 已按“后续 Issue 调整提案”同步；PR #160 已把 #155 设计文档合入集成分支。
 - 2026-05-24 已同步 GitHub #137、#156、#158：agent runtime 采用 Rig + rmcp；skills 和 MCP server 配置从文件/配置读取，不作为 fresh database source tables。现有 fresh DB 结构支持 Rig execution persistence，只需补充 runtime snapshot、skill activation transcript item 和 runtime tool name 映射。
 - 2026-05-24 已完成 #156 本地实现和验证：`cargo test -p ai-chat-core`、`cargo test -p ai-chat-db`、`cargo clippy -p ai-chat-core --all-targets --all-features -- -D warnings`、`cargo clippy -p ai-chat-db --all-targets --all-features -- -D warnings` 和 `git diff --check` 均通过。
 - 2026-05-26 已同步 GitHub #137、#156-#159 和 PR 状态：PR #161 已合入集成分支；#156-#159 仍为 open issues；下一步实现子 issue 是 #157。
+- 2026-05-26 决定不再为 Rig 路线保留独立 `ai-chat-provider` crate。#157 改为数据库类型/约束清理；Rig adapter、provider step 持久化和 provider 观测边界归入 #158 的 `ai-chat-agent`。
 
 ## 当前架构事实
 
@@ -146,7 +147,7 @@ Issue #139 建立了以下 Rust 运行时类型：
 高层决策：
 
 - 新模型通过 `app/ai-chat2` 和独立 crates 落地，不在旧 `app/ai-chat` 内做原地大重构。旧 app 保持可运行，用作 legacy path。
-- `app/ai-chat2` 是薄 GPUI shell。领域模型、fresh database、provider adapter、agent runtime 分别进入 `ai-chat-core`、`ai-chat-db`、`ai-chat-provider`、`ai-chat-agent`。
+- `app/ai-chat2` 是薄 GPUI shell。领域模型、fresh database、agent runtime 分别进入 `ai-chat-core`、`ai-chat-db`、`ai-chat-agent`；Rig provider adapter 和 provider step 观测边界属于 `ai-chat-agent`。
 - #156 优先创建 `ai-chat-core` 和 `ai-chat-db`，让 schema bootstrap 和 typed repository tests 独立通过；UI 迁移留给 #159。
 - 使用 SQLite-first fresh store，typed JSON payload 必须落到 SQL `JSON` 列。每个 app 自有 JSON 列必须映射到一个具名 Rust 类型，并使用严格 serde 解码；不要使用 `TEXT` 列保存 JSON 字符串。
 - 项目就是实际文件夹。scratch 或 no-project chats 必须使用 app 创建的 scratch folder，并写入 `projects` 行。
@@ -170,16 +171,14 @@ app/ai-chat/              # 现有 legacy app，迁移期保持可运行
 app/ai-chat2/             # 新 GPUI app shell，只组合 UI、窗口、路由和状态
 crates/ai-chat-core/      # 领域数据契约和核心不变量
 crates/ai-chat-db/        # fresh SQLite schema、migrations、typed repositories
-crates/ai-chat-provider/  # provider-neutral trait、capabilities、OpenAI/Ollama adapter
-crates/ai-chat-agent/     # agent loop、tool registry、approval、continuation、cancel/retry
+crates/ai-chat-agent/     # Rig adapter、agent loop、tool registry、approval、continuation、cancel/retry
 ```
 
 边界约束：
 
 - `ai-chat-core` 不能依赖 GPUI、Diesel、HTTP client 或具体 provider。
 - `ai-chat-db` 依赖 `ai-chat-core`，负责 SQL `JSON` typed roundtrip、migration 和 repository transaction。全文搜索/FTS 暂未实现，是否需要单独搜索索引留给后续 issue 决定。
-- `ai-chat-provider` 依赖 `ai-chat-core`，负责 provider wire conversion 和 provider-step events。
-- `ai-chat-agent` 依赖 core/provider/repository traits，负责 Rig + rmcp 多步 agent loop、tool registry、file-backed skills、MCP runtime、approval 和 canonical item 写入。
+- `ai-chat-agent` 依赖 core 和 repository traits，负责 Rig + rmcp 多步 agent loop、Rig message conversion、provider step 观测、tool registry、file-backed skills、MCP runtime、approval 和 canonical item 写入。
 - `app/ai-chat2` 只依赖这些 crates，不重新拥有长期业务模型。
 - 旧 `app/ai-chat` 不在 #156-#159 中被强制迁移；它可以继续承载 legacy UI 和旧数据库访问，直到有明确替代策略。
 
@@ -206,7 +205,7 @@ crates/ai-chat-agent/     # agent loop、tool registry、approval、continuation
 范围：
 
 - 明确采用 `app/ai-chat2` 并行重构，而不是在旧 `app/ai-chat` 中原地替换全部数据层和 UI。
-- 定义 `ai-chat-core`、`ai-chat-db`、`ai-chat-provider`、`ai-chat-agent`、`app/ai-chat2` 的 ownership boundary。
+- 定义 `ai-chat-core`、`ai-chat-db`、`ai-chat-agent`、`app/ai-chat2` 的 ownership boundary。
 - 围绕 projects、canonical conversation items、agent runs、provider steps、tool invocations、approvals、usage events、prompts、shortcuts、providers、provider model caches、app settings、deduplicated attachments 定义新 schema。
 - 在实现前定义每个 app 自有 JSON payload 对应的 Rust 类型。Repository API 中不要留下含糊的 `serde_json::Value` payload。
 - 决定新 database file name 和 bootstrap strategy。新 store 不能覆盖已有 v1-v6 stores。
@@ -236,18 +235,18 @@ crates/ai-chat-agent/     # agent loop、tool registry、approval、continuation
 - 增加 tests，覆盖 new database creation、internal version detection、repeated idempotent bootstrap、empty first run、transaction boundaries、cascade deletes、item ordering、typed JSON roundtrip、provider model cache persistence、legacy-store coexistence。
 - 全文搜索/FTS 不在 #156 实现。`conversation_items.search_text` 仅作为普通派生文本字段保留，后续如果确认需要搜索，再单独设计 FTS、external-content FTS 或其他索引方案。
 
-### #157 provider runtime crate
+### #157 ai-chat-db SQLite 类型清理
 
-标题建议：`[tech] ai-chat: extract provider-neutral runtime crate for ai-chat2`
+标题建议：`[tech] ai-chat-db: clean up SQLite types and constraints`
 
 范围：
 
-- 新增 `crates/ai-chat-provider`，承载 provider-neutral provider trait、provider-step request/event/state、model capability snapshots 和 adapter conversion。
-- 保持 `Provider` 只负责一次 provider run，不执行 local/MCP tools，不拥有 multi-step loop。
-- 把 OpenAI Responses、Ollama chat/show 等 provider-specific request/stream conversion 留在 adapter 内。
-- provider request/response snapshot 只进入 `provider_steps` debug/replay path，不成为 canonical chat history。
-- provider models 采用设置页手动刷新、保存到 `provider_models`、启动读缓存的策略。
-- 增加 tests，覆盖 capability mapping、unsupported content rejection、provider-specific extension roundtrip、request snapshot redaction boundary。
+- 不新增 `ai-chat-provider` crate；未来 Rig provider integration 归入 #158 的 `ai-chat-agent`。
+- 在 `crates/ai-chat-db` fresh schema 中把时间列改为 SQLite `DateTime`，Diesel schema 映射为 `TimestamptzSqlite`，repository row 使用 `OffsetDateTime`。
+- 将 `providers.enabled`、`prompts.enabled`、`shortcuts.enabled` 表达为 `BOOLEAN NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1))`。
+- 给 `agent_runs.status`、`provider_steps.status`、`tool_invocations.status`、`conversation_items.kind`、`conversation_items.status` 等 closed enum/status 列补充 `CHECK`。
+- 不做 legacy schema 兼容迁移；只修改 fresh schema、typed Diesel schema 和 repository 映射。
+- 增加 tests，覆盖 bootstrap DDL、非法 boolean、非法 enum/status 和 repository `OffsetDateTime` roundtrip。
 
 ### #158 agent runtime 和持久化
 
@@ -428,7 +427,7 @@ crates/ai-chat-agent/     # agent loop、tool registry、approval、continuation
 
 ## 下一个子 Issue 约束
 
-#156 已通过 PR #161 完成 fresh core/db bootstrap 并合入集成分支。下一步实现子 issue 是 #157，用于抽出 provider runtime crate。#155 已把 `ai-chat2` 并行重构、crate 拆分和后续 issue 重排固定到设计文档中。除非明确重新定义 scope，否则 #154 不应作为旧 `messages` table 上的窄补丁继续推进。
+#156 已通过 PR #161 完成 fresh core/db bootstrap 并合入集成分支。下一步实现子 issue 是 #157，用于清理 fresh SQLite schema 的时间、布尔和 closed enum/status 类型约束。#155 已把 `ai-chat2` 并行重构、crate 拆分和后续 issue 重排固定到设计文档中。除非明确重新定义 scope，否则 #154 不应作为旧 `messages` table 上的窄补丁继续推进。
 
 - GitHub #155-#159 的 title/body 已与“后续 Issue 调整提案”保持一致；后续修改必须先更新文档再同步线上 issue，避免实现继续沿旧 `app/ai-chat` 原地改造路线推进。
 - #156 已从 `crates/ai-chat-core` 和 `crates/ai-chat-db` 落地；没有先改旧 app UI，也没有新增 `app/ai-chat2` shell。

--- a/crates/ai-chat-db/Cargo.toml
+++ b/crates/ai-chat-db/Cargo.toml
@@ -8,6 +8,7 @@ ai-chat-core.workspace = true
 diesel = { version = "2.3.9", features = [
   "sqlite",
   "r2d2",
+  "time",
   "returning_clauses_for_sqlite_3_35",
   "serde_json",
 ] }

--- a/crates/ai-chat-db/src/migrations.rs
+++ b/crates/ai-chat-db/src/migrations.rs
@@ -7,7 +7,7 @@ use crate::{
 use diesel::{
     connection::SimpleConnection, prelude::*, sql_query, sql_types::Text, upsert::excluded,
 };
-use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+use time::OffsetDateTime;
 
 pub(crate) const SCHEMA_VERSION: i32 = 1;
 
@@ -24,7 +24,7 @@ pub(crate) const MIGRATIONS: &[Migration] = &[Migration {
 const CREATE_FRESH_SCHEMA_SQL: &str = r#"
 CREATE TABLE schema_migrations (
     name TEXT PRIMARY KEY,
-    executed_at TEXT NOT NULL
+    executed_at DateTime NOT NULL
 );
 
 CREATE TABLE schema_metadata (
@@ -33,8 +33,8 @@ CREATE TABLE schema_metadata (
     created_app_version TEXT,
     last_opened_app_version TEXT,
     payload_json JSON NOT NULL DEFAULT '{}',
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
+    created_at DateTime NOT NULL,
+    updated_at DateTime NOT NULL
 );
 
 CREATE TABLE projects (
@@ -43,30 +43,30 @@ CREATE TABLE projects (
     display_name TEXT NOT NULL,
     kind TEXT NOT NULL CHECK (kind IN ('normal', 'scratch')),
     metadata_json JSON NOT NULL DEFAULT '{}',
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    last_opened_at TEXT
+    created_at DateTime NOT NULL,
+    updated_at DateTime NOT NULL,
+    last_opened_at DateTime
 );
 
 CREATE TABLE providers (
     id TEXT PRIMARY KEY,
     kind TEXT NOT NULL,
     display_name TEXT NOT NULL,
-    enabled INTEGER NOT NULL DEFAULT 1,
+    enabled BOOLEAN NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
     settings_json JSON NOT NULL DEFAULT '{}',
     secret_refs_json JSON NOT NULL DEFAULT '{}',
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
+    created_at DateTime NOT NULL,
+    updated_at DateTime NOT NULL
 );
 
 CREATE TABLE prompts (
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL UNIQUE,
     content_json JSON NOT NULL,
-    enabled INTEGER NOT NULL DEFAULT 1,
+    enabled BOOLEAN NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
     sort_order INTEGER NOT NULL DEFAULT 0,
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
+    created_at DateTime NOT NULL,
+    updated_at DateTime NOT NULL
 );
 
 CREATE TABLE provider_models (
@@ -76,9 +76,9 @@ CREATE TABLE provider_models (
     display_name TEXT,
     capabilities_json JSON NOT NULL,
     metadata_json JSON NOT NULL DEFAULT '{}',
-    fetched_at TEXT NOT NULL,
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
+    fetched_at DateTime NOT NULL,
+    created_at DateTime NOT NULL,
+    updated_at DateTime NOT NULL,
     UNIQUE(provider_id, model_id)
 );
 
@@ -93,10 +93,10 @@ CREATE TABLE conversations (
     last_item_seq INTEGER NOT NULL DEFAULT 0,
     metadata_json JSON NOT NULL DEFAULT '{}',
     settings_snapshot_json JSON NOT NULL DEFAULT '{}',
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    archived_at TEXT,
-    deleted_at TEXT
+    created_at DateTime NOT NULL,
+    updated_at DateTime NOT NULL,
+    archived_at DateTime,
+    deleted_at DateTime
 );
 
 CREATE TABLE attachments (
@@ -113,22 +113,22 @@ CREATE TABLE attachments (
     sha256 TEXT,
     size_bytes INTEGER,
     metadata_json JSON NOT NULL DEFAULT '{}',
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
+    created_at DateTime NOT NULL,
+    updated_at DateTime NOT NULL
 );
 
 CREATE TABLE agent_runs (
     id TEXT PRIMARY KEY,
     conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
     trigger_kind TEXT NOT NULL CHECK (trigger_kind IN ('user', 'shortcut', 'resume', 'retry')),
-    status TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'waiting_for_approval', 'completed', 'failed', 'canceled')),
     input_json JSON NOT NULL,
     output_json JSON,
     error_json JSON,
-    created_at TEXT NOT NULL,
-    started_at TEXT,
-    completed_at TEXT,
-    updated_at TEXT NOT NULL
+    created_at DateTime NOT NULL,
+    started_at DateTime,
+    completed_at DateTime,
+    updated_at DateTime NOT NULL
 );
 
 CREATE TABLE provider_steps (
@@ -137,16 +137,16 @@ CREATE TABLE provider_steps (
     seq INTEGER NOT NULL,
     provider_id TEXT NOT NULL REFERENCES providers(id),
     model_id TEXT NOT NULL,
-    status TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'completed', 'failed', 'canceled')),
     request_snapshot_json JSON NOT NULL,
     response_snapshot_json JSON,
     state_snapshot_json JSON,
     settings_snapshot_json JSON NOT NULL,
     error_json JSON,
-    created_at TEXT NOT NULL,
-    started_at TEXT,
-    completed_at TEXT,
-    updated_at TEXT NOT NULL,
+    created_at DateTime NOT NULL,
+    started_at DateTime,
+    completed_at DateTime,
+    updated_at DateTime NOT NULL,
     UNIQUE(agent_run_id, seq)
 );
 
@@ -160,30 +160,30 @@ CREATE TABLE tool_invocations (
     server_id TEXT,
     tool_name TEXT NOT NULL,
     runtime_tool_name TEXT NOT NULL,
-    status TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('requested', 'awaiting_approval', 'running', 'succeeded', 'failed', 'denied', 'canceled')),
     input_json JSON NOT NULL,
     output_json JSON,
     error_json JSON,
-    created_at TEXT NOT NULL,
-    started_at TEXT,
-    completed_at TEXT,
-    updated_at TEXT NOT NULL
+    created_at DateTime NOT NULL,
+    started_at DateTime,
+    completed_at DateTime,
+    updated_at DateTime NOT NULL
 );
 
 CREATE TABLE conversation_items (
     id TEXT PRIMARY KEY,
     conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
     seq INTEGER NOT NULL,
-    kind TEXT NOT NULL,
-    status TEXT NOT NULL,
+    kind TEXT NOT NULL CHECK (kind IN ('message', 'skill_activation', 'reasoning', 'tool_call', 'tool_result', 'approval_request', 'approval_decision', 'status', 'error')),
+    status TEXT NOT NULL CHECK (status IN ('pending', 'running', 'completed', 'failed', 'canceled', 'waiting_for_approval')),
     agent_run_id TEXT REFERENCES agent_runs(id) ON DELETE SET NULL,
     provider_step_id TEXT REFERENCES provider_steps(id) ON DELETE SET NULL,
     tool_invocation_id TEXT REFERENCES tool_invocations(id) ON DELETE SET NULL,
     provider_item_id TEXT,
     payload_json JSON NOT NULL,
     search_text TEXT NOT NULL DEFAULT '',
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
+    created_at DateTime NOT NULL,
+    updated_at DateTime NOT NULL,
     UNIQUE(conversation_id, seq)
 );
 
@@ -193,9 +193,9 @@ CREATE TABLE approval_decisions (
     status TEXT NOT NULL CHECK (status IN ('pending', 'approved', 'denied', 'expired', 'canceled')),
     request_json JSON NOT NULL,
     decision_json JSON,
-    requested_at TEXT NOT NULL,
-    decided_at TEXT,
-    expires_at TEXT
+    requested_at DateTime NOT NULL,
+    decided_at DateTime,
+    expires_at DateTime
 );
 
 CREATE TABLE usage_events (
@@ -212,28 +212,28 @@ CREATE TABLE usage_events (
     reasoning_tokens INTEGER NOT NULL DEFAULT 0,
     total_tokens INTEGER NOT NULL DEFAULT 0,
     usage_json JSON NOT NULL,
-    created_at TEXT NOT NULL
+    created_at DateTime NOT NULL
 );
 
 CREATE TABLE shortcuts (
     id TEXT PRIMARY KEY,
     hotkey TEXT NOT NULL UNIQUE,
-    enabled INTEGER NOT NULL DEFAULT 1,
+    enabled BOOLEAN NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
     prompt_id TEXT REFERENCES prompts(id) ON DELETE SET NULL,
     provider_id TEXT REFERENCES providers(id) ON DELETE SET NULL,
     model_id TEXT,
     input_source TEXT NOT NULL CHECK (input_source IN ('selection_or_clipboard', 'screenshot')),
     action_json JSON NOT NULL,
     settings_snapshot_json JSON NOT NULL DEFAULT '{}',
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
+    created_at DateTime NOT NULL,
+    updated_at DateTime NOT NULL
 );
 
 CREATE TABLE app_settings (
     id TEXT PRIMARY KEY DEFAULT 'default',
     settings_json JSON NOT NULL DEFAULT '{}',
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
+    created_at DateTime NOT NULL,
+    updated_at DateTime NOT NULL
 );
 
 CREATE INDEX idx_conversations_project_id ON conversations(project_id);
@@ -350,8 +350,8 @@ fn existing_schema_version(conn: &mut SqliteConnection) -> Result<Option<i32>> {
         .optional()?)
 }
 
-fn now_string() -> Result<String> {
-    Ok(OffsetDateTime::now_utc().format(&Rfc3339)?)
+fn now_string() -> Result<OffsetDateTime> {
+    Ok(OffsetDateTime::now_utc())
 }
 
 #[cfg(test)]

--- a/crates/ai-chat-db/src/models.rs
+++ b/crates/ai-chat-db/src/models.rs
@@ -3,13 +3,13 @@ use ai_chat_core::*;
 use diesel::prelude::*;
 use serde::{Serialize, de::DeserializeOwned};
 use serde_json::Value;
-use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+use time::OffsetDateTime;
 
 #[derive(Debug, Clone, Insertable)]
 #[diesel(table_name = schema_migrations)]
 pub(crate) struct SqlNewSchemaMigrationRow {
     pub(crate) name: String,
-    pub(crate) executed_at: String,
+    pub(crate) executed_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable)]
@@ -21,8 +21,8 @@ pub(crate) struct SqlSchemaMetadataRow {
     pub(crate) created_app_version: Option<String>,
     pub(crate) last_opened_app_version: Option<String>,
     pub(crate) payload_json: Value,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -33,8 +33,8 @@ pub(crate) struct SqlNewSchemaMetadataRow {
     pub(crate) created_app_version: Option<String>,
     pub(crate) last_opened_app_version: Option<String>,
     pub(crate) payload_json: Value,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable)]
@@ -46,9 +46,9 @@ pub(crate) struct SqlProjectRow {
     pub(crate) display_name: String,
     pub(crate) kind: String,
     pub(crate) metadata_json: Value,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
-    pub(crate) last_opened_at: Option<String>,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
+    pub(crate) last_opened_at: Option<OffsetDateTime>,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -59,9 +59,9 @@ pub(crate) struct SqlNewProjectRow {
     pub(crate) display_name: String,
     pub(crate) kind: String,
     pub(crate) metadata_json: Value,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
-    pub(crate) last_opened_at: Option<String>,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
+    pub(crate) last_opened_at: Option<OffsetDateTime>,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable)]
@@ -78,10 +78,10 @@ pub(crate) struct SqlConversationRow {
     pub(crate) last_item_seq: i32,
     pub(crate) metadata_json: Value,
     pub(crate) settings_snapshot_json: Value,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
-    pub(crate) archived_at: Option<String>,
-    pub(crate) deleted_at: Option<String>,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
+    pub(crate) archived_at: Option<OffsetDateTime>,
+    pub(crate) deleted_at: Option<OffsetDateTime>,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -97,10 +97,10 @@ pub(crate) struct SqlNewConversationRow {
     pub(crate) last_item_seq: i32,
     pub(crate) metadata_json: Value,
     pub(crate) settings_snapshot_json: Value,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
-    pub(crate) archived_at: Option<String>,
-    pub(crate) deleted_at: Option<String>,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
+    pub(crate) archived_at: Option<OffsetDateTime>,
+    pub(crate) deleted_at: Option<OffsetDateTime>,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable)]
@@ -118,8 +118,8 @@ pub(crate) struct SqlConversationItemRow {
     pub(crate) provider_item_id: Option<String>,
     pub(crate) payload_json: Value,
     pub(crate) search_text: String,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -136,8 +136,8 @@ pub(crate) struct SqlNewConversationItemRow {
     pub(crate) provider_item_id: Option<String>,
     pub(crate) payload_json: Value,
     pub(crate) search_text: String,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, AsChangeset)]
@@ -147,7 +147,7 @@ pub(crate) struct SqlConversationItemPayloadChanges {
     pub(crate) status: String,
     pub(crate) payload_json: Value,
     pub(crate) search_text: String,
-    pub(crate) updated_at: String,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable)]
@@ -167,8 +167,8 @@ pub(crate) struct SqlAttachmentRow {
     pub(crate) sha256: Option<String>,
     pub(crate) size_bytes: Option<i64>,
     pub(crate) metadata_json: Value,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -187,8 +187,8 @@ pub(crate) struct SqlNewAttachmentRow {
     pub(crate) sha256: Option<String>,
     pub(crate) size_bytes: Option<i64>,
     pub(crate) metadata_json: Value,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable)]
@@ -202,10 +202,10 @@ pub(crate) struct SqlAgentRunRow {
     pub(crate) input_json: Value,
     pub(crate) output_json: Option<Value>,
     pub(crate) error_json: Option<Value>,
-    pub(crate) created_at: String,
-    pub(crate) started_at: Option<String>,
-    pub(crate) completed_at: Option<String>,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) started_at: Option<OffsetDateTime>,
+    pub(crate) completed_at: Option<OffsetDateTime>,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -218,10 +218,10 @@ pub(crate) struct SqlNewAgentRunRow {
     pub(crate) input_json: Value,
     pub(crate) output_json: Option<Value>,
     pub(crate) error_json: Option<Value>,
-    pub(crate) created_at: String,
-    pub(crate) started_at: Option<String>,
-    pub(crate) completed_at: Option<String>,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) started_at: Option<OffsetDateTime>,
+    pub(crate) completed_at: Option<OffsetDateTime>,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable)]
@@ -239,10 +239,10 @@ pub(crate) struct SqlProviderStepRow {
     pub(crate) state_snapshot_json: Option<Value>,
     pub(crate) settings_snapshot_json: Value,
     pub(crate) error_json: Option<Value>,
-    pub(crate) created_at: String,
-    pub(crate) started_at: Option<String>,
-    pub(crate) completed_at: Option<String>,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) started_at: Option<OffsetDateTime>,
+    pub(crate) completed_at: Option<OffsetDateTime>,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -259,10 +259,10 @@ pub(crate) struct SqlNewProviderStepRow {
     pub(crate) state_snapshot_json: Option<Value>,
     pub(crate) settings_snapshot_json: Value,
     pub(crate) error_json: Option<Value>,
-    pub(crate) created_at: String,
-    pub(crate) started_at: Option<String>,
-    pub(crate) completed_at: Option<String>,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) started_at: Option<OffsetDateTime>,
+    pub(crate) completed_at: Option<OffsetDateTime>,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable)]
@@ -282,10 +282,10 @@ pub(crate) struct SqlToolInvocationRow {
     pub(crate) input_json: Value,
     pub(crate) output_json: Option<Value>,
     pub(crate) error_json: Option<Value>,
-    pub(crate) created_at: String,
-    pub(crate) started_at: Option<String>,
-    pub(crate) completed_at: Option<String>,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) started_at: Option<OffsetDateTime>,
+    pub(crate) completed_at: Option<OffsetDateTime>,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -304,10 +304,10 @@ pub(crate) struct SqlNewToolInvocationRow {
     pub(crate) input_json: Value,
     pub(crate) output_json: Option<Value>,
     pub(crate) error_json: Option<Value>,
-    pub(crate) created_at: String,
-    pub(crate) started_at: Option<String>,
-    pub(crate) completed_at: Option<String>,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) started_at: Option<OffsetDateTime>,
+    pub(crate) completed_at: Option<OffsetDateTime>,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable)]
@@ -319,9 +319,9 @@ pub(crate) struct SqlApprovalDecisionRow {
     pub(crate) status: String,
     pub(crate) request_json: Value,
     pub(crate) decision_json: Option<Value>,
-    pub(crate) requested_at: String,
-    pub(crate) decided_at: Option<String>,
-    pub(crate) expires_at: Option<String>,
+    pub(crate) requested_at: OffsetDateTime,
+    pub(crate) decided_at: Option<OffsetDateTime>,
+    pub(crate) expires_at: Option<OffsetDateTime>,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -332,9 +332,9 @@ pub(crate) struct SqlNewApprovalDecisionRow {
     pub(crate) status: String,
     pub(crate) request_json: Value,
     pub(crate) decision_json: Option<Value>,
-    pub(crate) requested_at: String,
-    pub(crate) decided_at: Option<String>,
-    pub(crate) expires_at: Option<String>,
+    pub(crate) requested_at: OffsetDateTime,
+    pub(crate) decided_at: Option<OffsetDateTime>,
+    pub(crate) expires_at: Option<OffsetDateTime>,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable)]
@@ -354,7 +354,7 @@ pub(crate) struct SqlUsageEventRow {
     pub(crate) reasoning_tokens: i64,
     pub(crate) total_tokens: i64,
     pub(crate) usage_json: Value,
-    pub(crate) created_at: String,
+    pub(crate) created_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -373,7 +373,7 @@ pub(crate) struct SqlNewUsageEventRow {
     pub(crate) reasoning_tokens: i64,
     pub(crate) total_tokens: i64,
     pub(crate) usage_json: Value,
-    pub(crate) created_at: String,
+    pub(crate) created_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable)]
@@ -385,8 +385,8 @@ pub(crate) struct SqlPromptRow {
     pub(crate) content_json: Value,
     pub(crate) enabled: bool,
     pub(crate) sort_order: i32,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -397,8 +397,8 @@ pub(crate) struct SqlNewPromptRow {
     pub(crate) content_json: Value,
     pub(crate) enabled: bool,
     pub(crate) sort_order: i32,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable)]
@@ -414,8 +414,8 @@ pub(crate) struct SqlShortcutRow {
     pub(crate) input_source: String,
     pub(crate) action_json: Value,
     pub(crate) settings_snapshot_json: Value,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -430,8 +430,8 @@ pub(crate) struct SqlNewShortcutRow {
     pub(crate) input_source: String,
     pub(crate) action_json: Value,
     pub(crate) settings_snapshot_json: Value,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable)]
@@ -444,8 +444,8 @@ pub(crate) struct SqlProviderRow {
     pub(crate) enabled: bool,
     pub(crate) settings_json: Value,
     pub(crate) secret_refs_json: Value,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -457,8 +457,8 @@ pub(crate) struct SqlNewProviderRow {
     pub(crate) enabled: bool,
     pub(crate) settings_json: Value,
     pub(crate) secret_refs_json: Value,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable)]
@@ -471,9 +471,9 @@ pub(crate) struct SqlProviderModelRow {
     pub(crate) display_name: Option<String>,
     pub(crate) capabilities_json: Value,
     pub(crate) metadata_json: Value,
-    pub(crate) fetched_at: String,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
+    pub(crate) fetched_at: OffsetDateTime,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -485,9 +485,9 @@ pub(crate) struct SqlNewProviderModelRow {
     pub(crate) display_name: Option<String>,
     pub(crate) capabilities_json: Value,
     pub(crate) metadata_json: Value,
-    pub(crate) fetched_at: String,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
+    pub(crate) fetched_at: OffsetDateTime,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Queryable, Selectable)]
@@ -496,8 +496,8 @@ pub(crate) struct SqlNewProviderModelRow {
 pub(crate) struct SqlAppSettingsRow {
     pub(crate) id: String,
     pub(crate) settings_json: Value,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -505,8 +505,8 @@ pub(crate) struct SqlAppSettingsRow {
 pub(crate) struct SqlNewAppSettingsRow {
     pub(crate) id: String,
     pub(crate) settings_json: Value,
-    pub(crate) created_at: String,
-    pub(crate) updated_at: String,
+    pub(crate) created_at: OffsetDateTime,
+    pub(crate) updated_at: OffsetDateTime,
 }
 
 impl TryFrom<SqlSchemaMetadataRow> for SchemaMetadataRecord {
@@ -524,8 +524,8 @@ impl TryFrom<SqlSchemaMetadataRow> for SchemaMetadataRecord {
             created_app_version: row.created_app_version,
             last_opened_app_version: row.last_opened_app_version,
             payload: from_json(row.payload_json)?,
-            created_at: parse_time(row.created_at)?,
-            updated_at: parse_time(row.updated_at)?,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
         })
     }
 }
@@ -540,9 +540,9 @@ impl TryFrom<SqlProjectRow> for ProjectRecord {
             display_name: row.display_name,
             kind: db_label_parse(row.kind)?,
             metadata: from_json(row.metadata_json)?,
-            created_at: parse_time(row.created_at)?,
-            updated_at: parse_time(row.updated_at)?,
-            last_opened_at: parse_time_opt(row.last_opened_at)?,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            last_opened_at: row.last_opened_at,
         })
     }
 }
@@ -562,10 +562,10 @@ impl TryFrom<SqlConversationRow> for ConversationRecord {
             last_item_seq: row.last_item_seq,
             metadata: from_json(row.metadata_json)?,
             settings_snapshot: from_json(row.settings_snapshot_json)?,
-            created_at: parse_time(row.created_at)?,
-            updated_at: parse_time(row.updated_at)?,
-            archived_at: parse_time_opt(row.archived_at)?,
-            deleted_at: parse_time_opt(row.deleted_at)?,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            archived_at: row.archived_at,
+            deleted_at: row.deleted_at,
         })
     }
 }
@@ -593,8 +593,8 @@ impl TryFrom<SqlConversationItemRow> for ConversationItemRecord {
             provider_item_id: row.provider_item_id,
             payload,
             search_text: row.search_text,
-            created_at: parse_time(row.created_at)?,
-            updated_at: parse_time(row.updated_at)?,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
         })
     }
 }
@@ -617,8 +617,8 @@ impl TryFrom<SqlAttachmentRow> for AttachmentRecord {
             sha256: row.sha256,
             size_bytes: row.size_bytes,
             metadata: from_json(row.metadata_json)?,
-            created_at: parse_time(row.created_at)?,
-            updated_at: parse_time(row.updated_at)?,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
         })
     }
 }
@@ -635,10 +635,10 @@ impl TryFrom<SqlAgentRunRow> for AgentRunRecord {
             input: from_json(row.input_json)?,
             output: from_json_opt(row.output_json)?,
             error: from_json_opt(row.error_json)?,
-            created_at: parse_time(row.created_at)?,
-            started_at: parse_time_opt(row.started_at)?,
-            completed_at: parse_time_opt(row.completed_at)?,
-            updated_at: parse_time(row.updated_at)?,
+            created_at: row.created_at,
+            started_at: row.started_at,
+            completed_at: row.completed_at,
+            updated_at: row.updated_at,
         })
     }
 }
@@ -659,10 +659,10 @@ impl TryFrom<SqlProviderStepRow> for ProviderStepRecord {
             state_snapshot: from_json_opt(row.state_snapshot_json)?,
             settings_snapshot: from_json(row.settings_snapshot_json)?,
             error: from_json_opt(row.error_json)?,
-            created_at: parse_time(row.created_at)?,
-            started_at: parse_time_opt(row.started_at)?,
-            completed_at: parse_time_opt(row.completed_at)?,
-            updated_at: parse_time(row.updated_at)?,
+            created_at: row.created_at,
+            started_at: row.started_at,
+            completed_at: row.completed_at,
+            updated_at: row.updated_at,
         })
     }
 }
@@ -695,10 +695,10 @@ impl TryFrom<SqlToolInvocationRow> for ToolInvocationRecord {
             input,
             output: from_json_opt(row.output_json)?,
             error: from_json_opt(row.error_json)?,
-            created_at: parse_time(row.created_at)?,
-            started_at: parse_time_opt(row.started_at)?,
-            completed_at: parse_time_opt(row.completed_at)?,
-            updated_at: parse_time(row.updated_at)?,
+            created_at: row.created_at,
+            started_at: row.started_at,
+            completed_at: row.completed_at,
+            updated_at: row.updated_at,
         })
     }
 }
@@ -713,9 +713,9 @@ impl TryFrom<SqlApprovalDecisionRow> for ApprovalDecisionRecord {
             status: db_label_parse(row.status)?,
             request: from_json(row.request_json)?,
             decision: from_json_opt(row.decision_json)?,
-            requested_at: parse_time(row.requested_at)?,
-            decided_at: parse_time_opt(row.decided_at)?,
-            expires_at: parse_time_opt(row.expires_at)?,
+            requested_at: row.requested_at,
+            decided_at: row.decided_at,
+            expires_at: row.expires_at,
         })
     }
 }
@@ -738,7 +738,7 @@ impl TryFrom<SqlUsageEventRow> for UsageEventRecord {
             reasoning_tokens: row.reasoning_tokens,
             total_tokens: row.total_tokens,
             usage: from_json(row.usage_json)?,
-            created_at: parse_time(row.created_at)?,
+            created_at: row.created_at,
         })
     }
 }
@@ -753,8 +753,8 @@ impl TryFrom<SqlPromptRow> for PromptRecord {
             content: from_json(row.content_json)?,
             enabled: row.enabled,
             sort_order: row.sort_order,
-            created_at: parse_time(row.created_at)?,
-            updated_at: parse_time(row.updated_at)?,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
         })
     }
 }
@@ -773,8 +773,8 @@ impl TryFrom<SqlShortcutRow> for ShortcutRecord {
             input_source: db_label_parse(row.input_source)?,
             action: from_json(row.action_json)?,
             settings_snapshot: from_json(row.settings_snapshot_json)?,
-            created_at: parse_time(row.created_at)?,
-            updated_at: parse_time(row.updated_at)?,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
         })
     }
 }
@@ -790,8 +790,8 @@ impl TryFrom<SqlProviderRow> for ProviderRecord {
             enabled: row.enabled,
             settings: from_json(row.settings_json)?,
             secret_refs: from_json(row.secret_refs_json)?,
-            created_at: parse_time(row.created_at)?,
-            updated_at: parse_time(row.updated_at)?,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
         })
     }
 }
@@ -807,9 +807,9 @@ impl TryFrom<SqlProviderModelRow> for ProviderModelRecord {
             display_name: row.display_name,
             capabilities: from_json(row.capabilities_json)?,
             metadata: from_json(row.metadata_json)?,
-            fetched_at: parse_time(row.fetched_at)?,
-            created_at: parse_time(row.created_at)?,
-            updated_at: parse_time(row.updated_at)?,
+            fetched_at: row.fetched_at,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
         })
     }
 }
@@ -821,22 +821,10 @@ impl TryFrom<SqlAppSettingsRow> for AppSettingsRecord {
         Ok(Self {
             id: row.id,
             settings: from_json(row.settings_json)?,
-            created_at: parse_time(row.created_at)?,
-            updated_at: parse_time(row.updated_at)?,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
         })
     }
-}
-
-pub(crate) fn parse_time(value: String) -> Result<OffsetDateTime> {
-    Ok(OffsetDateTime::parse(&value, &Rfc3339)?)
-}
-
-pub(crate) fn parse_time_opt(value: Option<String>) -> Result<Option<OffsetDateTime>> {
-    value.map(parse_time).transpose()
-}
-
-pub(crate) fn format_time_opt(value: Option<&OffsetDateTime>) -> Result<Option<String>> {
-    value.map(|time| Ok(time.format(&Rfc3339)?)).transpose()
 }
 
 pub(crate) fn db_label<T: Serialize>(value: &T) -> Result<String> {

--- a/crates/ai-chat-db/src/repository.rs
+++ b/crates/ai-chat-db/src/repository.rs
@@ -18,7 +18,7 @@ use diesel::{
     sql_types::Text,
     upsert::excluded,
 };
-use time::{OffsetDateTime, format_description::well_known::Rfc3339};
+use time::OffsetDateTime;
 
 #[derive(Clone)]
 pub struct FreshRepository {
@@ -785,14 +785,14 @@ fn validate_provider_step_input_items(
 
 fn approval_outcome_columns(
     outcome: NewApprovalDecisionOutcome,
-    now: &str,
+    now: &OffsetDateTime,
 ) -> Result<ApprovalOutcomeColumns> {
     Ok(match outcome {
         NewApprovalDecisionOutcome::Pending { expires_at } => ApprovalOutcomeColumns {
             status: ApprovalStatus::Pending,
             decision: None,
             decided_at: None,
-            expires_at: format_time_opt(expires_at.as_ref())?,
+            expires_at,
         },
         NewApprovalDecisionOutcome::Approved { decided_by, reason } => ApprovalOutcomeColumns {
             status: ApprovalStatus::Approved,
@@ -801,7 +801,7 @@ fn approval_outcome_columns(
                 decided_by,
                 reason,
             }),
-            decided_at: Some(now.to_string()),
+            decided_at: Some(*now),
             expires_at: None,
         },
         NewApprovalDecisionOutcome::Denied { decided_by, reason } => ApprovalOutcomeColumns {
@@ -811,19 +811,19 @@ fn approval_outcome_columns(
                 decided_by,
                 reason,
             }),
-            decided_at: Some(now.to_string()),
+            decided_at: Some(*now),
             expires_at: None,
         },
         NewApprovalDecisionOutcome::Expired => ApprovalOutcomeColumns {
             status: ApprovalStatus::Expired,
             decision: None,
-            decided_at: Some(now.to_string()),
+            decided_at: Some(*now),
             expires_at: None,
         },
         NewApprovalDecisionOutcome::Canceled => ApprovalOutcomeColumns {
             status: ApprovalStatus::Canceled,
             decision: None,
-            decided_at: Some(now.to_string()),
+            decided_at: Some(*now),
             expires_at: None,
         },
     })
@@ -832,8 +832,8 @@ fn approval_outcome_columns(
 struct ApprovalOutcomeColumns {
     status: ApprovalStatus,
     decision: Option<ApprovalDecisionPayload>,
-    decided_at: Option<String>,
-    expires_at: Option<String>,
+    decided_at: Option<OffsetDateTime>,
+    expires_at: Option<OffsetDateTime>,
 }
 
 fn ensure_equal(entity: &str, actual: &str, expected: &str) -> Result<()> {
@@ -875,8 +875,8 @@ fn ensure_agent_link(
     }
 }
 
-fn now_string() -> Result<String> {
-    Ok(OffsetDateTime::now_utc().format(&Rfc3339)?)
+fn now_string() -> Result<OffsetDateTime> {
+    Ok(OffsetDateTime::now_utc())
 }
 
 #[derive(diesel::QueryableByName)]

--- a/crates/ai-chat-db/src/schema.rs
+++ b/crates/ai-chat-db/src/schema.rs
@@ -1,7 +1,7 @@
 diesel::table! {
     schema_migrations (name) {
         name -> Text,
-        executed_at -> Text,
+        executed_at -> TimestamptzSqlite,
     }
 }
 
@@ -12,8 +12,8 @@ diesel::table! {
         created_app_version -> Nullable<Text>,
         last_opened_app_version -> Nullable<Text>,
         payload_json -> Json,
-        created_at -> Text,
-        updated_at -> Text,
+        created_at -> TimestamptzSqlite,
+        updated_at -> TimestamptzSqlite,
     }
 }
 
@@ -24,9 +24,9 @@ diesel::table! {
         display_name -> Text,
         kind -> Text,
         metadata_json -> Json,
-        created_at -> Text,
-        updated_at -> Text,
-        last_opened_at -> Nullable<Text>,
+        created_at -> TimestamptzSqlite,
+        updated_at -> TimestamptzSqlite,
+        last_opened_at -> Nullable<TimestamptzSqlite>,
     }
 }
 
@@ -42,10 +42,10 @@ diesel::table! {
         last_item_seq -> Integer,
         metadata_json -> Json,
         settings_snapshot_json -> Json,
-        created_at -> Text,
-        updated_at -> Text,
-        archived_at -> Nullable<Text>,
-        deleted_at -> Nullable<Text>,
+        created_at -> TimestamptzSqlite,
+        updated_at -> TimestamptzSqlite,
+        archived_at -> Nullable<TimestamptzSqlite>,
+        deleted_at -> Nullable<TimestamptzSqlite>,
     }
 }
 
@@ -62,8 +62,8 @@ diesel::table! {
         provider_item_id -> Nullable<Text>,
         payload_json -> Json,
         search_text -> Text,
-        created_at -> Text,
-        updated_at -> Text,
+        created_at -> TimestamptzSqlite,
+        updated_at -> TimestamptzSqlite,
     }
 }
 
@@ -82,8 +82,8 @@ diesel::table! {
         sha256 -> Nullable<Text>,
         size_bytes -> Nullable<BigInt>,
         metadata_json -> Json,
-        created_at -> Text,
-        updated_at -> Text,
+        created_at -> TimestamptzSqlite,
+        updated_at -> TimestamptzSqlite,
     }
 }
 
@@ -96,10 +96,10 @@ diesel::table! {
         input_json -> Json,
         output_json -> Nullable<Json>,
         error_json -> Nullable<Json>,
-        created_at -> Text,
-        started_at -> Nullable<Text>,
-        completed_at -> Nullable<Text>,
-        updated_at -> Text,
+        created_at -> TimestamptzSqlite,
+        started_at -> Nullable<TimestamptzSqlite>,
+        completed_at -> Nullable<TimestamptzSqlite>,
+        updated_at -> TimestamptzSqlite,
     }
 }
 
@@ -116,10 +116,10 @@ diesel::table! {
         state_snapshot_json -> Nullable<Json>,
         settings_snapshot_json -> Json,
         error_json -> Nullable<Json>,
-        created_at -> Text,
-        started_at -> Nullable<Text>,
-        completed_at -> Nullable<Text>,
-        updated_at -> Text,
+        created_at -> TimestamptzSqlite,
+        started_at -> Nullable<TimestamptzSqlite>,
+        completed_at -> Nullable<TimestamptzSqlite>,
+        updated_at -> TimestamptzSqlite,
     }
 }
 
@@ -138,10 +138,10 @@ diesel::table! {
         input_json -> Json,
         output_json -> Nullable<Json>,
         error_json -> Nullable<Json>,
-        created_at -> Text,
-        started_at -> Nullable<Text>,
-        completed_at -> Nullable<Text>,
-        updated_at -> Text,
+        created_at -> TimestamptzSqlite,
+        started_at -> Nullable<TimestamptzSqlite>,
+        completed_at -> Nullable<TimestamptzSqlite>,
+        updated_at -> TimestamptzSqlite,
     }
 }
 
@@ -152,9 +152,9 @@ diesel::table! {
         status -> Text,
         request_json -> Json,
         decision_json -> Nullable<Json>,
-        requested_at -> Text,
-        decided_at -> Nullable<Text>,
-        expires_at -> Nullable<Text>,
+        requested_at -> TimestamptzSqlite,
+        decided_at -> Nullable<TimestamptzSqlite>,
+        expires_at -> Nullable<TimestamptzSqlite>,
     }
 }
 
@@ -173,7 +173,7 @@ diesel::table! {
         reasoning_tokens -> BigInt,
         total_tokens -> BigInt,
         usage_json -> Json,
-        created_at -> Text,
+        created_at -> TimestamptzSqlite,
     }
 }
 
@@ -184,8 +184,8 @@ diesel::table! {
         content_json -> Json,
         enabled -> Bool,
         sort_order -> Integer,
-        created_at -> Text,
-        updated_at -> Text,
+        created_at -> TimestamptzSqlite,
+        updated_at -> TimestamptzSqlite,
     }
 }
 
@@ -200,8 +200,8 @@ diesel::table! {
         input_source -> Text,
         action_json -> Json,
         settings_snapshot_json -> Json,
-        created_at -> Text,
-        updated_at -> Text,
+        created_at -> TimestamptzSqlite,
+        updated_at -> TimestamptzSqlite,
     }
 }
 
@@ -213,8 +213,8 @@ diesel::table! {
         enabled -> Bool,
         settings_json -> Json,
         secret_refs_json -> Json,
-        created_at -> Text,
-        updated_at -> Text,
+        created_at -> TimestamptzSqlite,
+        updated_at -> TimestamptzSqlite,
     }
 }
 
@@ -226,9 +226,9 @@ diesel::table! {
         display_name -> Nullable<Text>,
         capabilities_json -> Json,
         metadata_json -> Json,
-        fetched_at -> Text,
-        created_at -> Text,
-        updated_at -> Text,
+        fetched_at -> TimestamptzSqlite,
+        created_at -> TimestamptzSqlite,
+        updated_at -> TimestamptzSqlite,
     }
 }
 
@@ -236,8 +236,8 @@ diesel::table! {
     app_settings (id) {
         id -> Text,
         settings_json -> Json,
-        created_at -> Text,
-        updated_at -> Text,
+        created_at -> TimestamptzSqlite,
+        updated_at -> TimestamptzSqlite,
     }
 }
 

--- a/crates/ai-chat-db/src/tests.rs
+++ b/crates/ai-chat-db/src/tests.rs
@@ -6,7 +6,7 @@ use crate::{
 use ai_chat_core::*;
 use diesel::{
     Connection, RunQueryDsl, SqliteConnection, sql_query,
-    sql_types::{BigInt, Integer},
+    sql_types::{BigInt, Integer, Text},
 };
 use serde_json::json;
 use std::{collections::HashSet, fs};
@@ -113,6 +113,124 @@ fn empty_first_run_has_no_user_data_or_source_tables() {
     ] {
         assert!(!tables.contains(disallowed));
     }
+}
+
+#[test]
+fn fresh_schema_declares_structured_sqlite_types_and_checks() {
+    let dir = tempdir().unwrap();
+    let store = FreshStore::open_in_dir(dir.path()).unwrap();
+    let mut conn = store.pool().get().unwrap();
+
+    let schema_migrations_sql = table_sql(&mut conn, "schema_migrations");
+    assert!(schema_migrations_sql.contains("executed_at DateTime NOT NULL"));
+
+    let providers_sql = table_sql(&mut conn, "providers");
+    assert!(providers_sql.contains("enabled BOOLEAN NOT NULL DEFAULT 1"));
+    assert!(providers_sql.contains("CHECK (enabled IN (0, 1))"));
+    assert!(providers_sql.contains("created_at DateTime NOT NULL"));
+    assert!(providers_sql.contains("updated_at DateTime NOT NULL"));
+
+    let agent_runs_sql = table_sql(&mut conn, "agent_runs");
+    assert!(agent_runs_sql.contains(
+        "status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'waiting_for_approval', 'completed', 'failed', 'canceled'))"
+    ));
+    assert!(agent_runs_sql.contains("started_at DateTime"));
+    assert!(agent_runs_sql.contains("completed_at DateTime"));
+
+    let conversation_items_sql = table_sql(&mut conn, "conversation_items");
+    assert!(conversation_items_sql.contains(
+        "kind TEXT NOT NULL CHECK (kind IN ('message', 'skill_activation', 'reasoning', 'tool_call', 'tool_result', 'approval_request', 'approval_decision', 'status', 'error'))"
+    ));
+    assert!(conversation_items_sql.contains(
+        "status TEXT NOT NULL CHECK (status IN ('pending', 'running', 'completed', 'failed', 'canceled', 'waiting_for_approval'))"
+    ));
+
+    let tool_invocations_sql = table_sql(&mut conn, "tool_invocations");
+    assert!(tool_invocations_sql.contains(
+        "status TEXT NOT NULL CHECK (status IN ('requested', 'awaiting_approval', 'running', 'succeeded', 'failed', 'denied', 'canceled'))"
+    ));
+}
+
+#[test]
+fn fresh_schema_rejects_invalid_boolean_and_closed_enum_values() {
+    let dir = tempdir().unwrap();
+    let store = FreshStore::open_in_dir(dir.path()).unwrap();
+    let repo = store.repository();
+    let project = repo.insert_project(project("checks")).unwrap();
+    let conversation = repo.insert_conversation(conversation(&project)).unwrap();
+    let user_item = repo
+        .append_conversation_item(message_item(&conversation.id, "hello"))
+        .unwrap();
+    let provider = repo.insert_provider(provider()).unwrap();
+    let agent_run = repo
+        .insert_agent_run(NewAgentRun {
+            trigger_kind: AgentRunTriggerKind::User,
+            status: AgentRunStatus::Running,
+            input: agent_run_input(&user_item.id, &provider.id, "gpt-5"),
+        })
+        .unwrap();
+
+    let mut conn = store.pool().get().unwrap();
+    assert!(
+        sql_query(
+            "INSERT INTO providers \
+             (id, kind, display_name, enabled, settings_json, secret_refs_json, created_at, updated_at) \
+             VALUES ('bad_provider', 'openai', 'Bad', 2, '{}', '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+        )
+        .execute(&mut conn)
+        .is_err()
+    );
+    assert!(
+        sql_query(
+            "INSERT INTO agent_runs \
+             (id, conversation_id, trigger_kind, status, input_json, created_at, updated_at) \
+             VALUES ('bad_run', ?, 'user', 'bogus', '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+        )
+        .bind::<Text, _>(&conversation.id)
+        .execute(&mut conn)
+        .is_err()
+    );
+    assert!(
+        sql_query(
+            "INSERT INTO provider_steps \
+             (id, agent_run_id, seq, provider_id, model_id, status, request_snapshot_json, settings_snapshot_json, created_at, updated_at) \
+             VALUES ('bad_step', ?, 99, ?, 'gpt-5', 'bogus', '{}', '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+        )
+        .bind::<Text, _>(&agent_run.id)
+        .bind::<Text, _>(&provider.id)
+        .execute(&mut conn)
+        .is_err()
+    );
+    assert!(
+        sql_query(
+            "INSERT INTO tool_invocations \
+             (id, agent_run_id, call_id, source, tool_name, runtime_tool_name, status, input_json, created_at, updated_at) \
+             VALUES ('bad_tool', ?, 'call_bad', 'local', 'read_file', 'read_file', 'bogus', '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+        )
+        .bind::<Text, _>(&agent_run.id)
+        .execute(&mut conn)
+        .is_err()
+    );
+    assert!(
+        sql_query(
+            "INSERT INTO conversation_items \
+             (id, conversation_id, seq, kind, status, payload_json, created_at, updated_at) \
+             VALUES ('bad_item_kind', ?, 99, 'bogus', 'completed', '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+        )
+        .bind::<Text, _>(&conversation.id)
+        .execute(&mut conn)
+        .is_err()
+    );
+    assert!(
+        sql_query(
+            "INSERT INTO conversation_items \
+             (id, conversation_id, seq, kind, status, payload_json, created_at, updated_at) \
+             VALUES ('bad_item_status', ?, 100, 'message', 'bogus', '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+        )
+        .bind::<Text, _>(&conversation.id)
+        .execute(&mut conn)
+        .is_err()
+    );
 }
 
 #[test]
@@ -919,6 +1037,15 @@ fn busy_timeout(conn: &mut SqliteConnection) -> i32 {
         .timeout
 }
 
+fn table_sql(conn: &mut SqliteConnection, table: &str) -> String {
+    sql_query("SELECT sql AS value FROM sqlite_master WHERE type = 'table' AND name = ?")
+        .bind::<Text, _>(table)
+        .load::<TextRow>(conn)
+        .unwrap()[0]
+        .value
+        .clone()
+}
+
 #[derive(diesel::QueryableByName)]
 struct CountRow {
     #[diesel(sql_type = BigInt)]
@@ -935,6 +1062,12 @@ struct BusyTimeoutRow {
 struct IntRow {
     #[diesel(sql_type = Integer)]
     value: i32,
+}
+
+#[derive(diesel::QueryableByName)]
+struct TextRow {
+    #[diesel(sql_type = Text)]
+    value: String,
 }
 
 fn project(suffix: &str) -> NewProject {


### PR DESCRIPTION
## Summary

- Cleans up the fresh `ai-chat-db` SQLite schema and Diesel mappings.
- Affected crate: `ai-chat-db`; affected docs: `app/ai-chat/docs/dev`.

## Motivation

The fresh database should use typed SQLite/Diesel representations for timestamps and DB-level constraints for closed values. This keeps invalid boolean/status/kind values from entering the fresh store and removes hand-written RFC3339 timestamp conversion from repository mappings.

## Changes

- Enables Diesel SQLite time support and maps fresh DB time columns through typed `DateTime` / `TimestamptzSqlite` with `OffsetDateTime` row fields.
- Declares enabled flags as `BOOLEAN NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1))`.
- Adds `CHECK` constraints for closed run/status/kind columns across agent runs, provider steps, tool invocations, and conversation items.
- Updates repository mappings and tests for typed timestamp roundtrips and invalid raw SQL rejection.
- Retargets #157 docs away from the removed standalone provider crate plan; Rig/provider integration is now documented under the future `ai-chat-agent` work.

## Validation

- [ ] `cargo build`
- [x] `cargo test`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
cargo fmt
cargo test -p ai-chat-db
  21 passed; 0 failed; doctests 0 passed; 0 failed
git diff --check
```

Full workspace build/clippy and manual UI verification were not run because this PR is scoped to `ai-chat-db` schema/repository mappings plus coordination docs.

## Risks

- Fresh schema only: no backward-compatible migration is added.
- SQLite `BOOLEAN` remains integer-backed, enforced by the explicit `CHECK` constraint.

## Related Issues

- Closes #157
- Related to #137
