### PR TITLE
ai-chat: implement Rig/rmcp agent runtime persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ai-chat-agent"
+version = "0.1.0"
+dependencies = [
+ "ai-chat-core",
+ "ai-chat-db",
+ "async-trait",
+ "futures",
+ "hex",
+ "rig-core",
+ "rmcp",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "ai-chat-core"
 version = "0.1.0"
 dependencies = [
@@ -289,7 +311,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -300,7 +322,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -417,7 +439,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "tungstenite",
+ "tungstenite 0.21.0",
  "uuid",
  "walkdir",
  "widestring",
@@ -727,6 +749,12 @@ dependencies = [
  "regex",
  "regex-syntax",
 ]
+
+[[package]]
+name = "as-any"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
 
 [[package]]
 name = "as-raw-xcb-connection"
@@ -1161,7 +1189,7 @@ dependencies = [
  "log",
  "num-rational",
  "num-traits",
- "pastey",
+ "pastey 0.1.1",
  "rayon",
  "thiserror 2.0.18",
  "v_frame",
@@ -1300,7 +1328,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1321,7 +1349,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1929,7 +1957,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -2688,7 +2716,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
 ]
 
@@ -2702,7 +2730,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
 ]
 
@@ -2715,7 +2743,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.117",
 ]
 
@@ -2784,6 +2812,47 @@ name = "deflate64"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
+name = "deluxe"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed332aaf752b459088acf3dd4eca323e3ef4b83c70a84ca48fb0ec5305f1488"
+dependencies = [
+ "deluxe-core",
+ "deluxe-macros",
+ "once_cell",
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "deluxe-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddada51c8576df9d6a8450c351ff63042b092c9458b8ac7d20f89cbd0ffd313"
+dependencies = [
+ "arrayvec",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "deluxe-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87546d9c837f0b7557e47b8bd6eae52c3c223141b76aa233c345c9ab41d9117"
+dependencies = [
+ "deluxe-core",
+ "heck 0.4.1",
+ "if_chain",
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "der"
@@ -3055,7 +3124,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3104,7 +3173,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -3565,7 +3634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4135,6 +4204,12 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -5515,12 +5590,12 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.4.0",
+ "windows-registry 0.5.3",
 ]
 
 [[package]]
@@ -5682,6 +5757,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "if_chain"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
+
+[[package]]
 name = "ignore"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5764,6 +5845,15 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -5897,7 +5987,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6899,7 +6989,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6925,6 +7015,15 @@ dependencies = [
  "spirv",
  "thiserror 2.0.18",
  "unicode-ident",
+]
+
+[[package]]
+name = "nanoid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
+dependencies = [
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -7099,7 +7198,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7268,7 +7367,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7756,7 +7855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7900,6 +7999,12 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pathdiff"
@@ -8053,7 +8158,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitfield",
  "block-padding",
  "blowfish",
@@ -8596,6 +8701,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap 2.14.0",
+ "nix 0.31.3",
+ "tokio",
+ "tracing",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "profiling"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8696,7 +8815,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8734,7 +8853,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -9215,6 +9334,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -9275,6 +9395,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "rig-core"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6bd308c89a90f89ce7cd6641a078c7d2a2c55fb5a4147fd48b5a0989c3430bd"
+dependencies = [
+ "as-any",
+ "async-stream",
+ "base64 0.22.1",
+ "bytes",
+ "eventsource-stream",
+ "fastrand 2.4.1",
+ "futures",
+ "futures-timer",
+ "glob",
+ "http 1.4.0",
+ "mime",
+ "mime_guess",
+ "nanoid",
+ "ordered-float",
+ "pin-project-lite",
+ "reqwest 0.13.3",
+ "rig-derive",
+ "rmcp",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
+
+[[package]]
+name = "rig-derive"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba9149c63403a49ddfd5d373860487e6feef0021bfe5329812d1c4e72ee207c"
+dependencies = [
+ "convert_case 0.10.0",
+ "deluxe",
+ "indoc",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9324,6 +9495,46 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "http 1.4.0",
+ "pastey 0.2.3",
+ "pin-project-lite",
+ "process-wrap",
+ "reqwest 0.13.3",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9551,7 +9762,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9564,7 +9775,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9692,7 +9903,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9713,7 +9924,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9856,6 +10067,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "indexmap 2.14.0",
  "ref-cast",
@@ -10019,7 +10231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10333,7 +10545,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 5.0.1",
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -10512,7 +10724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10588,6 +10800,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10603,7 +10828,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10702,6 +10927,12 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
@@ -11116,7 +11347,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2",
- "strsim",
+ "strsim 0.11.1",
  "tar",
  "tauri-icns",
  "tauri-macos-sign",
@@ -11209,7 +11440,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11415,6 +11646,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -11461,6 +11693,33 @@ dependencies = [
  "futures-util",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite 0.23.0",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -11674,6 +11933,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11717,7 +11988,7 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12129,6 +12400,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "twofish"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12197,7 +12488,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12975,6 +13266,15 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
@@ -13209,7 +13509,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,7 @@ dependencies = [
  "ai-chat-core",
  "ai-chat-db",
  "async-trait",
+ "dirs 6.0.0",
  "futures",
  "hex",
  "rig-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "app/novel-download",
   "crates/app-assets",
   "crates/app-theme",
+  "crates/ai-chat-agent",
   "crates/ai-chat-core",
   "crates/ai-chat-db",
   "crates/platform-ext",
@@ -23,10 +24,18 @@ gpui-component = { git = "https://github.com/longbridge/gpui-component" }
 gpui-component-assets = { git = "https://github.com/longbridge/gpui-component", package = "gpui-component-assets" }
 ai-chat-core = { path = "./crates/ai-chat-core" }
 ai-chat-db = { path = "./crates/ai-chat-db" }
+ai-chat-agent = { path = "./crates/ai-chat-agent" }
 app-assets = { path = "./crates/app-assets" }
 app-theme = { path = "./crates/app-theme", default-features = false }
 window-ext = { path = "./crates/window-ext" }
 platform-ext = { path = "./crates/platform-ext" }
+rig-core = { version = "0.37.0", features = ["rmcp"] }
+rmcp = { version = "1.7.0", features = [
+  "client",
+  "macros",
+  "transport-child-process",
+  "transport-streamable-http-client-reqwest",
+] }
 
 [patch.crates-io]
 gpui = { git = "https://github.com/zed-industries/zed" }

--- a/crates/ai-chat-agent/Cargo.toml
+++ b/crates/ai-chat-agent/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 ai-chat-core.workspace = true
 ai-chat-db.workspace = true
 async-trait = "0.1.89"
+dirs = "6.0.0"
 futures = "0.3.32"
 hex = "0.4.3"
 rig-core.workspace = true

--- a/crates/ai-chat-agent/Cargo.toml
+++ b/crates/ai-chat-agent/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "ai-chat-agent"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+ai-chat-core.workspace = true
+ai-chat-db.workspace = true
+async-trait = "0.1.89"
+futures = "0.3.32"
+hex = "0.4.3"
+rig-core.workspace = true
+rmcp.workspace = true
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+sha2 = "0.10.9"
+thiserror = "2.0.18"
+time = { version = "0.3.47", features = ["formatting", "parsing", "serde"] }
+tokio = { version = "1.52.3", features = ["sync", "time"] }
+tokio-util = "0.7.18"
+tracing = "0.1.44"
+
+[dev-dependencies]
+rig-core = { workspace = true, features = ["test-utils"] }
+tempfile = "3.27.0"
+tokio = { version = "1.52.3", features = ["macros", "rt", "sync", "time"] }

--- a/crates/ai-chat-agent/src/error.rs
+++ b/crates/ai-chat-agent/src/error.rs
@@ -24,6 +24,8 @@ pub enum AgentRuntimeError {
     },
     #[error("runtime canceled")]
     Canceled,
+    #[error("unsupported runtime operation: {0}")]
+    Unsupported(String),
     #[error("runtime invariant failed: {0}")]
     Invariant(String),
 }

--- a/crates/ai-chat-agent/src/error.rs
+++ b/crates/ai-chat-agent/src/error.rs
@@ -1,0 +1,35 @@
+use ai_chat_core::ToolInvocationId;
+
+pub type Result<T> = std::result::Result<T, AgentRuntimeError>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum AgentRuntimeError {
+    #[error("database error: {0}")]
+    Db(#[from] ai_chat_db::DbError),
+    #[error("filesystem error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("Rig completion error: {0}")]
+    RigCompletion(#[from] rig_core::completion::CompletionError),
+    #[error("Rig prompt error: {0}")]
+    RigPrompt(#[from] Box<rig_core::completion::PromptError>),
+    #[error("Rig tool server error: {0}")]
+    RigToolServer(#[from] rig_core::tool::server::ToolServerError),
+    #[error("MCP error: {0}")]
+    Mcp(String),
+    #[error("tool {tool_invocation_id} is waiting for approval")]
+    WaitingForApproval {
+        tool_invocation_id: ToolInvocationId,
+    },
+    #[error("runtime canceled")]
+    Canceled,
+    #[error("runtime invariant failed: {0}")]
+    Invariant(String),
+}
+
+impl From<rig_core::completion::PromptError> for AgentRuntimeError {
+    fn from(value: rig_core::completion::PromptError) -> Self {
+        Self::RigPrompt(Box::new(value))
+    }
+}

--- a/crates/ai-chat-agent/src/history.rs
+++ b/crates/ai-chat-agent/src/history.rs
@@ -16,6 +16,7 @@ pub(crate) struct PromptHistory {
 pub(crate) fn build_prompt_history(
     items: &[ConversationItemRecord],
     user_item_id: &str,
+    agent_run_id: &str,
 ) -> Result<PromptHistory> {
     let user_index = items
         .iter()
@@ -23,17 +24,31 @@ pub(crate) fn build_prompt_history(
         .ok_or_else(|| {
             AgentRuntimeError::Invariant(format!("user item {user_item_id} is missing"))
         })?;
-    let prompt = conversation_item_to_rig_message(&items[user_index])?.ok_or_else(|| {
-        AgentRuntimeError::Invariant(format!("user item {user_item_id} cannot be used as prompt"))
-    })?;
+    let current_run_skill_items = items[user_index + 1..]
+        .iter()
+        .filter(|item| {
+            item.agent_run_id.as_deref() == Some(agent_run_id)
+                && matches!(item.payload, ConversationItemPayload::SkillActivation(_))
+        })
+        .collect::<Vec<_>>();
+    let prompt = if current_run_skill_items.is_empty() {
+        conversation_item_to_rig_message(&items[user_index])?.ok_or_else(|| {
+            AgentRuntimeError::Invariant(format!(
+                "user item {user_item_id} cannot be used as prompt"
+            ))
+        })?
+    } else {
+        user_prompt_with_skill_context(&items[user_index], &current_run_skill_items)?
+    };
     let history = items[..user_index]
         .iter()
         .filter_map(|item| conversation_item_to_rig_message(item).transpose())
         .collect::<Result<Vec<_>>>()?;
-    let input_item_ids = items[..=user_index]
+    let mut input_item_ids = items[..=user_index]
         .iter()
         .map(|item| item.id.clone())
-        .collect();
+        .collect::<Vec<_>>();
+    input_item_ids.extend(current_run_skill_items.iter().map(|item| item.id.clone()));
     Ok(PromptHistory {
         prompt,
         history,
@@ -57,12 +72,9 @@ pub(crate) fn conversation_item_to_rig_message(
                 TranscriptRole::Tool => Some(RigMessage::user(text)),
             }
         }
-        ConversationItemPayload::SkillActivation(skill) => Some(RigMessage::system(format!(
-            "Loaded skill `{}` from {}:\n{}",
-            skill.name,
-            skill.skill_file_path,
-            content_text(&skill.content)
-        ))),
+        ConversationItemPayload::SkillActivation(skill) => {
+            Some(RigMessage::user(skill_activation_context(skill)))
+        }
         ConversationItemPayload::Reasoning { text, summary } => {
             let reasoning = summary.as_ref().map_or_else(
                 || rig_core::message::Reasoning::new(text),
@@ -98,6 +110,43 @@ pub(crate) fn conversation_item_to_rig_message(
         ))),
         ConversationItemPayload::ApprovalRequest(_) | ConversationItemPayload::Status(_) => None,
     })
+}
+
+fn user_prompt_with_skill_context(
+    user_item: &ConversationItemRecord,
+    skill_items: &[&ConversationItemRecord],
+) -> Result<RigMessage> {
+    let ConversationItemPayload::Message {
+        role: TranscriptRole::User,
+        content,
+    } = &user_item.payload
+    else {
+        return Err(AgentRuntimeError::Invariant(format!(
+            "user item {} cannot be merged with skill context",
+            user_item.id
+        )));
+    };
+
+    let mut text = content_text(content);
+    for item in skill_items {
+        let ConversationItemPayload::SkillActivation(skill) = &item.payload else {
+            continue;
+        };
+        if !text.is_empty() {
+            text.push_str("\n\n");
+        }
+        text.push_str(&skill_activation_context(skill));
+    }
+    Ok(RigMessage::user(text))
+}
+
+fn skill_activation_context(skill: &SkillActivationItem) -> String {
+    format!(
+        "<skill>\n<name>{}</name>\n<path>{}</path>\n{}\n</skill>",
+        skill.name,
+        skill.skill_file_path,
+        content_text(&skill.content)
+    )
 }
 
 pub(crate) fn content_text(content: &[ContentPart]) -> String {

--- a/crates/ai-chat-agent/src/history.rs
+++ b/crates/ai-chat-agent/src/history.rs
@@ -1,0 +1,109 @@
+use crate::{AgentRuntimeError, Result};
+use ai_chat_core::*;
+use ai_chat_db::ConversationItemRecord;
+use rig_core::{
+    OneOrMany,
+    completion::{AssistantContent, Message as RigMessage},
+    message::{ToolCall, ToolFunction, ToolResult, ToolResultContent, UserContent},
+};
+
+pub(crate) struct PromptHistory {
+    pub(crate) prompt: RigMessage,
+    pub(crate) history: Vec<RigMessage>,
+    pub(crate) input_item_ids: Vec<ConversationItemId>,
+}
+
+pub(crate) fn build_prompt_history(
+    items: &[ConversationItemRecord],
+    user_item_id: &str,
+) -> Result<PromptHistory> {
+    let user_index = items
+        .iter()
+        .position(|item| item.id == user_item_id)
+        .ok_or_else(|| {
+            AgentRuntimeError::Invariant(format!("user item {user_item_id} is missing"))
+        })?;
+    let prompt = conversation_item_to_rig_message(&items[user_index])?.ok_or_else(|| {
+        AgentRuntimeError::Invariant(format!("user item {user_item_id} cannot be used as prompt"))
+    })?;
+    let history = items[..user_index]
+        .iter()
+        .filter_map(|item| conversation_item_to_rig_message(item).transpose())
+        .collect::<Result<Vec<_>>>()?;
+    let input_item_ids = items[..=user_index]
+        .iter()
+        .map(|item| item.id.clone())
+        .collect();
+    Ok(PromptHistory {
+        prompt,
+        history,
+        input_item_ids,
+    })
+}
+
+pub(crate) fn conversation_item_to_rig_message(
+    item: &ConversationItemRecord,
+) -> Result<Option<RigMessage>> {
+    Ok(match &item.payload {
+        ConversationItemPayload::Message { role, content } => {
+            let text = content_text(content);
+            match role {
+                TranscriptRole::System => Some(RigMessage::system(text)),
+                TranscriptRole::Developer => Some(RigMessage::system(format!(
+                    "Developer instruction:\n{text}"
+                ))),
+                TranscriptRole::User => Some(RigMessage::user(text)),
+                TranscriptRole::Assistant => Some(RigMessage::assistant(text)),
+                TranscriptRole::Tool => Some(RigMessage::user(text)),
+            }
+        }
+        ConversationItemPayload::SkillActivation(skill) => Some(RigMessage::system(format!(
+            "Loaded skill `{}` from {}:\n{}",
+            skill.name,
+            skill.skill_file_path,
+            content_text(&skill.content)
+        ))),
+        ConversationItemPayload::Reasoning { text, summary } => {
+            let reasoning = summary.as_ref().map_or_else(
+                || rig_core::message::Reasoning::new(text),
+                |summary| rig_core::message::Reasoning::summaries(vec![summary.clone()]),
+            );
+            Some(RigMessage::Assistant {
+                id: item.provider_item_id.clone(),
+                content: OneOrMany::one(AssistantContent::Reasoning(reasoning)),
+            })
+        }
+        ConversationItemPayload::ToolCall(call) => Some(RigMessage::Assistant {
+            id: item.provider_item_id.clone(),
+            content: OneOrMany::one(AssistantContent::ToolCall(ToolCall::new(
+                call.call_id.clone(),
+                ToolFunction::new(call.runtime_tool_name.clone(), call.arguments.value.clone()),
+            ))),
+        }),
+        ConversationItemPayload::ToolResult(result) => Some(RigMessage::User {
+            content: OneOrMany::one(UserContent::ToolResult(ToolResult {
+                id: result.call_id.clone(),
+                call_id: None,
+                content: OneOrMany::one(ToolResultContent::text(content_text(&result.content))),
+            })),
+        }),
+        ConversationItemPayload::Error(error) => Some(RigMessage::system(format!(
+            "Previous run error [{}]: {}",
+            error.code, error.message
+        ))),
+        ConversationItemPayload::ApprovalDecision(item) => Some(RigMessage::system(format!(
+            "Tool approval decision: approved={} reason={}",
+            item.decision.approved,
+            item.decision.reason.clone().unwrap_or_default()
+        ))),
+        ConversationItemPayload::ApprovalRequest(_) | ConversationItemPayload::Status(_) => None,
+    })
+}
+
+pub(crate) fn content_text(content: &[ContentPart]) -> String {
+    content
+        .iter()
+        .filter_map(ContentPart::search_text)
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/crates/ai-chat-agent/src/history.rs
+++ b/crates/ai-chat-agent/src/history.rs
@@ -87,15 +87,18 @@ pub(crate) fn conversation_item_to_rig_message(
         }
         ConversationItemPayload::ToolCall(call) => Some(RigMessage::Assistant {
             id: item.provider_item_id.clone(),
-            content: OneOrMany::one(AssistantContent::ToolCall(ToolCall::new(
-                call.call_id.clone(),
-                ToolFunction::new(call.runtime_tool_name.clone(), call.arguments.value.clone()),
-            ))),
+            content: OneOrMany::one(AssistantContent::ToolCall(
+                ToolCall::new(
+                    call.call_id.clone(),
+                    ToolFunction::new(call.runtime_tool_name.clone(), call.arguments.value.clone()),
+                )
+                .with_call_id(call.call_id.clone()),
+            )),
         }),
         ConversationItemPayload::ToolResult(result) => Some(RigMessage::User {
             content: OneOrMany::one(UserContent::ToolResult(ToolResult {
                 id: result.call_id.clone(),
-                call_id: None,
+                call_id: Some(result.call_id.clone()),
                 content: OneOrMany::one(ToolResultContent::text(content_text(&result.content))),
             })),
         }),

--- a/crates/ai-chat-agent/src/history.rs
+++ b/crates/ai-chat-agent/src/history.rs
@@ -99,7 +99,7 @@ pub(crate) fn conversation_item_to_rig_message(
             content: OneOrMany::one(UserContent::ToolResult(ToolResult {
                 id: result.call_id.clone(),
                 call_id: Some(result.call_id.clone()),
-                content: OneOrMany::one(ToolResultContent::text(content_text(&result.content))),
+                content: OneOrMany::one(ToolResultContent::text(tool_result_model_text(result))),
             })),
         }),
         ConversationItemPayload::Error(error) => Some(RigMessage::system(format!(
@@ -113,6 +113,13 @@ pub(crate) fn conversation_item_to_rig_message(
         ))),
         ConversationItemPayload::ApprovalRequest(_) | ConversationItemPayload::Status(_) => None,
     })
+}
+
+fn tool_result_model_text(result: &ToolResultItem) -> String {
+    if let Some(structured) = result.structured_output.as_ref() {
+        return structured.value.to_string();
+    }
+    content_text(&result.content)
 }
 
 fn user_prompt_with_skill_context(

--- a/crates/ai-chat-agent/src/lib.rs
+++ b/crates/ai-chat-agent/src/lib.rs
@@ -1,0 +1,23 @@
+mod error;
+mod history;
+mod mcp;
+mod persistence;
+mod runtime;
+mod skills;
+mod tool_registry;
+mod types;
+
+pub use error::{AgentRuntimeError, Result};
+pub use mcp::{
+    McpConfigLayer, McpConnector, McpServerConfig, McpServerTransport, McpStdioTransport,
+    McpStreamableHttpTransport,
+};
+pub use persistence::PersistingCompletionModel;
+pub use runtime::AgentRuntime;
+pub use skills::{SkillActivationRequest, SkillCatalog, SkillCatalogEntry, SkillLoader};
+pub use tool_registry::{
+    LocalTool, RegisteredToolDefinition, ToolDefinition, ToolExecutor, ToolRegistry, ToolRunPolicy,
+};
+pub use types::{
+    AgentRunHandle, AgentRunRequest, AgentStep, CompletionModelFactory, RuntimeGuards,
+};

--- a/crates/ai-chat-agent/src/mcp.rs
+++ b/crates/ai-chat-agent/src/mcp.rs
@@ -1,0 +1,107 @@
+use crate::{Result, ToolDefinition, ToolRegistry, ToolRunPolicy};
+use ai_chat_core::{ToolApprovalPolicy, ToolExecutionPolicy, ToolSource};
+use rig_core::tool::rmcp::McpTool;
+use rmcp::{model::Tool as RmcpToolDefinition, service::ServerSink};
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, path::PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct McpConfigLayer {
+    pub servers: Vec<McpServerConfig>,
+}
+
+impl McpConfigLayer {
+    pub fn merge_ordered(layers: impl IntoIterator<Item = McpConfigLayer>) -> Vec<McpServerConfig> {
+        let mut servers = BTreeMap::new();
+        for layer in layers {
+            for server in layer.servers {
+                servers.insert(server.server_id.clone(), server);
+            }
+        }
+        servers.into_values().collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct McpServerConfig {
+    pub server_id: String,
+    pub display_name: Option<String>,
+    pub transport: McpServerTransport,
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+    pub cwd: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub enum McpServerTransport {
+    Stdio(McpStdioTransport),
+    StreamableHttp(McpStreamableHttpTransport),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct McpStdioTransport {
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct McpStreamableHttpTransport {
+    pub url: String,
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
+    pub oauth: Option<serde_json::Value>,
+}
+
+#[derive(Default)]
+pub struct McpConnector;
+
+impl McpConnector {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn register_rmcp_tools(
+        &self,
+        registry: &mut ToolRegistry,
+        server_id: impl Into<String>,
+        tools: impl IntoIterator<Item = RmcpToolDefinition>,
+        client: ServerSink,
+        approval_policy: ToolApprovalPolicy,
+        execution_policy: ToolExecutionPolicy,
+    ) -> Result<()> {
+        let server_id = server_id.into();
+        for tool in tools {
+            let original_name = tool.name.to_string();
+            let description = tool
+                .description
+                .clone()
+                .map(|description| description.to_string());
+            let parameters = tool.schema_as_json_value();
+            let mcp_tool = McpTool::from_mcp_server(tool, client.clone());
+            registry.register_mcp_tool(
+                ToolDefinition {
+                    source: ToolSource::Mcp {
+                        server_id: server_id.clone(),
+                    },
+                    namespace: Some(server_id.clone()),
+                    name: original_name,
+                    description: description.unwrap_or_default(),
+                    parameters,
+                    policy: ToolRunPolicy {
+                        approval_policy,
+                        execution_policy,
+                        timeout_ms: None,
+                    },
+                },
+                mcp_tool,
+            )?;
+        }
+        Ok(())
+    }
+}

--- a/crates/ai-chat-agent/src/persistence.rs
+++ b/crates/ai-chat-agent/src/persistence.rs
@@ -1,0 +1,707 @@
+use crate::{AgentRuntimeError, AgentStep, RegisteredToolDefinition, Result};
+use ai_chat_core::*;
+use ai_chat_db::{
+    ConversationItemRecord, FreshRepository, NewAgentRun, NewApprovalDecision,
+    NewApprovalDecisionOutcome, NewConversationItem, NewProviderStep, NewToolInvocation,
+    NewUsageEvent, ProviderStepRecord, UpdateAgentRunStatus, UpdateProviderStepStatus,
+    UpdateToolInvocationStatus,
+};
+use rig_core::{
+    agent::{HookAction, PromptHook, ToolCallHookAction},
+    completion::{AssistantContent, CompletionModel, CompletionRequest, CompletionResponse, Usage},
+    streaming::StreamingCompletionResponse,
+};
+use serde::{Serialize, de::DeserializeOwned};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Clone)]
+pub struct PersistingCompletionModel<M>
+where
+    M: CompletionModel,
+{
+    inner: M,
+    context: Option<PersistenceContext>,
+}
+
+impl<M> PersistingCompletionModel<M>
+where
+    M: CompletionModel,
+{
+    pub(crate) fn new(inner: M, context: PersistenceContext) -> Self {
+        Self {
+            inner,
+            context: Some(context),
+        }
+    }
+}
+
+impl<M> CompletionModel for PersistingCompletionModel<M>
+where
+    M: CompletionModel,
+    M::Response: Serialize + DeserializeOwned,
+    M::StreamingResponse: Clone
+        + Unpin
+        + Send
+        + Sync
+        + Serialize
+        + DeserializeOwned
+        + rig_core::completion::GetTokenUsage,
+{
+    type Response = M::Response;
+    type StreamingResponse = M::StreamingResponse;
+    type Client = M::Client;
+
+    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
+        Self {
+            inner: M::make(client, model),
+            context: None,
+        }
+    }
+
+    async fn completion(
+        &self,
+        request: CompletionRequest,
+    ) -> std::result::Result<
+        CompletionResponse<Self::Response>,
+        rig_core::completion::CompletionError,
+    > {
+        let Some(context) = self.context.clone() else {
+            return self.inner.completion(request).await;
+        };
+        let provider_step = context
+            .insert_provider_step(&request)
+            .map_err(completion_request_error)?;
+
+        let response = self.inner.completion(request).await;
+        match response {
+            Ok(response) => {
+                context
+                    .finish_provider_step(&provider_step.id, &response)
+                    .map_err(completion_request_error)?;
+                Ok(response)
+            }
+            Err(error) => {
+                let payload = run_error("provider_error", error.to_string(), true, None);
+                let _ = context.fail_provider_step(&provider_step.id, payload);
+                Err(error)
+            }
+        }
+    }
+
+    async fn stream(
+        &self,
+        request: CompletionRequest,
+    ) -> std::result::Result<
+        StreamingCompletionResponse<Self::StreamingResponse>,
+        rig_core::completion::CompletionError,
+    > {
+        let Some(context) = self.context.clone() else {
+            return self.inner.stream(request).await;
+        };
+        let provider_step = context
+            .insert_provider_step(&request)
+            .map_err(completion_request_error)?;
+        let response = self.inner.stream(request).await;
+        match response {
+            Ok(response) => {
+                let _ = context.finish_streaming_provider_step(&provider_step.id);
+                Ok(response)
+            }
+            Err(error) => {
+                let payload = run_error("provider_error", error.to_string(), true, None);
+                let _ = context.fail_provider_step(&provider_step.id, payload);
+                Err(error)
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct PersistenceContext {
+    repo: FreshRepository,
+    agent_run_id: AgentRunId,
+    conversation_id: ConversationId,
+    provider_id: ProviderId,
+    model_id: ProviderModelId,
+    settings_snapshot: RunSettingsSnapshot,
+    input_item_ids: Arc<Mutex<Vec<ConversationItemId>>>,
+    last_provider_step_id: Arc<Mutex<Option<ProviderStepId>>>,
+    final_item_id: Arc<Mutex<Option<ConversationItemId>>>,
+    events: Arc<Mutex<Vec<AgentRunEvent>>>,
+    steps: Arc<Mutex<Vec<AgentStep>>>,
+    tool_definitions: Arc<HashMap<String, RegisteredToolDefinition>>,
+    tool_calls: Arc<Mutex<HashMap<String, ToolInvocationId>>>,
+    repeated_tool_calls: Arc<Mutex<HashMap<String, u32>>>,
+    max_tool_calls: u32,
+    repeated_tool_call_limit: u32,
+    cancellation_token: CancellationToken,
+}
+
+impl PersistenceContext {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        repo: FreshRepository,
+        agent_run_id: AgentRunId,
+        conversation_id: ConversationId,
+        provider_id: ProviderId,
+        model_id: ProviderModelId,
+        settings_snapshot: RunSettingsSnapshot,
+        input_item_ids: Vec<ConversationItemId>,
+        tool_definitions: Vec<RegisteredToolDefinition>,
+        max_tool_calls: u32,
+        repeated_tool_call_limit: u32,
+        cancellation_token: CancellationToken,
+    ) -> Self {
+        Self {
+            repo,
+            agent_run_id,
+            conversation_id,
+            provider_id,
+            model_id,
+            settings_snapshot,
+            input_item_ids: Arc::new(Mutex::new(input_item_ids)),
+            last_provider_step_id: Arc::new(Mutex::new(None)),
+            final_item_id: Arc::new(Mutex::new(None)),
+            events: Arc::new(Mutex::new(Vec::new())),
+            steps: Arc::new(Mutex::new(Vec::new())),
+            tool_definitions: Arc::new(
+                tool_definitions
+                    .into_iter()
+                    .map(|definition| (definition.runtime_tool_name.clone(), definition))
+                    .collect(),
+            ),
+            tool_calls: Arc::new(Mutex::new(HashMap::new())),
+            repeated_tool_calls: Arc::new(Mutex::new(HashMap::new())),
+            max_tool_calls,
+            repeated_tool_call_limit,
+            cancellation_token,
+        }
+    }
+
+    pub(crate) fn hook(&self) -> PersistingPromptHook {
+        PersistingPromptHook {
+            context: self.clone(),
+        }
+    }
+
+    pub(crate) fn events(&self) -> Vec<AgentRunEvent> {
+        mutex_clone(&self.events)
+    }
+
+    pub(crate) fn steps(&self) -> Vec<AgentStep> {
+        mutex_clone(&self.steps)
+    }
+
+    pub(crate) fn final_item_id(&self) -> Option<ConversationItemId> {
+        mutex_clone(&self.final_item_id)
+    }
+
+    fn insert_provider_step(&self, request: &CompletionRequest) -> Result<ProviderStepRecord> {
+        let seq = self.repo.next_provider_step_seq(&self.agent_run_id)?;
+        let input_item_ids = mutex_clone(&self.input_item_ids);
+        let step = self.repo.insert_provider_step(NewProviderStep {
+            agent_run_id: self.agent_run_id.clone(),
+            seq,
+            status: ProviderStepStatus::Running,
+            request_snapshot: ProviderStepRequestSnapshot {
+                provider_id: self.provider_id.clone(),
+                model_id: self.model_id.clone(),
+                input_item_ids,
+                snapshot_kind: ProviderStepSnapshotKind::RigCompletionRequest,
+                request_body: ProviderRawPayload {
+                    provider_kind: "rig".to_string(),
+                    value: serde_json::to_value(request)?,
+                },
+            },
+            response_snapshot: None,
+            state_snapshot: None,
+            settings_snapshot: self.settings_snapshot.clone(),
+            error: None,
+        })?;
+        mutex_replace(&self.last_provider_step_id, Some(step.id.clone()));
+        self.push_event(AgentRunEvent::ProviderStepStarted {
+            provider_step_id: step.id.clone(),
+        });
+        self.push_step(AgentStep::ProviderStep(step.id.clone()));
+        Ok(step)
+    }
+
+    fn finish_provider_step<M>(
+        &self,
+        provider_step_id: &str,
+        response: &CompletionResponse<M>,
+    ) -> Result<()>
+    where
+        M: Serialize,
+    {
+        let output_item_ids = response
+            .choice
+            .iter()
+            .filter_map(|content| match content {
+                AssistantContent::Reasoning(reasoning) => reasoning.id.clone(),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        let response_snapshot = ProviderStepResponseSnapshot {
+            provider_run_id: response.message_id.clone(),
+            output_item_ids: output_item_ids.clone(),
+            response_body: Some(ProviderRawPayload {
+                provider_kind: "rig".to_string(),
+                value: serde_json::to_value(&response.raw_response)?,
+            }),
+        };
+        let state_snapshot = ProviderRunStateSnapshot {
+            provider_id: self.provider_id.clone(),
+            provider_run_id: response.message_id.clone(),
+            output_item_ids,
+            continuation: response
+                .message_id
+                .as_ref()
+                .map(|message_id| ProviderRawPayload {
+                    provider_kind: "rig".to_string(),
+                    value: serde_json::json!({ "messageId": message_id }),
+                }),
+        };
+        self.repo.update_provider_step_status(
+            provider_step_id,
+            UpdateProviderStepStatus {
+                status: ProviderStepStatus::Completed,
+                response_snapshot: Some(response_snapshot),
+                state_snapshot: Some(state_snapshot.clone()),
+                error: None,
+            },
+        )?;
+        let usage = provider_usage(response.usage);
+        self.repo.insert_usage_event(NewUsageEvent {
+            provider_step_id: provider_step_id.to_string(),
+            date_key: time::OffsetDateTime::now_utc().date().to_string(),
+            usage: usage.clone(),
+        })?;
+        self.push_event(AgentRunEvent::ProviderStepEvent {
+            provider_step_id: provider_step_id.to_string(),
+            event: ProviderStepEvent::UsageUpdated { usage },
+        });
+        self.push_event(AgentRunEvent::ProviderStepEvent {
+            provider_step_id: provider_step_id.to_string(),
+            event: ProviderStepEvent::Completed {
+                state: Some(state_snapshot),
+            },
+        });
+        Ok(())
+    }
+
+    fn finish_streaming_provider_step(&self, provider_step_id: &str) -> Result<()> {
+        self.repo.update_provider_step_status(
+            provider_step_id,
+            UpdateProviderStepStatus {
+                status: ProviderStepStatus::Completed,
+                response_snapshot: Some(ProviderStepResponseSnapshot {
+                    provider_run_id: None,
+                    output_item_ids: Vec::new(),
+                    response_body: None,
+                }),
+                state_snapshot: None,
+                error: None,
+            },
+        )?;
+        Ok(())
+    }
+
+    fn fail_provider_step(&self, provider_step_id: &str, error: RunErrorPayload) -> Result<()> {
+        self.repo.update_provider_step_status(
+            provider_step_id,
+            UpdateProviderStepStatus {
+                status: ProviderStepStatus::Failed,
+                response_snapshot: None,
+                state_snapshot: None,
+                error: Some(error.clone()),
+            },
+        )?;
+        self.push_event(AgentRunEvent::ProviderStepEvent {
+            provider_step_id: provider_step_id.to_string(),
+            event: ProviderStepEvent::Failed { error },
+        });
+        Ok(())
+    }
+
+    fn append_item(&self, payload: ConversationItemPayload) -> Result<ConversationItemRecord> {
+        let item = self.repo.append_conversation_item(NewConversationItem {
+            conversation_id: self.conversation_id.clone(),
+            status: ConversationItemStatus::Completed,
+            agent_run_id: Some(self.agent_run_id.clone()),
+            provider_step_id: mutex_clone(&self.last_provider_step_id),
+            tool_invocation_id: None,
+            provider_item_id: None,
+            payload,
+        })?;
+        self.add_input_item_id(item.id.clone());
+        self.push_step(AgentStep::ConversationItem(item.id.clone()));
+        Ok(item)
+    }
+
+    fn append_tool_item(
+        &self,
+        tool_invocation_id: ToolInvocationId,
+        payload: ConversationItemPayload,
+    ) -> Result<ConversationItemRecord> {
+        let item = self.repo.append_conversation_item(NewConversationItem {
+            conversation_id: self.conversation_id.clone(),
+            status: ConversationItemStatus::Completed,
+            agent_run_id: Some(self.agent_run_id.clone()),
+            provider_step_id: mutex_clone(&self.last_provider_step_id),
+            tool_invocation_id: Some(tool_invocation_id),
+            provider_item_id: None,
+            payload,
+        })?;
+        self.add_input_item_id(item.id.clone());
+        self.push_step(AgentStep::ConversationItem(item.id.clone()));
+        Ok(item)
+    }
+
+    fn add_input_item_id(&self, item_id: ConversationItemId) {
+        let mut guard = lock(&self.input_item_ids);
+        guard.push(item_id);
+    }
+
+    fn push_event(&self, event: AgentRunEvent) {
+        lock(&self.events).push(event);
+    }
+
+    fn push_step(&self, step: AgentStep) {
+        lock(&self.steps).push(step);
+    }
+
+    fn check_tool_guard(&self, runtime_tool_name: &str, args: &str) -> ToolCallHookAction {
+        let calls = lock(&self.tool_calls);
+        if calls.len() as u32 >= self.max_tool_calls {
+            return ToolCallHookAction::terminate("max tool call guard reached");
+        }
+        drop(calls);
+
+        let key = format!("{runtime_tool_name}\0{args}");
+        let mut repeated = lock(&self.repeated_tool_calls);
+        let count = repeated.entry(key).or_insert(0);
+        *count += 1;
+        if *count > self.repeated_tool_call_limit {
+            ToolCallHookAction::terminate(format!(
+                "repeated tool call guard reached for {runtime_tool_name}"
+            ))
+        } else {
+            ToolCallHookAction::cont()
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct PersistingPromptHook {
+    context: PersistenceContext,
+}
+
+impl<M> PromptHook<M> for PersistingPromptHook
+where
+    M: CompletionModel,
+{
+    async fn on_completion_call(
+        &self,
+        _prompt: &rig_core::completion::Message,
+        _history: &[rig_core::completion::Message],
+    ) -> HookAction {
+        if self.context.cancellation_token.is_cancelled() {
+            HookAction::terminate("runtime canceled")
+        } else {
+            HookAction::cont()
+        }
+    }
+
+    async fn on_completion_response(
+        &self,
+        _prompt: &rig_core::completion::Message,
+        response: &CompletionResponse<M::Response>,
+    ) -> HookAction {
+        let provider_step_id = mutex_clone(&self.context.last_provider_step_id);
+        for content in response.choice.iter() {
+            let payload = match content {
+                AssistantContent::Text(text) if !text.text.is_empty() => {
+                    Some(ConversationItemPayload::Message {
+                        role: TranscriptRole::Assistant,
+                        content: vec![ContentPart::Text {
+                            text: text.text.clone(),
+                        }],
+                    })
+                }
+                AssistantContent::Reasoning(reasoning) => {
+                    Some(ConversationItemPayload::Reasoning {
+                        text: reasoning.display_text(),
+                        summary: None,
+                    })
+                }
+                _ => None,
+            };
+
+            if let Some(payload) = payload {
+                match self.context.append_item(payload.clone()) {
+                    Ok(item) => {
+                        if matches!(payload, ConversationItemPayload::Message { .. }) {
+                            mutex_replace(&self.context.final_item_id, Some(item.id.clone()));
+                        }
+                        if let Some(provider_step_id) = provider_step_id.as_ref() {
+                            self.context.push_event(AgentRunEvent::ProviderStepEvent {
+                                provider_step_id: provider_step_id.clone(),
+                                event: ProviderStepEvent::OutputItemCompleted {
+                                    provider_item_id: item.provider_item_id.clone(),
+                                    item: payload,
+                                },
+                            });
+                        }
+                    }
+                    Err(error) => return HookAction::terminate(error.to_string()),
+                }
+            }
+        }
+        HookAction::cont()
+    }
+
+    async fn on_tool_call(
+        &self,
+        tool_name: &str,
+        tool_call_id: Option<String>,
+        internal_call_id: &str,
+        args: &str,
+    ) -> ToolCallHookAction {
+        if self.context.cancellation_token.is_cancelled() {
+            return ToolCallHookAction::terminate("runtime canceled");
+        }
+        let guard_action = self.context.check_tool_guard(tool_name, args);
+        if !matches!(guard_action, ToolCallHookAction::Continue) {
+            return guard_action;
+        }
+
+        let Some(definition) = self.context.tool_definitions.get(tool_name).cloned() else {
+            return ToolCallHookAction::terminate(format!("tool {tool_name} is not registered"));
+        };
+        let call_id = tool_call_id.unwrap_or_else(|| internal_call_id.to_string());
+        let arguments = serde_json::from_str::<serde_json::Value>(args)
+            .unwrap_or_else(|_| serde_json::Value::String(args.to_string()));
+        let status = if definition.policy.approval_policy == ToolApprovalPolicy::Never {
+            ToolInvocationStatus::Running
+        } else {
+            ToolInvocationStatus::AwaitingApproval
+        };
+        let invocation = match self.context.repo.insert_tool_invocation(NewToolInvocation {
+            agent_run_id: self.context.agent_run_id.clone(),
+            provider_step_id: mutex_clone(&self.context.last_provider_step_id),
+            status,
+            input: ToolInvocationInput {
+                source: definition.source.clone(),
+                namespace: definition.namespace.clone(),
+                tool_name: definition.tool_name.clone(),
+                runtime_tool_name: definition.runtime_tool_name.clone(),
+                call_id: call_id.clone(),
+                arguments: ToolArguments {
+                    value: arguments.clone(),
+                },
+                approval_policy: definition.policy.approval_policy,
+                execution_policy: definition.policy.execution_policy,
+            },
+            output: None,
+            error: None,
+        }) {
+            Ok(invocation) => invocation,
+            Err(error) => return ToolCallHookAction::terminate(error.to_string()),
+        };
+
+        lock(&self.context.tool_calls).insert(internal_call_id.to_string(), invocation.id.clone());
+        self.context
+            .push_event(AgentRunEvent::ToolInvocationRequested {
+                tool_invocation_id: invocation.id.clone(),
+            });
+        self.context
+            .push_step(AgentStep::ToolInvocation(invocation.id.clone()));
+
+        let payload = ConversationItemPayload::ToolCall(ToolCallItem {
+            tool_invocation_id: Some(invocation.id.clone()),
+            call_id: call_id.clone(),
+            source: definition.source.clone(),
+            name: definition.tool_name.clone(),
+            runtime_tool_name: definition.runtime_tool_name.clone(),
+            arguments: ToolArguments { value: arguments },
+        });
+        if let Err(error) = self
+            .context
+            .append_tool_item(invocation.id.clone(), payload)
+        {
+            return ToolCallHookAction::terminate(error.to_string());
+        }
+
+        if definition.policy.approval_policy != ToolApprovalPolicy::Never {
+            let request = ApprovalRequestPayload {
+                reason: format!("Tool `{}` requires approval", definition.tool_name),
+                tool_source: definition.source.clone(),
+                tool_name: definition.tool_name.clone(),
+                arguments_preview: args.to_string(),
+            };
+            let approval = match self
+                .context
+                .repo
+                .insert_approval_decision(NewApprovalDecision {
+                    tool_invocation_id: invocation.id.clone(),
+                    request: request.clone(),
+                    outcome: NewApprovalDecisionOutcome::Pending { expires_at: None },
+                }) {
+                Ok(approval) => approval,
+                Err(error) => return ToolCallHookAction::terminate(error.to_string()),
+            };
+            self.context
+                .push_step(AgentStep::Approval(approval.id.clone()));
+            self.context.push_event(AgentRunEvent::ApprovalRequested {
+                approval_decision_id: approval.id.clone(),
+            });
+            let payload = ConversationItemPayload::ApprovalRequest(ApprovalRequestItem {
+                approval_decision_id: approval.id,
+                tool_invocation_id: invocation.id.clone(),
+                request,
+            });
+            if let Err(error) = self
+                .context
+                .append_tool_item(invocation.id.clone(), payload)
+            {
+                return ToolCallHookAction::terminate(error.to_string());
+            }
+            if let Err(error) = self.context.repo.update_agent_run_status(
+                &self.context.agent_run_id,
+                UpdateAgentRunStatus {
+                    status: AgentRunStatus::WaitingForApproval,
+                    output: None,
+                    error: None,
+                },
+            ) {
+                return ToolCallHookAction::terminate(error.to_string());
+            }
+            return ToolCallHookAction::terminate("tool approval required");
+        }
+
+        ToolCallHookAction::cont()
+    }
+
+    async fn on_tool_result(
+        &self,
+        _tool_name: &str,
+        _tool_call_id: Option<String>,
+        internal_call_id: &str,
+        _args: &str,
+        result: &str,
+    ) -> HookAction {
+        let Some(tool_invocation_id) = lock(&self.context.tool_calls)
+            .get(internal_call_id)
+            .cloned()
+        else {
+            return HookAction::terminate(format!(
+                "tool result {internal_call_id} has no invocation"
+            ));
+        };
+        let output = ToolInvocationOutput {
+            content: vec![ContentPart::Text {
+                text: result.to_string(),
+            }],
+            structured_output: serde_json::from_str::<serde_json::Value>(result)
+                .ok()
+                .map(|value| StructuredOutput { value }),
+            raw_output: None,
+            is_error: false,
+        };
+        let invocation = match self.context.repo.update_tool_invocation_status(
+            &tool_invocation_id,
+            UpdateToolInvocationStatus {
+                status: ToolInvocationStatus::Succeeded,
+                output: Some(output.clone()),
+                error: None,
+            },
+        ) {
+            Ok(invocation) => invocation,
+            Err(error) => return HookAction::terminate(error.to_string()),
+        };
+        let payload = ConversationItemPayload::ToolResult(ToolResultItem {
+            tool_invocation_id: Some(tool_invocation_id.clone()),
+            call_id: invocation.call_id,
+            content: output.content.clone(),
+            is_error: output.is_error,
+            structured_output: output.structured_output.clone(),
+        });
+        if let Err(error) = self
+            .context
+            .append_tool_item(tool_invocation_id.clone(), payload)
+        {
+            return HookAction::terminate(error.to_string());
+        }
+        self.context
+            .push_event(AgentRunEvent::ToolInvocationFinished { tool_invocation_id });
+        HookAction::cont()
+    }
+}
+
+pub(crate) fn new_agent_run_input(request: &crate::AgentRunRequest) -> NewAgentRun {
+    NewAgentRun {
+        trigger_kind: request.trigger_kind,
+        status: AgentRunStatus::Queued,
+        input: AgentRunInput {
+            user_item_id: request.user_item_id.clone(),
+            parent_agent_run_id: request.parent_agent_run_id.clone(),
+            prompt_snapshot: request.prompt_snapshot.clone(),
+            provider_id: request.provider_id.clone(),
+            model_id: request.model_id.clone(),
+            settings_snapshot: request.settings_snapshot.clone(),
+            runtime_snapshot: request.runtime_snapshot.clone(),
+            max_steps: request.guards.max_steps,
+        },
+    }
+}
+
+pub(crate) fn run_error(
+    code: impl Into<String>,
+    message: impl Into<String>,
+    retryable: bool,
+    raw: Option<ProviderRawPayload>,
+) -> RunErrorPayload {
+    RunErrorPayload {
+        code: code.into(),
+        message: message.into(),
+        retryable,
+        provider: None,
+        raw,
+    }
+}
+
+pub(crate) fn provider_usage(usage: Usage) -> ProviderUsageSnapshot {
+    ProviderUsageSnapshot {
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        cached_input_tokens: usage.cached_input_tokens,
+        cache_write_input_tokens: usage.cache_creation_input_tokens,
+        reasoning_tokens: usage.reasoning_tokens,
+        total_tokens: usage.total_tokens,
+        metadata: None,
+    }
+}
+
+fn completion_request_error(error: AgentRuntimeError) -> rig_core::completion::CompletionError {
+    rig_core::completion::CompletionError::RequestError(Box::new(error))
+}
+
+fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+fn mutex_clone<T: Clone>(mutex: &Mutex<T>) -> T {
+    lock(mutex).clone()
+}
+
+fn mutex_replace<T>(mutex: &Mutex<T>, value: T) {
+    *lock(mutex) = value;
+}

--- a/crates/ai-chat-agent/src/persistence.rs
+++ b/crates/ai-chat-agent/src/persistence.rs
@@ -1,10 +1,13 @@
-use crate::{AgentRuntimeError, AgentStep, RegisteredToolDefinition, Result};
+use crate::{
+    AgentRuntimeError, AgentStep, RegisteredToolDefinition, Result,
+    tool_registry::{RegisteredRuntimeTool, tool_output_to_model_text},
+};
 use ai_chat_core::*;
 use ai_chat_db::{
     ConversationItemRecord, FreshRepository, NewAgentRun, NewApprovalDecision,
     NewApprovalDecisionOutcome, NewConversationItem, NewProviderStep, NewToolInvocation,
-    NewUsageEvent, ProviderStepRecord, UpdateAgentRunStatus, UpdateProviderStepStatus,
-    UpdateToolInvocationStatus,
+    NewUsageEvent, ProviderStepRecord, ToolInvocationRecord, UpdateAgentRunStatus,
+    UpdateProviderStepStatus, UpdateToolInvocationStatus,
 };
 use rig_core::{
     agent::{HookAction, PromptHook, ToolCallHookAction},
@@ -16,6 +19,7 @@ use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
 };
+use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Clone)]
@@ -134,6 +138,7 @@ pub(crate) struct PersistenceContext {
     events: Arc<Mutex<Vec<AgentRunEvent>>>,
     steps: Arc<Mutex<Vec<AgentStep>>>,
     tool_definitions: Arc<HashMap<String, RegisteredToolDefinition>>,
+    runtime_tools: Arc<HashMap<String, RegisteredRuntimeTool>>,
     tool_calls: Arc<Mutex<HashMap<String, ToolInvocationId>>>,
     repeated_tool_calls: Arc<Mutex<HashMap<String, u32>>>,
     max_tool_calls: u32,
@@ -152,6 +157,7 @@ impl PersistenceContext {
         settings_snapshot: RunSettingsSnapshot,
         input_item_ids: Vec<ConversationItemId>,
         tool_definitions: Vec<RegisteredToolDefinition>,
+        runtime_tools: Vec<RegisteredRuntimeTool>,
         max_tool_calls: u32,
         repeated_tool_call_limit: u32,
         cancellation_token: CancellationToken,
@@ -172,6 +178,12 @@ impl PersistenceContext {
                 tool_definitions
                     .into_iter()
                     .map(|definition| (definition.runtime_tool_name.clone(), definition))
+                    .collect(),
+            ),
+            runtime_tools: Arc::new(
+                runtime_tools
+                    .into_iter()
+                    .map(|tool| (tool.definition.runtime_tool_name.clone(), tool))
                     .collect(),
             ),
             tool_calls: Arc::new(Mutex::new(HashMap::new())),
@@ -375,6 +387,78 @@ impl PersistenceContext {
         lock(&self.steps).push(step);
     }
 
+    async fn execute_tool_invocation(
+        &self,
+        tool: RegisteredRuntimeTool,
+        invocation: ToolInvocationRecord,
+        arguments: serde_json::Value,
+    ) -> Result<String> {
+        let execution = timeout(tool.timeout, tool.executor.execute(arguments)).await;
+        let (output, status, error) = match execution {
+            Ok(Ok(output)) => {
+                let error = output.is_error.then(|| {
+                    run_error("tool_error", tool_output_to_model_text(&output), true, None)
+                });
+                let status = if output.is_error {
+                    ToolInvocationStatus::Failed
+                } else {
+                    ToolInvocationStatus::Succeeded
+                };
+                (output, status, error)
+            }
+            Ok(Err(error)) => {
+                let payload = run_error("tool_error", error.to_string(), true, None);
+                (
+                    error_tool_output(payload.message.clone()),
+                    ToolInvocationStatus::Failed,
+                    Some(payload),
+                )
+            }
+            Err(_) => {
+                let payload = run_error("tool_timeout", "tool execution timed out", true, None);
+                (
+                    error_tool_output(payload.message.clone()),
+                    ToolInvocationStatus::Failed,
+                    Some(payload),
+                )
+            }
+        };
+        let model_text = tool_output_to_model_text(&output);
+        let payload = ConversationItemPayload::ToolResult(ToolResultItem {
+            tool_invocation_id: Some(invocation.id.clone()),
+            call_id: invocation.call_id.clone(),
+            content: output.content.clone(),
+            is_error: output.is_error,
+            structured_output: output.structured_output.clone(),
+            raw_output: output.raw_output.clone(),
+        });
+        let (item, _) = self
+            .repo
+            .append_conversation_item_and_update_tool_invocation(
+                NewConversationItem {
+                    conversation_id: self.conversation_id.clone(),
+                    status: ConversationItemStatus::Completed,
+                    agent_run_id: Some(self.agent_run_id.clone()),
+                    provider_step_id: invocation.provider_step_id.clone(),
+                    tool_invocation_id: Some(invocation.id.clone()),
+                    provider_item_id: None,
+                    payload,
+                },
+                &invocation.id,
+                UpdateToolInvocationStatus {
+                    status,
+                    output: Some(output),
+                    error,
+                },
+            )?;
+        self.add_input_item_id(item.id.clone());
+        self.push_step(AgentStep::ConversationItem(item.id));
+        self.push_event(AgentRunEvent::ToolInvocationFinished {
+            tool_invocation_id: invocation.id,
+        });
+        Ok(model_text)
+    }
+
     fn check_tool_guard(&self, runtime_tool_name: &str, args: &str) -> ToolCallHookAction {
         let calls = lock(&self.tool_calls);
         if calls.len() as u32 >= self.max_tool_calls {
@@ -483,6 +567,11 @@ where
         let Some(definition) = self.context.tool_definitions.get(tool_name).cloned() else {
             return ToolCallHookAction::terminate(format!("tool {tool_name} is not registered"));
         };
+        let Some(runtime_tool) = self.context.runtime_tools.get(tool_name).cloned() else {
+            return ToolCallHookAction::terminate(format!(
+                "tool {tool_name} has no runtime executor"
+            ));
+        };
         let call_id = tool_call_id.unwrap_or_else(|| internal_call_id.to_string());
         let arguments = serde_json::from_str::<serde_json::Value>(args)
             .unwrap_or_else(|_| serde_json::Value::String(args.to_string()));
@@ -528,7 +617,9 @@ where
             source: definition.source.clone(),
             name: definition.tool_name.clone(),
             runtime_tool_name: definition.runtime_tool_name.clone(),
-            arguments: ToolArguments { value: arguments },
+            arguments: ToolArguments {
+                value: arguments.clone(),
+            },
         });
         if let Err(error) = self
             .context
@@ -584,7 +675,14 @@ where
             return ToolCallHookAction::terminate("tool approval required");
         }
 
-        ToolCallHookAction::cont()
+        match self
+            .context
+            .execute_tool_invocation(runtime_tool, invocation, arguments)
+            .await
+        {
+            Ok(model_text) => ToolCallHookAction::skip(model_text),
+            Err(error) => ToolCallHookAction::terminate(error.to_string()),
+        }
     }
 
     async fn on_tool_result(
@@ -630,6 +728,7 @@ where
             content: output.content.clone(),
             is_error: output.is_error,
             structured_output: output.structured_output.clone(),
+            raw_output: output.raw_output.clone(),
         });
         if let Err(error) = self
             .context
@@ -672,6 +771,17 @@ pub(crate) fn run_error(
         retryable,
         provider: None,
         raw,
+    }
+}
+
+fn error_tool_output(message: impl Into<String>) -> ToolInvocationOutput {
+    ToolInvocationOutput {
+        content: vec![ContentPart::Text {
+            text: message.into(),
+        }],
+        structured_output: None,
+        raw_output: None,
+        is_error: true,
     }
 }
 

--- a/crates/ai-chat-agent/src/runtime.rs
+++ b/crates/ai-chat-agent/src/runtime.rs
@@ -67,7 +67,7 @@ impl AgentRuntime {
         self.activate_skills(&request, &agent_run.id)?;
 
         let items = self.repo.conversation_items(&request.conversation_id)?;
-        let prompt_history = build_prompt_history(&items, &request.user_item_id)?;
+        let prompt_history = build_prompt_history(&items, &request.user_item_id, &agent_run.id)?;
 
         let tool_server = ToolServer::new().run();
         let mut toolset = ToolSet::default();
@@ -151,10 +151,7 @@ impl AgentRuntime {
                     .map(|run| run.status)
                     .unwrap_or(AgentRunStatus::Failed);
                 if status == AgentRunStatus::WaitingForApproval {
-                    let mut events = context.events();
-                    events.push(AgentRunEvent::Failed {
-                        error: run_error("waiting_for_approval", error.to_string(), true, None),
-                    });
+                    let events = context.events();
                     let agent_run = self.repo.get_agent_run(&agent_run.id)?.ok_or_else(|| {
                         AgentRuntimeError::Invariant("agent run disappeared".to_string())
                     })?;
@@ -375,7 +372,11 @@ mod tests {
         ProviderRecord,
     };
     use async_trait::async_trait;
-    use rig_core::test_utils::{MockCompletionModel, MockTurn};
+    use rig_core::{
+        completion::Message as RigMessage,
+        message::UserContent,
+        test_utils::{MockCompletionModel, MockTurn},
+    };
     use rmcp::{
         RoleServer, ServerHandler, ServiceExt,
         model::{
@@ -531,6 +532,13 @@ mod tests {
                 .iter()
                 .any(|event| matches!(event, AgentRunEvent::ApprovalRequested { .. }))
         );
+        assert!(
+            !handle
+                .events
+                .iter()
+                .any(|event| matches!(event, AgentRunEvent::Failed { .. }))
+        );
+        assert_eq!(handle.agent_run.error, None);
     }
 
     #[tokio::test]
@@ -549,8 +557,9 @@ mod tests {
         let mut request = fixture.request();
         request.project_root = Some(fixture.dir.path().to_path_buf());
         request.skill_requests = vec![crate::SkillActivationRequest::new("rust")];
-        runtime
-            .run_with_model(request, MockCompletionModel::text("ok"))
+        let model = MockCompletionModel::text("ok");
+        let handle = runtime
+            .run_with_model(request, model.clone())
             .await
             .unwrap();
         std::fs::write(&skill_file, "---\nname: rust\n---\nUse cargo clippy.\n").unwrap();
@@ -573,6 +582,31 @@ mod tests {
                 text: "---\nname: rust\ndescription: Rust workflow\n---\nUse cargo test.\n"
                     .to_string(),
             }]
+        );
+        let skill_item = items
+            .iter()
+            .find(|item| matches!(item.payload, ConversationItemPayload::SkillActivation(_)))
+            .unwrap();
+        let provider_steps = fixture
+            .repo
+            .provider_steps_for_run(&handle.agent_run.id)
+            .unwrap();
+        assert_eq!(provider_steps.len(), 1);
+        assert_eq!(
+            provider_steps[0].request_snapshot.input_item_ids,
+            vec![fixture.user_item.id.clone(), skill_item.id.clone()]
+        );
+
+        let requests = model.requests();
+        assert_eq!(requests.len(), 1);
+        let messages = requests[0].chat_history.iter().collect::<Vec<_>>();
+        let last_message_text = rig_message_text(messages.last().unwrap());
+        assert!(last_message_text.starts_with("hello\n\n<skill>\n<name>rust</name>"));
+        assert!(last_message_text.contains("Use cargo test."));
+        assert!(
+            messages[..messages.len() - 1]
+                .iter()
+                .all(|message| !rig_message_text(message).contains("<skill>"))
         );
     }
 
@@ -795,6 +829,21 @@ mod tests {
                 responses_api: true,
                 raw: None,
             },
+        }
+    }
+
+    fn rig_message_text(message: &RigMessage) -> String {
+        match message {
+            RigMessage::System { content } => content.clone(),
+            RigMessage::User { content } => content
+                .iter()
+                .filter_map(|content| match content {
+                    UserContent::Text(text) => Some(text.text.as_str()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join("\n"),
+            RigMessage::Assistant { .. } => String::new(),
         }
     }
 

--- a/crates/ai-chat-agent/src/runtime.rs
+++ b/crates/ai-chat-agent/src/runtime.rs
@@ -64,10 +64,21 @@ impl AgentRuntime {
             },
         )?;
 
-        self.activate_skills(&request, &agent_run.id)?;
+        if let Err(error) = self.activate_skills(&request, &agent_run.id) {
+            return Err(self.mark_setup_failed(&agent_run.id, error)?);
+        }
 
-        let items = self.repo.conversation_items(&request.conversation_id)?;
-        let prompt_history = build_prompt_history(&items, &request.user_item_id, &agent_run.id)?;
+        let items = match self.repo.conversation_items(&request.conversation_id) {
+            Ok(items) => items,
+            Err(error) => {
+                return Err(self.mark_setup_failed(&agent_run.id, AgentRuntimeError::from(error))?);
+            }
+        };
+        let prompt_history =
+            match build_prompt_history(&items, &request.user_item_id, &agent_run.id) {
+                Ok(prompt_history) => prompt_history,
+                Err(error) => return Err(self.mark_setup_failed(&agent_run.id, error)?),
+            };
 
         let tool_server = ToolServer::new().run();
         let mut toolset = ToolSet::default();
@@ -78,7 +89,9 @@ impl AgentRuntime {
         {
             toolset.add_tool_boxed(tool);
         }
-        tool_server.append_toolset(toolset).await?;
+        if let Err(error) = tool_server.append_toolset(toolset).await {
+            return Err(self.mark_setup_failed(&agent_run.id, AgentRuntimeError::from(error))?);
+        }
 
         let context = PersistenceContext::new(
             self.repo.clone(),
@@ -199,6 +212,22 @@ impl AgentRuntime {
                 })
             }
         }
+    }
+
+    fn mark_setup_failed(
+        &self,
+        agent_run_id: &str,
+        error: AgentRuntimeError,
+    ) -> Result<AgentRuntimeError> {
+        self.repo.update_agent_run_status(
+            agent_run_id,
+            UpdateAgentRunStatus {
+                status: AgentRunStatus::Failed,
+                output: None,
+                error: Some(run_error("setup_error", error.to_string(), true, None)),
+            },
+        )?;
+        Ok(error)
     }
 
     pub fn decide_approval(
@@ -373,7 +402,7 @@ mod tests {
     };
     use async_trait::async_trait;
     use rig_core::{
-        completion::Message as RigMessage,
+        completion::{AssistantContent, Message as RigMessage},
         message::UserContent,
         test_utils::{MockCompletionModel, MockTurn},
     };
@@ -542,6 +571,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn setup_failure_marks_agent_run_failed() {
+        let fixture = Fixture::new("setup-failure");
+        let runtime = AgentRuntime::new(fixture.repo.clone());
+        let mut request = fixture.request();
+        request.project_root = Some(fixture.dir.path().to_path_buf());
+        request.skill_requests = vec![crate::SkillActivationRequest::new("missing-skill")];
+
+        let error = runtime
+            .run_with_model(request, MockCompletionModel::text("unused"))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("missing-skill"));
+
+        assert!(
+            fixture
+                .repo
+                .agent_runs_by_status(AgentRunStatus::Running)
+                .unwrap()
+                .is_empty()
+        );
+        let failed = fixture
+            .repo
+            .agent_runs_by_status(AgentRunStatus::Failed)
+            .unwrap();
+        assert_eq!(failed.len(), 1);
+        let payload = failed[0].error.as_ref().unwrap();
+        assert_eq!(payload.code, "setup_error");
+        assert!(payload.message.contains("missing-skill"));
+        assert!(payload.retryable);
+    }
+
+    #[tokio::test]
     async fn skill_activation_is_persisted_as_snapshot() {
         let fixture = Fixture::new("skills");
         let skill_dir = fixture.dir.path().join(".agents/skills/rust");
@@ -608,6 +669,109 @@ mod tests {
                 .iter()
                 .all(|message| !rig_message_text(message).contains("<skill>"))
         );
+    }
+
+    #[tokio::test]
+    async fn tool_history_replay_preserves_provider_call_ids() {
+        let fixture = Fixture::new("tool-history");
+        fixture
+            .repo
+            .append_conversation_item(NewConversationItem {
+                conversation_id: fixture.conversation.id.clone(),
+                status: ConversationItemStatus::Completed,
+                agent_run_id: None,
+                provider_step_id: None,
+                tool_invocation_id: None,
+                provider_item_id: None,
+                payload: ConversationItemPayload::ToolCall(ToolCallItem {
+                    tool_invocation_id: None,
+                    call_id: "call_previous".to_string(),
+                    source: ToolSource::Local,
+                    name: "echo".to_string(),
+                    runtime_tool_name: "echo".to_string(),
+                    arguments: ToolArguments {
+                        value: json!({"text": "hi"}),
+                    },
+                }),
+            })
+            .unwrap();
+        fixture
+            .repo
+            .append_conversation_item(NewConversationItem {
+                conversation_id: fixture.conversation.id.clone(),
+                status: ConversationItemStatus::Completed,
+                agent_run_id: None,
+                provider_step_id: None,
+                tool_invocation_id: None,
+                provider_item_id: None,
+                payload: ConversationItemPayload::ToolResult(ToolResultItem {
+                    tool_invocation_id: None,
+                    call_id: "call_previous".to_string(),
+                    content: vec![ContentPart::Text {
+                        text: "hi".to_string(),
+                    }],
+                    is_error: false,
+                    structured_output: None,
+                }),
+            })
+            .unwrap();
+        let next_user_item = fixture
+            .repo
+            .append_conversation_item(NewConversationItem {
+                conversation_id: fixture.conversation.id.clone(),
+                status: ConversationItemStatus::Completed,
+                agent_run_id: None,
+                provider_step_id: None,
+                tool_invocation_id: None,
+                provider_item_id: None,
+                payload: ConversationItemPayload::Message {
+                    role: TranscriptRole::User,
+                    content: vec![ContentPart::Text {
+                        text: "continue".to_string(),
+                    }],
+                },
+            })
+            .unwrap();
+        let runtime = AgentRuntime::new(fixture.repo.clone());
+        let mut request = fixture.request();
+        request.user_item_id = next_user_item.id;
+        let model = MockCompletionModel::text("ok");
+
+        runtime
+            .run_with_model(request, model.clone())
+            .await
+            .unwrap();
+
+        let requests = model.requests();
+        assert_eq!(requests.len(), 1);
+        let messages = requests[0].chat_history.iter().collect::<Vec<_>>();
+        let tool_call = messages
+            .iter()
+            .find_map(|message| match message {
+                RigMessage::Assistant { content, .. } => {
+                    content.iter().find_map(|content| match content {
+                        AssistantContent::ToolCall(call) => Some(call),
+                        _ => None,
+                    })
+                }
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(tool_call.id, "call_previous");
+        assert_eq!(tool_call.call_id.as_deref(), Some("call_previous"));
+
+        let tool_result = messages
+            .iter()
+            .find_map(|message| match message {
+                RigMessage::User { content } => content.iter().find_map(|content| match content {
+                    UserContent::ToolResult(result) => Some(result),
+                    _ => None,
+                }),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(tool_result.id, "call_previous");
+        assert_eq!(tool_result.call_id.as_deref(), Some("call_previous"));
     }
 
     struct Fixture {

--- a/crates/ai-chat-agent/src/runtime.rs
+++ b/crates/ai-chat-agent/src/runtime.rs
@@ -186,6 +186,16 @@ impl AgentRuntime {
                 } else {
                     AgentRunStatus::Failed
                 };
+                self.finalize_active_tool_invocations(
+                    &agent_run.id,
+                    &request.conversation_id,
+                    if final_status == AgentRunStatus::Canceled {
+                        ToolInvocationStatus::Canceled
+                    } else {
+                        ToolInvocationStatus::Failed
+                    },
+                    payload.clone(),
+                )?;
                 let output = (final_status == AgentRunStatus::Canceled).then_some(AgentRunOutput {
                     final_item_id: context.final_item_id(),
                     stopped_reason: AgentStoppedReason::Canceled,
@@ -212,6 +222,60 @@ impl AgentRuntime {
                 })
             }
         }
+    }
+
+    fn finalize_active_tool_invocations(
+        &self,
+        agent_run_id: &str,
+        conversation_id: &str,
+        status: ToolInvocationStatus,
+        error: RunErrorPayload,
+    ) -> Result<()> {
+        for invocation in self.repo.tool_invocations_for_run(agent_run_id)? {
+            if !matches!(
+                invocation.status,
+                ToolInvocationStatus::Requested
+                    | ToolInvocationStatus::AwaitingApproval
+                    | ToolInvocationStatus::Running
+            ) {
+                continue;
+            }
+
+            let output = ToolInvocationOutput {
+                content: vec![ContentPart::Text {
+                    text: error.message.clone(),
+                }],
+                structured_output: None,
+                raw_output: None,
+                is_error: true,
+            };
+            let payload = ConversationItemPayload::ToolResult(ToolResultItem {
+                tool_invocation_id: Some(invocation.id.clone()),
+                call_id: invocation.call_id.clone(),
+                content: output.content.clone(),
+                is_error: true,
+                structured_output: None,
+            });
+            self.repo
+                .append_conversation_item_and_update_tool_invocation(
+                    NewConversationItem {
+                        conversation_id: conversation_id.to_string(),
+                        status: ConversationItemStatus::Completed,
+                        agent_run_id: Some(agent_run_id.to_string()),
+                        provider_step_id: invocation.provider_step_id.clone(),
+                        tool_invocation_id: Some(invocation.id.clone()),
+                        provider_item_id: None,
+                        payload,
+                    },
+                    &invocation.id,
+                    UpdateToolInvocationStatus {
+                        status,
+                        output: Some(output),
+                        error: Some(error.clone()),
+                    },
+                )?;
+        }
+        Ok(())
     }
 
     fn mark_setup_failed(
@@ -397,8 +461,8 @@ mod tests {
     use crate::{LocalTool, McpConnector, ToolDefinition, ToolExecutor, ToolRunPolicy};
     use ai_chat_db::{
         ConversationItemRecord, ConversationRecord, FreshStore, NewConversation,
-        NewConversationItem, NewProject, NewProvider, NewProviderModel, ProviderModelRecord,
-        ProviderRecord,
+        NewConversationItem, NewProject, NewProvider, NewProviderModel, NewToolInvocation,
+        ProviderModelRecord, ProviderRecord,
     };
     use async_trait::async_trait;
     use rig_core::{
@@ -494,6 +558,76 @@ mod tests {
                 .iter()
                 .any(|item| matches!(item.payload, ConversationItemPayload::ToolResult(_)))
         );
+    }
+
+    #[tokio::test]
+    async fn prompt_error_fails_active_tool_invocations() {
+        let fixture = Fixture::new("tool-failure");
+        let runtime = AgentRuntime::new(fixture.repo.clone());
+        let agent_run = fixture
+            .repo
+            .insert_agent_run(new_agent_run_input(&fixture.request()))
+            .unwrap();
+        let invocation = fixture
+            .repo
+            .insert_tool_invocation(NewToolInvocation {
+                agent_run_id: agent_run.id.clone(),
+                provider_step_id: None,
+                status: ToolInvocationStatus::Running,
+                input: ToolInvocationInput {
+                    source: ToolSource::Local,
+                    namespace: None,
+                    tool_name: "echo".to_string(),
+                    runtime_tool_name: "echo".to_string(),
+                    call_id: "call_1".to_string(),
+                    arguments: ToolArguments {
+                        value: json!({"text": "hi"}),
+                    },
+                    approval_policy: ToolApprovalPolicy::Never,
+                    execution_policy: ToolExecutionPolicy::Foreground,
+                },
+                output: None,
+                error: None,
+            })
+            .unwrap();
+
+        runtime
+            .finalize_active_tool_invocations(
+                &agent_run.id,
+                &fixture.conversation.id,
+                ToolInvocationStatus::Failed,
+                run_error("prompt_error", "tool failed", true, None),
+            )
+            .unwrap();
+
+        let invocation = fixture
+            .repo
+            .get_tool_invocation(&invocation.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(invocation.status, ToolInvocationStatus::Failed);
+        let error = invocation.error.as_ref().unwrap();
+        assert_eq!(error.code, "prompt_error");
+        assert_eq!(error.message, "tool failed");
+        let invocations = fixture
+            .repo
+            .tool_invocations_for_run(&agent_run.id)
+            .unwrap();
+        assert_eq!(invocations.len(), 1);
+
+        let tool_results = fixture
+            .repo
+            .conversation_items(&fixture.conversation.id)
+            .unwrap()
+            .into_iter()
+            .filter_map(|item| match item.payload {
+                ConversationItemPayload::ToolResult(result) => Some(result),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(tool_results.len(), 1);
+        assert_eq!(tool_results[0].call_id, "call_1");
+        assert!(tool_results[0].is_error);
     }
 
     #[tokio::test]

--- a/crates/ai-chat-agent/src/runtime.rs
+++ b/crates/ai-chat-agent/src/runtime.rs
@@ -94,6 +94,10 @@ impl AgentRuntime {
             return Err(self.mark_setup_failed(&agent_run.id, AgentRuntimeError::from(error))?);
         }
 
+        let registered_definitions = request.tool_registry.registered_definitions();
+        let runtime_tools = request
+            .tool_registry
+            .runtime_tools(request.guards.tool_timeout);
         let context = PersistenceContext::new(
             self.repo.clone(),
             agent_run.id.clone(),
@@ -102,7 +106,8 @@ impl AgentRuntime {
             request.model_id.clone(),
             request.settings_snapshot.clone(),
             prompt_history.input_item_ids,
-            request.tool_registry.registered_definitions(),
+            registered_definitions,
+            runtime_tools,
             request.guards.max_tool_calls,
             request.guards.repeated_tool_call_limit,
             request.cancellation_token.clone(),
@@ -273,6 +278,7 @@ impl AgentRuntime {
             content: output.content.clone(),
             is_error: true,
             structured_output: None,
+            raw_output: None,
         });
         let (item, _) = self
             .repo
@@ -635,6 +641,17 @@ mod tests {
         assert_eq!(invocations.len(), 1);
         assert_eq!(invocations[0].status, ToolInvocationStatus::Succeeded);
         assert_eq!(invocations[0].runtime_tool_name, "echo");
+        let output = invocations[0].output.as_ref().unwrap();
+        assert_eq!(
+            output.content,
+            vec![ContentPart::Text {
+                text: "hi".to_string()
+            }]
+        );
+        assert_eq!(
+            output.structured_output.as_ref().unwrap().value,
+            json!({"text": "hi"})
+        );
 
         let items = fixture
             .repo
@@ -649,6 +666,92 @@ mod tests {
             items
                 .iter()
                 .any(|item| matches!(item.payload, ConversationItemPayload::ToolResult(_)))
+        );
+        let tool_result = items
+            .iter()
+            .find_map(|item| match &item.payload {
+                ConversationItemPayload::ToolResult(result) => Some(result),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(
+            tool_result.content,
+            vec![ContentPart::Text {
+                text: "hi".to_string()
+            }]
+        );
+        assert_eq!(
+            tool_result.structured_output.as_ref().unwrap().value,
+            json!({"text": "hi"})
+        );
+        assert!(!tool_result.is_error);
+    }
+
+    #[tokio::test]
+    async fn tool_error_output_is_persisted_without_reconstructing_from_model_text() {
+        let fixture = Fixture::new("tool-error-output");
+        let runtime = AgentRuntime::new(fixture.repo.clone());
+        let mut request = fixture.request();
+        request
+            .tool_registry
+            .register_local_tool(ErrorTool)
+            .unwrap();
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("call_1", "error_tool", json!({"code": "E_BAD"})),
+            MockTurn::text("handled"),
+        ]);
+
+        let handle = runtime.run_with_model(request, model).await.unwrap();
+        assert_eq!(handle.agent_run.status, AgentRunStatus::Completed);
+        let invocations = fixture
+            .repo
+            .tool_invocations_for_run(&handle.agent_run.id)
+            .unwrap();
+        assert_eq!(invocations.len(), 1);
+        assert_eq!(invocations[0].status, ToolInvocationStatus::Failed);
+        assert_eq!(invocations[0].error.as_ref().unwrap().code, "tool_error");
+        let output = invocations[0].output.as_ref().unwrap();
+        assert!(output.is_error);
+        assert_eq!(
+            output.content,
+            vec![ContentPart::Text {
+                text: "human readable error".to_string()
+            }]
+        );
+        assert_eq!(
+            output.structured_output.as_ref().unwrap().value,
+            json!({"code": "E_BAD"})
+        );
+        assert_eq!(
+            output.raw_output.as_ref().unwrap().value,
+            json!({"raw": "details"})
+        );
+
+        let items = fixture
+            .repo
+            .conversation_items(&fixture.conversation.id)
+            .unwrap();
+        let tool_result = items
+            .iter()
+            .find_map(|item| match &item.payload {
+                ConversationItemPayload::ToolResult(result) => Some(result),
+                _ => None,
+            })
+            .unwrap();
+        assert!(tool_result.is_error);
+        assert_eq!(
+            tool_result.content,
+            vec![ContentPart::Text {
+                text: "human readable error".to_string()
+            }]
+        );
+        assert_eq!(
+            tool_result.structured_output.as_ref().unwrap().value,
+            json!({"code": "E_BAD"})
+        );
+        assert_eq!(
+            tool_result.raw_output.as_ref().unwrap().value,
+            json!({"raw": "details"})
         );
     }
 
@@ -1153,6 +1256,7 @@ mod tests {
                     }],
                     is_error: false,
                     structured_output: None,
+                    raw_output: None,
                 }),
             })
             .unwrap();
@@ -1499,6 +1603,49 @@ mod tests {
                 }),
                 policy: ToolRunPolicy {
                     approval_policy: self.approval_policy,
+                    execution_policy: ToolExecutionPolicy::Foreground,
+                    timeout_ms: None,
+                },
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct ErrorTool;
+
+    #[async_trait]
+    impl ToolExecutor for ErrorTool {
+        async fn execute(&self, arguments: serde_json::Value) -> Result<ToolInvocationOutput> {
+            Ok(ToolInvocationOutput {
+                content: vec![ContentPart::Text {
+                    text: "human readable error".to_string(),
+                }],
+                structured_output: Some(StructuredOutput { value: arguments }),
+                raw_output: Some(ProviderRawPayload {
+                    provider_kind: "test".to_string(),
+                    value: json!({"raw": "details"}),
+                }),
+                is_error: true,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl LocalTool for ErrorTool {
+        fn definition(&self) -> ToolDefinition {
+            ToolDefinition {
+                source: ToolSource::Local,
+                namespace: None,
+                name: "error_tool".to_string(),
+                description: "Return an error output".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "code": { "type": "string" }
+                    }
+                }),
+                policy: ToolRunPolicy {
+                    approval_policy: ToolApprovalPolicy::Never,
                     execution_policy: ToolExecutionPolicy::Foreground,
                     timeout_ms: None,
                 },

--- a/crates/ai-chat-agent/src/runtime.rs
+++ b/crates/ai-chat-agent/src/runtime.rs
@@ -1,0 +1,870 @@
+use crate::{
+    AgentRunHandle, AgentRunRequest, AgentRuntimeError, Result, SkillCatalog, SkillLoader,
+    history::build_prompt_history,
+    persistence::{PersistenceContext, PersistingCompletionModel, new_agent_run_input, run_error},
+};
+use ai_chat_core::*;
+use ai_chat_db::{
+    AgentRunRecord, ApprovalDecisionRecord, FreshRepository, NewApprovalDecisionOutcome,
+    NewConversationItem, UpdateAgentRunStatus, UpdateToolInvocationStatus,
+};
+use rig_core::{
+    agent::AgentBuilder,
+    completion::{CompletionModel, Prompt},
+    tool::{ToolSet, server::ToolServer},
+};
+
+#[derive(Clone)]
+pub struct AgentRuntime {
+    repo: FreshRepository,
+    skill_loader: SkillLoader,
+}
+
+impl AgentRuntime {
+    pub fn new(repo: FreshRepository) -> Self {
+        Self {
+            repo,
+            skill_loader: SkillLoader::new(),
+        }
+    }
+
+    pub fn with_skill_loader(mut self, skill_loader: SkillLoader) -> Self {
+        self.skill_loader = skill_loader;
+        self
+    }
+
+    pub async fn run_with_model<M>(
+        &self,
+        mut request: AgentRunRequest,
+        model: M,
+    ) -> Result<AgentRunHandle>
+    where
+        M: CompletionModel + 'static,
+        M::Response: serde::Serialize + serde::de::DeserializeOwned,
+        M::StreamingResponse: Clone
+            + Unpin
+            + Send
+            + Sync
+            + serde::Serialize
+            + serde::de::DeserializeOwned
+            + rig_core::completion::GetTokenUsage,
+    {
+        if request.cancellation_token.is_cancelled() {
+            return Err(AgentRuntimeError::Canceled);
+        }
+
+        request.tool_registry.finalize_names();
+        let mut agent_run = self.repo.insert_agent_run(new_agent_run_input(&request))?;
+        agent_run = self.repo.update_agent_run_status(
+            &agent_run.id,
+            UpdateAgentRunStatus {
+                status: AgentRunStatus::Running,
+                output: None,
+                error: None,
+            },
+        )?;
+
+        self.activate_skills(&request, &agent_run.id)?;
+
+        let items = self.repo.conversation_items(&request.conversation_id)?;
+        let prompt_history = build_prompt_history(&items, &request.user_item_id)?;
+
+        let tool_server = ToolServer::new().run();
+        let mut toolset = ToolSet::default();
+        for tool in request
+            .tool_registry
+            .clone()
+            .into_rig_tools(request.guards.tool_timeout)
+        {
+            toolset.add_tool_boxed(tool);
+        }
+        tool_server.append_toolset(toolset).await?;
+
+        let context = PersistenceContext::new(
+            self.repo.clone(),
+            agent_run.id.clone(),
+            request.conversation_id.clone(),
+            request.provider_id.clone(),
+            request.model_id.clone(),
+            request.settings_snapshot.clone(),
+            prompt_history.input_item_ids,
+            request.tool_registry.registered_definitions(),
+            request.guards.max_tool_calls,
+            request.guards.repeated_tool_call_limit,
+            request.cancellation_token.clone(),
+        );
+        let model = PersistingCompletionModel::new(model, context.clone());
+        let hook = context.hook();
+
+        let mut builder = AgentBuilder::new(model)
+            .name("ai-chat-agent")
+            .hook(hook)
+            .tool_server_handle(tool_server)
+            .default_max_turns(request.guards.max_steps as usize);
+        if let Some(prompt) = prompt_preamble(request.prompt_snapshot.as_ref()) {
+            builder = builder.preamble(&prompt);
+        }
+        if !request.provider_tools.is_empty() {
+            builder = builder.additional_params(serde_json::json!({
+                "tools": request.provider_tools,
+            }));
+        }
+        let agent = builder.build();
+
+        let response = agent
+            .prompt(prompt_history.prompt)
+            .with_history(prompt_history.history)
+            .with_tool_concurrency(request.guards.tool_concurrency)
+            .without_memory()
+            .extended_details()
+            .await;
+
+        match response {
+            Ok(_response) => {
+                let output = AgentRunOutput {
+                    final_item_id: context.final_item_id(),
+                    stopped_reason: AgentStoppedReason::Completed,
+                };
+                let agent_run = self.repo.update_agent_run_status(
+                    &agent_run.id,
+                    UpdateAgentRunStatus {
+                        status: AgentRunStatus::Completed,
+                        output: Some(output.clone()),
+                        error: None,
+                    },
+                )?;
+                let mut events = context.events();
+                events.push(AgentRunEvent::Completed {
+                    output: output.clone(),
+                });
+                Ok(AgentRunHandle {
+                    agent_run,
+                    output: Some(output),
+                    events,
+                    steps: context.steps(),
+                })
+            }
+            Err(error) => {
+                let status = self
+                    .repo
+                    .get_agent_run(&agent_run.id)?
+                    .map(|run| run.status)
+                    .unwrap_or(AgentRunStatus::Failed);
+                if status == AgentRunStatus::WaitingForApproval {
+                    let mut events = context.events();
+                    events.push(AgentRunEvent::Failed {
+                        error: run_error("waiting_for_approval", error.to_string(), true, None),
+                    });
+                    let agent_run = self.repo.get_agent_run(&agent_run.id)?.ok_or_else(|| {
+                        AgentRuntimeError::Invariant("agent run disappeared".to_string())
+                    })?;
+                    return Ok(AgentRunHandle {
+                        agent_run,
+                        output: None,
+                        events,
+                        steps: context.steps(),
+                    });
+                }
+
+                let payload = if request.cancellation_token.is_cancelled() {
+                    run_error("canceled", "runtime canceled", false, None)
+                } else {
+                    run_error("prompt_error", error.to_string(), true, None)
+                };
+                let final_status = if request.cancellation_token.is_cancelled() {
+                    AgentRunStatus::Canceled
+                } else {
+                    AgentRunStatus::Failed
+                };
+                let output = (final_status == AgentRunStatus::Canceled).then_some(AgentRunOutput {
+                    final_item_id: context.final_item_id(),
+                    stopped_reason: AgentStoppedReason::Canceled,
+                });
+                let agent_run = self.repo.update_agent_run_status(
+                    &agent_run.id,
+                    UpdateAgentRunStatus {
+                        status: final_status,
+                        output: output.clone(),
+                        error: (final_status == AgentRunStatus::Failed).then_some(payload.clone()),
+                    },
+                )?;
+                let mut events = context.events();
+                if final_status == AgentRunStatus::Canceled {
+                    events.push(AgentRunEvent::Canceled);
+                } else {
+                    events.push(AgentRunEvent::Failed { error: payload });
+                }
+                Ok(AgentRunHandle {
+                    agent_run,
+                    output,
+                    events,
+                    steps: context.steps(),
+                })
+            }
+        }
+    }
+
+    pub fn decide_approval(
+        &self,
+        approval_decision_id: &str,
+        outcome: NewApprovalDecisionOutcome,
+    ) -> Result<ApprovalDecisionRecord> {
+        let approval = self
+            .repo
+            .get_approval_decision(approval_decision_id)?
+            .ok_or_else(|| {
+                AgentRuntimeError::Invariant(format!(
+                    "approval decision {approval_decision_id} is missing"
+                ))
+            })?;
+        let invocation = self
+            .repo
+            .get_tool_invocation(&approval.tool_invocation_id)?
+            .ok_or_else(|| {
+                AgentRuntimeError::Invariant(format!(
+                    "tool invocation {} is missing",
+                    approval.tool_invocation_id
+                ))
+            })?;
+        let updated = self
+            .repo
+            .update_approval_decision(approval_decision_id, outcome)?;
+        if let Some(decision) = updated.decision.as_ref() {
+            let payload = ConversationItemPayload::ApprovalDecision(ApprovalDecisionItem {
+                approval_decision_id: updated.id.clone(),
+                decision: decision.clone(),
+            });
+            self.repo.append_conversation_item(NewConversationItem {
+                conversation_id: self
+                    .repo
+                    .get_agent_run(&invocation.agent_run_id)?
+                    .ok_or_else(|| {
+                        AgentRuntimeError::Invariant(format!(
+                            "agent run {} is missing",
+                            invocation.agent_run_id
+                        ))
+                    })?
+                    .conversation_id,
+                status: ConversationItemStatus::Completed,
+                agent_run_id: Some(invocation.agent_run_id.clone()),
+                provider_step_id: invocation.provider_step_id.clone(),
+                tool_invocation_id: Some(invocation.id.clone()),
+                provider_item_id: None,
+                payload,
+            })?;
+            if !decision.approved {
+                let output = ToolInvocationOutput {
+                    content: vec![ContentPart::Text {
+                        text: decision
+                            .reason
+                            .clone()
+                            .unwrap_or_else(|| "Tool call denied by user".to_string()),
+                    }],
+                    structured_output: None,
+                    raw_output: None,
+                    is_error: true,
+                };
+                self.repo.update_tool_invocation_status(
+                    &invocation.id,
+                    UpdateToolInvocationStatus {
+                        status: ToolInvocationStatus::Denied,
+                        output: Some(output.clone()),
+                        error: None,
+                    },
+                )?;
+                self.repo.append_conversation_item(NewConversationItem {
+                    conversation_id: self
+                        .repo
+                        .get_agent_run(&invocation.agent_run_id)?
+                        .ok_or_else(|| {
+                            AgentRuntimeError::Invariant(format!(
+                                "agent run {} is missing",
+                                invocation.agent_run_id
+                            ))
+                        })?
+                        .conversation_id,
+                    status: ConversationItemStatus::Completed,
+                    agent_run_id: Some(invocation.agent_run_id.clone()),
+                    provider_step_id: invocation.provider_step_id,
+                    tool_invocation_id: Some(invocation.id.clone()),
+                    provider_item_id: None,
+                    payload: ConversationItemPayload::ToolResult(ToolResultItem {
+                        tool_invocation_id: Some(invocation.id),
+                        call_id: invocation.call_id,
+                        content: output.content,
+                        is_error: true,
+                        structured_output: None,
+                    }),
+                })?;
+            }
+        }
+        Ok(updated)
+    }
+
+    pub fn recover_interrupted_runs(&self) -> Result<Vec<AgentRunRecord>> {
+        let mut recovered = Vec::new();
+        for status in [AgentRunStatus::Queued, AgentRunStatus::Running] {
+            for run in self.repo.agent_runs_by_status(status)? {
+                let error = run_error(
+                    "interrupted",
+                    "agent run was interrupted before reaching a terminal state",
+                    true,
+                    None,
+                );
+                recovered.push(self.repo.update_agent_run_status(
+                    &run.id,
+                    UpdateAgentRunStatus {
+                        status: AgentRunStatus::Failed,
+                        output: None,
+                        error: Some(error),
+                    },
+                )?);
+            }
+        }
+        Ok(recovered)
+    }
+
+    fn activate_skills(&self, request: &AgentRunRequest, agent_run_id: &str) -> Result<()> {
+        if request.skill_requests.is_empty() {
+            return Ok(());
+        }
+        let catalog = SkillCatalog::scan(request.project_root.as_deref())?;
+        for skill_request in &request.skill_requests {
+            let entry = catalog.get(&skill_request.name).ok_or_else(|| {
+                AgentRuntimeError::Invariant(format!("skill {} is missing", skill_request.name))
+            })?;
+            let activation = self.skill_loader.load(entry)?;
+            self.repo.append_conversation_item(NewConversationItem {
+                conversation_id: request.conversation_id.clone(),
+                status: ConversationItemStatus::Completed,
+                agent_run_id: Some(agent_run_id.to_string()),
+                provider_step_id: None,
+                tool_invocation_id: None,
+                provider_item_id: None,
+                payload: ConversationItemPayload::SkillActivation(activation),
+            })?;
+        }
+        Ok(())
+    }
+}
+
+fn prompt_preamble(prompt: Option<&PromptContent>) -> Option<String> {
+    let prompt = prompt?;
+    let text = prompt
+        .messages
+        .iter()
+        .filter(|message| {
+            matches!(
+                message.role,
+                TranscriptRole::System | TranscriptRole::Developer
+            )
+        })
+        .flat_map(|message| message.content.iter().filter_map(ContentPart::search_text))
+        .collect::<Vec<_>>()
+        .join("\n");
+    (!text.is_empty()).then_some(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{LocalTool, McpConnector, ToolDefinition, ToolExecutor, ToolRunPolicy};
+    use ai_chat_db::{
+        ConversationItemRecord, ConversationRecord, FreshStore, NewConversation,
+        NewConversationItem, NewProject, NewProvider, NewProviderModel, ProviderModelRecord,
+        ProviderRecord,
+    };
+    use async_trait::async_trait;
+    use rig_core::test_utils::{MockCompletionModel, MockTurn};
+    use rmcp::{
+        RoleServer, ServerHandler, ServiceExt,
+        model::{
+            CallToolRequestParams, CallToolResult, Content, ErrorData, Implementation,
+            ListToolsResult, PaginatedRequestParams, ProtocolVersion, ServerCapabilities,
+            ServerInfo, Tool,
+        },
+        service::RequestContext,
+    };
+    use serde_json::json;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+    use tokio::sync::RwLock;
+
+    #[tokio::test]
+    async fn no_tool_run_persists_provider_step_and_final_message() {
+        let fixture = Fixture::new("no-tool");
+        let runtime = AgentRuntime::new(fixture.repo.clone());
+        let model = MockCompletionModel::text("hello from model");
+        let handle = runtime
+            .run_with_model(fixture.request(), model)
+            .await
+            .unwrap();
+
+        assert_eq!(handle.agent_run.status, AgentRunStatus::Completed);
+        assert_eq!(
+            handle.output.unwrap().stopped_reason,
+            AgentStoppedReason::Completed
+        );
+        assert_eq!(
+            fixture
+                .repo
+                .provider_steps_for_run(&handle.agent_run.id)
+                .unwrap()
+                .len(),
+            1
+        );
+        let items = fixture
+            .repo
+            .conversation_items(&fixture.conversation.id)
+            .unwrap();
+        assert!(items.iter().any(|item| matches!(
+            &item.payload,
+            ConversationItemPayload::Message {
+                role: TranscriptRole::Assistant,
+                content,
+            } if content[0].search_text() == Some("hello from model")
+        )));
+    }
+
+    #[tokio::test]
+    async fn rig_tool_call_persists_tool_call_and_result() {
+        let fixture = Fixture::new("tool-run");
+        let runtime = AgentRuntime::new(fixture.repo.clone());
+        let mut request = fixture.request();
+        request
+            .tool_registry
+            .register_local_tool(EchoTool::new(ToolApprovalPolicy::Never))
+            .unwrap();
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("call_1", "echo", json!({"text": "hi"})),
+            MockTurn::text("done"),
+        ]);
+
+        let handle = runtime.run_with_model(request, model).await.unwrap();
+        assert_eq!(handle.agent_run.status, AgentRunStatus::Completed);
+        let invocations = fixture
+            .repo
+            .tool_invocations_for_run(&handle.agent_run.id)
+            .unwrap();
+        assert_eq!(invocations.len(), 1);
+        assert_eq!(invocations[0].status, ToolInvocationStatus::Succeeded);
+        assert_eq!(invocations[0].runtime_tool_name, "echo");
+
+        let items = fixture
+            .repo
+            .conversation_items(&fixture.conversation.id)
+            .unwrap();
+        assert!(
+            items
+                .iter()
+                .any(|item| matches!(item.payload, ConversationItemPayload::ToolCall(_)))
+        );
+        assert!(
+            items
+                .iter()
+                .any(|item| matches!(item.payload, ConversationItemPayload::ToolResult(_)))
+        );
+    }
+
+    #[tokio::test]
+    async fn rmcp_tool_call_is_registered_and_persisted_with_source_server() {
+        let fixture = Fixture::new("mcp-tool-run");
+        let runtime = AgentRuntime::new(fixture.repo.clone());
+        let mcp_service = start_mcp_server(vec![make_mcp_tool("mcp_echo", "Echo over MCP")]).await;
+        let tools = mcp_service.peer().list_all_tools().await.unwrap();
+
+        let mut request = fixture.request();
+        McpConnector::new()
+            .register_rmcp_tools(
+                &mut request.tool_registry,
+                "test-server",
+                tools,
+                mcp_service.peer().clone(),
+                ToolApprovalPolicy::Never,
+                ToolExecutionPolicy::Foreground,
+            )
+            .unwrap();
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("call_1", "mcp_echo", json!({"text": "hi"})),
+            MockTurn::text("done"),
+        ]);
+
+        let handle = runtime.run_with_model(request, model).await.unwrap();
+        let invocations = fixture
+            .repo
+            .tool_invocations_for_run(&handle.agent_run.id)
+            .unwrap();
+        assert_eq!(invocations.len(), 1);
+        assert_eq!(
+            invocations[0].source,
+            ToolSource::Mcp {
+                server_id: "test-server".to_string(),
+            }
+        );
+        assert_eq!(invocations[0].tool_name, "mcp_echo");
+        assert_eq!(invocations[0].runtime_tool_name, "mcp_echo");
+        assert_eq!(invocations[0].status, ToolInvocationStatus::Succeeded);
+    }
+
+    #[tokio::test]
+    async fn approval_policy_pauses_run_with_pending_decision() {
+        let fixture = Fixture::new("approval");
+        let runtime = AgentRuntime::new(fixture.repo.clone());
+        let mut request = fixture.request();
+        request
+            .tool_registry
+            .register_local_tool(EchoTool::new(ToolApprovalPolicy::OnRequest))
+            .unwrap();
+        let model = MockCompletionModel::new([MockTurn::tool_call(
+            "call_1",
+            "echo",
+            json!({"text": "hi"}),
+        )]);
+
+        let handle = runtime.run_with_model(request, model).await.unwrap();
+        assert_eq!(handle.agent_run.status, AgentRunStatus::WaitingForApproval);
+        let pending = fixture.repo.pending_approval_decisions().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert!(
+            handle
+                .events
+                .iter()
+                .any(|event| matches!(event, AgentRunEvent::ApprovalRequested { .. }))
+        );
+    }
+
+    #[tokio::test]
+    async fn skill_activation_is_persisted_as_snapshot() {
+        let fixture = Fixture::new("skills");
+        let skill_dir = fixture.dir.path().join(".agents/skills/rust");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let skill_file = skill_dir.join("SKILL.md");
+        std::fs::write(
+            &skill_file,
+            "---\nname: rust\ndescription: Rust workflow\n---\nUse cargo test.\n",
+        )
+        .unwrap();
+
+        let runtime = AgentRuntime::new(fixture.repo.clone());
+        let mut request = fixture.request();
+        request.project_root = Some(fixture.dir.path().to_path_buf());
+        request.skill_requests = vec![crate::SkillActivationRequest::new("rust")];
+        runtime
+            .run_with_model(request, MockCompletionModel::text("ok"))
+            .await
+            .unwrap();
+        std::fs::write(&skill_file, "---\nname: rust\n---\nUse cargo clippy.\n").unwrap();
+
+        let items = fixture
+            .repo
+            .conversation_items(&fixture.conversation.id)
+            .unwrap();
+        let skill = items
+            .iter()
+            .find_map(|item| match &item.payload {
+                ConversationItemPayload::SkillActivation(skill) => Some(skill),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(skill.name, "rust");
+        assert_eq!(
+            skill.content,
+            vec![ContentPart::Text {
+                text: "---\nname: rust\ndescription: Rust workflow\n---\nUse cargo test.\n"
+                    .to_string(),
+            }]
+        );
+    }
+
+    struct Fixture {
+        dir: TempDir,
+        repo: FreshRepository,
+        conversation: ConversationRecord,
+        provider: ProviderRecord,
+        model: ProviderModelRecord,
+        user_item: ConversationItemRecord,
+    }
+
+    impl Fixture {
+        fn new(name: &str) -> Self {
+            let dir = tempfile::tempdir().unwrap();
+            let store = FreshStore::open_in_dir(dir.path()).unwrap();
+            let repo = store.repository();
+            let project = repo
+                .insert_project(NewProject {
+                    path: dir.path().to_string_lossy().to_string(),
+                    display_name: name.to_string(),
+                    kind: ProjectKind::Normal,
+                    metadata: ProjectMetadata {
+                        scratch_reason: None,
+                        git_root: Some(dir.path().to_string_lossy().to_string()),
+                        last_active_conversation_id: None,
+                    },
+                })
+                .unwrap();
+            let provider = repo
+                .insert_provider(NewProvider {
+                    kind: "openai".to_string(),
+                    display_name: "OpenAI".to_string(),
+                    enabled: true,
+                    settings: provider_settings(),
+                    secret_refs: ProviderSecretRefs { refs: Vec::new() },
+                })
+                .unwrap();
+            let model = repo
+                .upsert_provider_model(NewProviderModel {
+                    provider_id: provider.id.clone(),
+                    model_id: "gpt-5.2".to_string(),
+                    display_name: Some("GPT-5.2".to_string()),
+                    capabilities: model_capabilities(),
+                    metadata: ProviderModelMetadata {
+                        display_name: Some("GPT-5.2".to_string()),
+                        family: Some("gpt".to_string()),
+                        raw: None,
+                    },
+                })
+                .unwrap();
+            let conversation = repo
+                .insert_conversation(NewConversation {
+                    project_id: project.id,
+                    title: name.to_string(),
+                    prompt_id: None,
+                    default_provider_id: Some(provider.id.clone()),
+                    default_model_id: Some(model.model_id.clone()),
+                    metadata: ConversationMetadata {
+                        summary: None,
+                        tags: Vec::new(),
+                        pinned: false,
+                    },
+                    settings_snapshot: ConversationSettingsSnapshot {
+                        prompt: None,
+                        provider_id: Some(provider.id.clone()),
+                        model_id: Some(model.model_id.clone()),
+                        model_capabilities: Some(model_capabilities()),
+                        tool_policy: ToolPolicySnapshot {
+                            approval_policy: ToolApprovalPolicy::Never,
+                            enabled_sources: vec![ToolSource::Local],
+                            max_steps: 8,
+                        },
+                    },
+                })
+                .unwrap();
+            let user_item = repo
+                .append_conversation_item(NewConversationItem {
+                    conversation_id: conversation.id.clone(),
+                    status: ConversationItemStatus::Completed,
+                    agent_run_id: None,
+                    provider_step_id: None,
+                    tool_invocation_id: None,
+                    provider_item_id: None,
+                    payload: ConversationItemPayload::Message {
+                        role: TranscriptRole::User,
+                        content: vec![ContentPart::Text {
+                            text: "hello".to_string(),
+                        }],
+                    },
+                })
+                .unwrap();
+            Self {
+                dir,
+                repo,
+                conversation,
+                provider,
+                model,
+                user_item,
+            }
+        }
+
+        fn request(&self) -> AgentRunRequest {
+            AgentRunRequest::new(
+                self.conversation.id.clone(),
+                self.user_item.id.clone(),
+                self.provider.id.clone(),
+                self.model.model_id.clone(),
+                run_settings(&self.provider.id, &self.model.model_id),
+                AgentRuntimeSnapshot {
+                    engine: AgentEngineKind::Rig,
+                    engine_version: "0.37.0".to_string(),
+                    skill_catalog_hash: None,
+                    mcp_config_hash: None,
+                    tool_name_strategy: ToolNameStrategy::Namespaced,
+                },
+            )
+        }
+    }
+
+    #[derive(Clone)]
+    struct EchoTool {
+        approval_policy: ToolApprovalPolicy,
+    }
+
+    impl EchoTool {
+        fn new(approval_policy: ToolApprovalPolicy) -> Self {
+            Self { approval_policy }
+        }
+    }
+
+    #[async_trait]
+    impl ToolExecutor for EchoTool {
+        async fn execute(&self, arguments: serde_json::Value) -> Result<ToolInvocationOutput> {
+            Ok(ToolInvocationOutput {
+                content: vec![ContentPart::Text {
+                    text: arguments
+                        .get("text")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                }],
+                structured_output: Some(StructuredOutput { value: arguments }),
+                raw_output: None,
+                is_error: false,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl LocalTool for EchoTool {
+        fn definition(&self) -> ToolDefinition {
+            ToolDefinition {
+                source: ToolSource::Local,
+                namespace: None,
+                name: "echo".to_string(),
+                description: "Echo text".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "text": { "type": "string" }
+                    }
+                }),
+                policy: ToolRunPolicy {
+                    approval_policy: self.approval_policy,
+                    execution_policy: ToolExecutionPolicy::Foreground,
+                    timeout_ms: None,
+                },
+            }
+        }
+    }
+
+    fn run_settings(provider_id: &str, model_id: &str) -> RunSettingsSnapshot {
+        RunSettingsSnapshot {
+            prompt: Some(PromptContent {
+                messages: vec![PromptMessage {
+                    role: TranscriptRole::System,
+                    content: vec![ContentPart::Text {
+                        text: "You are useful.".to_string(),
+                    }],
+                }],
+            }),
+            provider_id: provider_id.to_string(),
+            model_id: model_id.to_string(),
+            model_capabilities: model_capabilities(),
+            provider_settings: provider_settings(),
+            tool_policy: ToolPolicySnapshot {
+                approval_policy: ToolApprovalPolicy::Never,
+                enabled_sources: vec![ToolSource::Local],
+                max_steps: 8,
+            },
+        }
+    }
+
+    fn provider_settings() -> ProviderSettingsPayload {
+        ProviderSettingsPayload {
+            provider_kind: "openai".to_string(),
+            fields: Vec::new(),
+        }
+    }
+
+    fn model_capabilities() -> ModelCapabilitiesSnapshot {
+        ModelCapabilitiesSnapshot {
+            text_input: true,
+            text_output: true,
+            streaming: true,
+            image_input: None,
+            file_input: None,
+            audio_input: false,
+            image_generation: false,
+            tool_calling: Some(ToolCallingCapabilitySnapshot {
+                parallel_tool_calls: true,
+            }),
+            hosted_web_search: true,
+            remote_mcp: false,
+            reasoning: None,
+            structured_output: true,
+            stateful_response_continuation: true,
+            extension: ProviderCapabilityExtensionSnapshot::OpenAi {
+                responses_api: true,
+                raw: None,
+            },
+        }
+    }
+
+    #[derive(Clone)]
+    struct DynamicMcpServer {
+        tools: Arc<RwLock<Vec<Tool>>>,
+    }
+
+    impl DynamicMcpServer {
+        fn new(tools: Vec<Tool>) -> Self {
+            Self {
+                tools: Arc::new(RwLock::new(tools)),
+            }
+        }
+    }
+
+    impl ServerHandler for DynamicMcpServer {
+        fn get_info(&self) -> ServerInfo {
+            ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+                .with_protocol_version(ProtocolVersion::LATEST)
+                .with_server_info(Implementation::new("ai-chat-agent-test", "0.1.0"))
+        }
+
+        async fn list_tools(
+            &self,
+            _request: Option<PaginatedRequestParams>,
+            _context: RequestContext<RoleServer>,
+        ) -> std::result::Result<ListToolsResult, ErrorData> {
+            Ok(ListToolsResult::with_all_items(
+                self.tools.read().await.clone(),
+            ))
+        }
+
+        async fn call_tool(
+            &self,
+            request: CallToolRequestParams,
+            _context: RequestContext<RoleServer>,
+        ) -> std::result::Result<CallToolResult, ErrorData> {
+            Ok(CallToolResult::success(vec![Content::text(format!(
+                "called {}",
+                request.name
+            ))]))
+        }
+    }
+
+    fn make_mcp_tool(name: &str, description: &str) -> Tool {
+        Tool::new(
+            name.to_string(),
+            description.to_string(),
+            Arc::new(serde_json::Map::new()),
+        )
+    }
+
+    async fn start_mcp_server(
+        tools: Vec<Tool>,
+    ) -> rmcp::service::RunningService<rmcp::service::RoleClient, ()> {
+        let server = DynamicMcpServer::new(tools);
+        let (client_to_server, server_from_client) = tokio::io::duplex(8192);
+        let (server_to_client, client_from_server) = tokio::io::duplex(8192);
+
+        tokio::spawn(async move {
+            let service = server
+                .serve((server_from_client, server_to_client))
+                .await
+                .expect("server failed to start");
+            service.waiting().await.expect("server error");
+        });
+
+        ().serve((client_from_server, client_to_server))
+            .await
+            .expect("client failed to connect")
+    }
+}

--- a/crates/ai-chat-agent/src/runtime.rs
+++ b/crates/ai-chat-agent/src/runtime.rs
@@ -6,7 +6,8 @@ use crate::{
 use ai_chat_core::*;
 use ai_chat_db::{
     AgentRunRecord, ApprovalDecisionRecord, FreshRepository, NewApprovalDecisionOutcome,
-    NewConversationItem, UpdateAgentRunStatus, UpdateToolInvocationStatus,
+    NewConversationItem, ToolInvocationRecord, UpdateAgentRunStatus, UpdateProviderStepStatus,
+    UpdateToolInvocationStatus,
 };
 use rig_core::{
     agent::AgentBuilder,
@@ -241,39 +242,78 @@ impl AgentRuntime {
                 continue;
             }
 
-            let output = ToolInvocationOutput {
-                content: vec![ContentPart::Text {
-                    text: error.message.clone(),
-                }],
-                structured_output: None,
-                raw_output: None,
-                is_error: true,
-            };
-            let payload = ConversationItemPayload::ToolResult(ToolResultItem {
-                tool_invocation_id: Some(invocation.id.clone()),
-                call_id: invocation.call_id.clone(),
-                content: output.content.clone(),
-                is_error: true,
-                structured_output: None,
-            });
-            self.repo
-                .append_conversation_item_and_update_tool_invocation(
-                    NewConversationItem {
-                        conversation_id: conversation_id.to_string(),
-                        status: ConversationItemStatus::Completed,
-                        agent_run_id: Some(agent_run_id.to_string()),
-                        provider_step_id: invocation.provider_step_id.clone(),
-                        tool_invocation_id: Some(invocation.id.clone()),
-                        provider_item_id: None,
-                        payload,
-                    },
-                    &invocation.id,
-                    UpdateToolInvocationStatus {
-                        status,
-                        output: Some(output),
-                        error: Some(error.clone()),
-                    },
-                )?;
+            self.append_error_tool_result_and_update_tool_invocation(
+                conversation_id,
+                &invocation,
+                status,
+                error.clone(),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn append_error_tool_result_and_update_tool_invocation(
+        &self,
+        conversation_id: &str,
+        invocation: &ToolInvocationRecord,
+        status: ToolInvocationStatus,
+        error: RunErrorPayload,
+    ) -> Result<ConversationItemId> {
+        let output = ToolInvocationOutput {
+            content: vec![ContentPart::Text {
+                text: error.message.clone(),
+            }],
+            structured_output: None,
+            raw_output: None,
+            is_error: true,
+        };
+        let payload = ConversationItemPayload::ToolResult(ToolResultItem {
+            tool_invocation_id: Some(invocation.id.clone()),
+            call_id: invocation.call_id.clone(),
+            content: output.content.clone(),
+            is_error: true,
+            structured_output: None,
+        });
+        let (item, _) = self
+            .repo
+            .append_conversation_item_and_update_tool_invocation(
+                NewConversationItem {
+                    conversation_id: conversation_id.to_string(),
+                    status: ConversationItemStatus::Completed,
+                    agent_run_id: Some(invocation.agent_run_id.clone()),
+                    provider_step_id: invocation.provider_step_id.clone(),
+                    tool_invocation_id: Some(invocation.id.clone()),
+                    provider_item_id: None,
+                    payload,
+                },
+                &invocation.id,
+                UpdateToolInvocationStatus {
+                    status,
+                    output: Some(output),
+                    error: Some(error),
+                },
+            )?;
+        Ok(item.id)
+    }
+
+    fn fail_active_provider_steps(&self, agent_run_id: &str, error: RunErrorPayload) -> Result<()> {
+        for step in self.repo.provider_steps_for_run(agent_run_id)? {
+            if !matches!(
+                step.status,
+                ProviderStepStatus::Queued | ProviderStepStatus::Running
+            ) {
+                continue;
+            }
+
+            self.repo.update_provider_step_status(
+                &step.id,
+                UpdateProviderStepStatus {
+                    status: ProviderStepStatus::Failed,
+                    response_snapshot: None,
+                    state_snapshot: None,
+                    error: Some(error.clone()),
+                },
+            )?;
         }
         Ok(())
     }
@@ -299,6 +339,28 @@ impl AgentRuntime {
         approval_decision_id: &str,
         outcome: NewApprovalDecisionOutcome,
     ) -> Result<ApprovalDecisionRecord> {
+        enum TerminalApproval {
+            Denied { message: String },
+            Canceled,
+            Expired,
+            Pending,
+        }
+
+        let terminal = match &outcome {
+            NewApprovalDecisionOutcome::Approved { .. } => {
+                return Err(AgentRuntimeError::Unsupported(
+                    "approved tool resume is not implemented in v1".to_string(),
+                ));
+            }
+            NewApprovalDecisionOutcome::Denied { reason, .. } => TerminalApproval::Denied {
+                message: reason
+                    .clone()
+                    .unwrap_or_else(|| "Tool call denied by user".to_string()),
+            },
+            NewApprovalDecisionOutcome::Canceled => TerminalApproval::Canceled,
+            NewApprovalDecisionOutcome::Expired => TerminalApproval::Expired,
+            NewApprovalDecisionOutcome::Pending { .. } => TerminalApproval::Pending,
+        };
         let approval = self
             .repo
             .get_approval_decision(approval_decision_id)?
@@ -316,6 +378,15 @@ impl AgentRuntime {
                     approval.tool_invocation_id
                 ))
             })?;
+        let agent_run = self
+            .repo
+            .get_agent_run(&invocation.agent_run_id)?
+            .ok_or_else(|| {
+                AgentRuntimeError::Invariant(format!(
+                    "agent run {} is missing",
+                    invocation.agent_run_id
+                ))
+            })?;
         let updated = self
             .repo
             .update_approval_decision(approval_decision_id, outcome)?;
@@ -325,16 +396,7 @@ impl AgentRuntime {
                 decision: decision.clone(),
             });
             self.repo.append_conversation_item(NewConversationItem {
-                conversation_id: self
-                    .repo
-                    .get_agent_run(&invocation.agent_run_id)?
-                    .ok_or_else(|| {
-                        AgentRuntimeError::Invariant(format!(
-                            "agent run {} is missing",
-                            invocation.agent_run_id
-                        ))
-                    })?
-                    .conversation_id,
+                conversation_id: agent_run.conversation_id.clone(),
                 status: ConversationItemStatus::Completed,
                 agent_run_id: Some(invocation.agent_run_id.clone()),
                 provider_step_id: invocation.provider_step_id.clone(),
@@ -342,51 +404,73 @@ impl AgentRuntime {
                 provider_item_id: None,
                 payload,
             })?;
-            if !decision.approved {
-                let output = ToolInvocationOutput {
-                    content: vec![ContentPart::Text {
-                        text: decision
-                            .reason
-                            .clone()
-                            .unwrap_or_else(|| "Tool call denied by user".to_string()),
-                    }],
-                    structured_output: None,
-                    raw_output: None,
-                    is_error: true,
+        }
+
+        match terminal {
+            TerminalApproval::Denied { message } => {
+                let error = run_error("approval_denied", message, false, None);
+                let item_id = self.append_error_tool_result_and_update_tool_invocation(
+                    &agent_run.conversation_id,
+                    &invocation,
+                    ToolInvocationStatus::Denied,
+                    error.clone(),
+                )?;
+                let output = AgentRunOutput {
+                    final_item_id: Some(item_id),
+                    stopped_reason: AgentStoppedReason::Failed,
                 };
-                self.repo.update_tool_invocation_status(
-                    &invocation.id,
-                    UpdateToolInvocationStatus {
-                        status: ToolInvocationStatus::Denied,
-                        output: Some(output.clone()),
+                self.repo.update_agent_run_status(
+                    &agent_run.id,
+                    UpdateAgentRunStatus {
+                        status: AgentRunStatus::Failed,
+                        output: Some(output),
+                        error: Some(error),
+                    },
+                )?;
+            }
+            TerminalApproval::Canceled => {
+                let error = run_error("approval_canceled", "Tool approval canceled", false, None);
+                let item_id = self.append_error_tool_result_and_update_tool_invocation(
+                    &agent_run.conversation_id,
+                    &invocation,
+                    ToolInvocationStatus::Canceled,
+                    error,
+                )?;
+                let output = AgentRunOutput {
+                    final_item_id: Some(item_id),
+                    stopped_reason: AgentStoppedReason::Canceled,
+                };
+                self.repo.update_agent_run_status(
+                    &agent_run.id,
+                    UpdateAgentRunStatus {
+                        status: AgentRunStatus::Canceled,
+                        output: Some(output),
                         error: None,
                     },
                 )?;
-                self.repo.append_conversation_item(NewConversationItem {
-                    conversation_id: self
-                        .repo
-                        .get_agent_run(&invocation.agent_run_id)?
-                        .ok_or_else(|| {
-                            AgentRuntimeError::Invariant(format!(
-                                "agent run {} is missing",
-                                invocation.agent_run_id
-                            ))
-                        })?
-                        .conversation_id,
-                    status: ConversationItemStatus::Completed,
-                    agent_run_id: Some(invocation.agent_run_id.clone()),
-                    provider_step_id: invocation.provider_step_id,
-                    tool_invocation_id: Some(invocation.id.clone()),
-                    provider_item_id: None,
-                    payload: ConversationItemPayload::ToolResult(ToolResultItem {
-                        tool_invocation_id: Some(invocation.id),
-                        call_id: invocation.call_id,
-                        content: output.content,
-                        is_error: true,
-                        structured_output: None,
-                    }),
-                })?;
             }
+            TerminalApproval::Expired => {
+                let error = run_error("approval_expired", "Tool approval expired", true, None);
+                let item_id = self.append_error_tool_result_and_update_tool_invocation(
+                    &agent_run.conversation_id,
+                    &invocation,
+                    ToolInvocationStatus::Failed,
+                    error.clone(),
+                )?;
+                let output = AgentRunOutput {
+                    final_item_id: Some(item_id),
+                    stopped_reason: AgentStoppedReason::Failed,
+                };
+                self.repo.update_agent_run_status(
+                    &agent_run.id,
+                    UpdateAgentRunStatus {
+                        status: AgentRunStatus::Failed,
+                        output: Some(output),
+                        error: Some(error),
+                    },
+                )?;
+            }
+            TerminalApproval::Pending => {}
         }
         Ok(updated)
     }
@@ -401,6 +485,13 @@ impl AgentRuntime {
                     true,
                     None,
                 );
+                self.fail_active_provider_steps(&run.id, error.clone())?;
+                self.finalize_active_tool_invocations(
+                    &run.id,
+                    &run.conversation_id,
+                    ToolInvocationStatus::Failed,
+                    error.clone(),
+                )?;
                 recovered.push(self.repo.update_agent_run_status(
                     &run.id,
                     UpdateAgentRunStatus {
@@ -460,9 +551,10 @@ mod tests {
     use super::*;
     use crate::{LocalTool, McpConnector, ToolDefinition, ToolExecutor, ToolRunPolicy};
     use ai_chat_db::{
-        ConversationItemRecord, ConversationRecord, FreshStore, NewConversation,
-        NewConversationItem, NewProject, NewProvider, NewProviderModel, NewToolInvocation,
-        ProviderModelRecord, ProviderRecord,
+        ConversationItemRecord, ConversationRecord, FreshStore, NewApprovalDecision,
+        NewConversation, NewConversationItem, NewProject, NewProvider, NewProviderModel,
+        NewProviderStep, NewToolInvocation, ProviderModelRecord, ProviderRecord,
+        ProviderStepRecord, ToolInvocationRecord,
     };
     use async_trait::async_trait;
     use rig_core::{
@@ -704,6 +796,221 @@ mod tests {
         assert_eq!(handle.agent_run.error, None);
     }
 
+    #[test]
+    fn approved_approval_decision_is_unsupported_without_mutating_state() {
+        let fixture = Fixture::new("approved-unsupported");
+        let runtime = AgentRuntime::new(fixture.repo.clone());
+        let (agent_run, invocation, approval) = insert_waiting_approval(&fixture);
+
+        let error = runtime
+            .decide_approval(
+                &approval.id,
+                NewApprovalDecisionOutcome::Approved {
+                    decided_by: "user".to_string(),
+                    reason: Some("ok".to_string()),
+                },
+            )
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            AgentRuntimeError::Unsupported(message)
+                if message == "approved tool resume is not implemented in v1"
+        ));
+
+        let approval = fixture
+            .repo
+            .get_approval_decision(&approval.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(approval.status, ApprovalStatus::Pending);
+        let invocation = fixture
+            .repo
+            .get_tool_invocation(&invocation.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(invocation.status, ToolInvocationStatus::AwaitingApproval);
+        let agent_run = fixture.repo.get_agent_run(&agent_run.id).unwrap().unwrap();
+        assert_eq!(agent_run.status, AgentRunStatus::WaitingForApproval);
+    }
+
+    #[test]
+    fn denied_approval_terminalizes_tool_and_run() {
+        let fixture = Fixture::new("approval-denied");
+        let runtime = AgentRuntime::new(fixture.repo.clone());
+        let (agent_run, invocation, approval) = insert_waiting_approval(&fixture);
+
+        let updated = runtime
+            .decide_approval(
+                &approval.id,
+                NewApprovalDecisionOutcome::Denied {
+                    decided_by: "user".to_string(),
+                    reason: Some("not allowed".to_string()),
+                },
+            )
+            .unwrap();
+        assert_eq!(updated.status, ApprovalStatus::Denied);
+
+        let invocation = fixture
+            .repo
+            .get_tool_invocation(&invocation.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(invocation.status, ToolInvocationStatus::Denied);
+        assert_eq!(invocation.error.as_ref().unwrap().code, "approval_denied");
+        assert!(invocation.output.as_ref().unwrap().is_error);
+
+        let agent_run = fixture.repo.get_agent_run(&agent_run.id).unwrap().unwrap();
+        assert_eq!(agent_run.status, AgentRunStatus::Failed);
+        assert_eq!(agent_run.error.as_ref().unwrap().code, "approval_denied");
+        assert_eq!(
+            agent_run.output.as_ref().unwrap().stopped_reason,
+            AgentStoppedReason::Failed
+        );
+
+        let items = fixture
+            .repo
+            .conversation_items(&fixture.conversation.id)
+            .unwrap();
+        assert!(items.iter().any(|item| {
+            matches!(
+                item.payload,
+                ConversationItemPayload::ApprovalDecision(ApprovalDecisionItem { .. })
+            )
+        }));
+        assert!(items.iter().any(|item| {
+            matches!(
+                &item.payload,
+                ConversationItemPayload::ToolResult(result)
+                    if result.call_id == "call_approval"
+                        && result.is_error
+                        && result.content[0].search_text() == Some("not allowed")
+            )
+        }));
+    }
+
+    #[test]
+    fn canceled_approval_terminalizes_tool_and_run() {
+        let fixture = Fixture::new("approval-canceled");
+        let runtime = AgentRuntime::new(fixture.repo.clone());
+        let (agent_run, invocation, approval) = insert_waiting_approval(&fixture);
+
+        let updated = runtime
+            .decide_approval(&approval.id, NewApprovalDecisionOutcome::Canceled)
+            .unwrap();
+        assert_eq!(updated.status, ApprovalStatus::Canceled);
+
+        let invocation = fixture
+            .repo
+            .get_tool_invocation(&invocation.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(invocation.status, ToolInvocationStatus::Canceled);
+        assert_eq!(invocation.error.as_ref().unwrap().code, "approval_canceled");
+        let agent_run = fixture.repo.get_agent_run(&agent_run.id).unwrap().unwrap();
+        assert_eq!(agent_run.status, AgentRunStatus::Canceled);
+        assert_eq!(agent_run.error, None);
+        assert_eq!(
+            agent_run.output.as_ref().unwrap().stopped_reason,
+            AgentStoppedReason::Canceled
+        );
+        assert_eq!(
+            tool_result_texts(&fixture),
+            vec!["Tool approval canceled".to_string()]
+        );
+    }
+
+    #[test]
+    fn expired_approval_terminalizes_tool_and_run() {
+        let fixture = Fixture::new("approval-expired");
+        let runtime = AgentRuntime::new(fixture.repo.clone());
+        let (agent_run, invocation, approval) = insert_waiting_approval(&fixture);
+
+        let updated = runtime
+            .decide_approval(&approval.id, NewApprovalDecisionOutcome::Expired)
+            .unwrap();
+        assert_eq!(updated.status, ApprovalStatus::Expired);
+
+        let invocation = fixture
+            .repo
+            .get_tool_invocation(&invocation.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(invocation.status, ToolInvocationStatus::Failed);
+        assert_eq!(invocation.error.as_ref().unwrap().code, "approval_expired");
+        let agent_run = fixture.repo.get_agent_run(&agent_run.id).unwrap().unwrap();
+        assert_eq!(agent_run.status, AgentRunStatus::Failed);
+        assert_eq!(agent_run.error.as_ref().unwrap().code, "approval_expired");
+        assert_eq!(
+            tool_result_texts(&fixture),
+            vec!["Tool approval expired".to_string()]
+        );
+    }
+
+    #[test]
+    fn recovery_fails_active_child_execution_rows() {
+        let fixture = Fixture::new("recovery-children");
+        let runtime = AgentRuntime::new(fixture.repo.clone());
+        let agent_run = insert_agent_run_with_status(&fixture, AgentRunStatus::Running);
+        let provider_step =
+            insert_provider_step(&fixture, &agent_run.id, ProviderStepStatus::Running);
+        let invocation = insert_tool_invocation(
+            &fixture,
+            &agent_run.id,
+            Some(provider_step.id.clone()),
+            ToolInvocationStatus::Running,
+        );
+
+        let recovered = runtime.recover_interrupted_runs().unwrap();
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].status, AgentRunStatus::Failed);
+        assert_eq!(recovered[0].error.as_ref().unwrap().code, "interrupted");
+
+        let provider_step = fixture
+            .repo
+            .get_provider_step(&provider_step.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(provider_step.status, ProviderStepStatus::Failed);
+        assert_eq!(provider_step.error.as_ref().unwrap().code, "interrupted");
+        let invocation = fixture
+            .repo
+            .get_tool_invocation(&invocation.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(invocation.status, ToolInvocationStatus::Failed);
+        assert_eq!(invocation.error.as_ref().unwrap().code, "interrupted");
+        assert_eq!(
+            tool_result_texts(&fixture),
+            vec!["agent run was interrupted before reaching a terminal state".to_string()]
+        );
+    }
+
+    #[test]
+    fn recovery_keeps_waiting_for_approval_runs_resumable() {
+        let fixture = Fixture::new("recovery-waiting");
+        let runtime = AgentRuntime::new(fixture.repo.clone());
+        let (agent_run, invocation, approval) = insert_waiting_approval(&fixture);
+
+        let recovered = runtime.recover_interrupted_runs().unwrap();
+        assert!(recovered.is_empty());
+
+        let agent_run = fixture.repo.get_agent_run(&agent_run.id).unwrap().unwrap();
+        assert_eq!(agent_run.status, AgentRunStatus::WaitingForApproval);
+        let invocation = fixture
+            .repo
+            .get_tool_invocation(&invocation.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(invocation.status, ToolInvocationStatus::AwaitingApproval);
+        let approval = fixture
+            .repo
+            .get_approval_decision(&approval.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(approval.status, ApprovalStatus::Pending);
+        assert!(tool_result_texts(&fixture).is_empty());
+    }
+
     #[tokio::test]
     async fn setup_failure_marks_agent_run_failed() {
         let fixture = Fixture::new("setup-failure");
@@ -906,6 +1213,128 @@ mod tests {
             .unwrap();
         assert_eq!(tool_result.id, "call_previous");
         assert_eq!(tool_result.call_id.as_deref(), Some("call_previous"));
+    }
+
+    fn insert_waiting_approval(
+        fixture: &Fixture,
+    ) -> (AgentRunRecord, ToolInvocationRecord, ApprovalDecisionRecord) {
+        let agent_run = insert_agent_run_with_status(fixture, AgentRunStatus::WaitingForApproval);
+        let invocation = insert_tool_invocation(
+            fixture,
+            &agent_run.id,
+            None,
+            ToolInvocationStatus::AwaitingApproval,
+        );
+        let approval = fixture
+            .repo
+            .insert_approval_decision(NewApprovalDecision {
+                tool_invocation_id: invocation.id.clone(),
+                request: ApprovalRequestPayload {
+                    reason: "approve echo".to_string(),
+                    tool_source: ToolSource::Local,
+                    tool_name: "echo".to_string(),
+                    arguments_preview: "{\"text\":\"hi\"}".to_string(),
+                },
+                outcome: NewApprovalDecisionOutcome::Pending { expires_at: None },
+            })
+            .unwrap();
+        (agent_run, invocation, approval)
+    }
+
+    fn insert_agent_run_with_status(fixture: &Fixture, status: AgentRunStatus) -> AgentRunRecord {
+        let agent_run = fixture
+            .repo
+            .insert_agent_run(new_agent_run_input(&fixture.request()))
+            .unwrap();
+        fixture
+            .repo
+            .update_agent_run_status(
+                &agent_run.id,
+                UpdateAgentRunStatus {
+                    status,
+                    output: None,
+                    error: None,
+                },
+            )
+            .unwrap()
+    }
+
+    fn insert_provider_step(
+        fixture: &Fixture,
+        agent_run_id: &str,
+        status: ProviderStepStatus,
+    ) -> ProviderStepRecord {
+        fixture
+            .repo
+            .insert_provider_step(NewProviderStep {
+                agent_run_id: agent_run_id.to_string(),
+                seq: fixture.repo.next_provider_step_seq(agent_run_id).unwrap(),
+                status,
+                request_snapshot: ProviderStepRequestSnapshot {
+                    provider_id: fixture.provider.id.clone(),
+                    model_id: fixture.model.model_id.clone(),
+                    input_item_ids: vec![fixture.user_item.id.clone()],
+                    snapshot_kind: ProviderStepSnapshotKind::RigCompletionRequest,
+                    request_body: ProviderRawPayload {
+                        provider_kind: "test".to_string(),
+                        value: json!({"messages": ["hello"]}),
+                    },
+                },
+                response_snapshot: None,
+                state_snapshot: None,
+                settings_snapshot: run_settings(&fixture.provider.id, &fixture.model.model_id),
+                error: None,
+            })
+            .unwrap()
+    }
+
+    fn insert_tool_invocation(
+        fixture: &Fixture,
+        agent_run_id: &str,
+        provider_step_id: Option<ProviderStepId>,
+        status: ToolInvocationStatus,
+    ) -> ToolInvocationRecord {
+        fixture
+            .repo
+            .insert_tool_invocation(NewToolInvocation {
+                agent_run_id: agent_run_id.to_string(),
+                provider_step_id,
+                status,
+                input: ToolInvocationInput {
+                    source: ToolSource::Local,
+                    namespace: None,
+                    tool_name: "echo".to_string(),
+                    runtime_tool_name: "echo".to_string(),
+                    call_id: "call_approval".to_string(),
+                    arguments: ToolArguments {
+                        value: json!({"text": "hi"}),
+                    },
+                    approval_policy: ToolApprovalPolicy::OnRequest,
+                    execution_policy: ToolExecutionPolicy::Foreground,
+                },
+                output: None,
+                error: None,
+            })
+            .unwrap()
+    }
+
+    fn tool_result_texts(fixture: &Fixture) -> Vec<String> {
+        fixture
+            .repo
+            .conversation_items(&fixture.conversation.id)
+            .unwrap()
+            .into_iter()
+            .filter_map(|item| match item.payload {
+                ConversationItemPayload::ToolResult(result) => {
+                    Some(result.content.into_iter().filter_map(|part| match part {
+                        ContentPart::Text { text } => Some(text),
+                        _ => None,
+                    }))
+                }
+                _ => None,
+            })
+            .flatten()
+            .collect()
     }
 
     struct Fixture {

--- a/crates/ai-chat-agent/src/runtime.rs
+++ b/crates/ai-chat-agent/src/runtime.rs
@@ -182,6 +182,34 @@ impl AgentRuntime {
                     });
                 }
 
+                if matches!(
+                    &error,
+                    rig_core::completion::PromptError::MaxTurnsError { .. }
+                ) {
+                    let output = AgentRunOutput {
+                        final_item_id: context.final_item_id(),
+                        stopped_reason: AgentStoppedReason::MaxSteps,
+                    };
+                    let agent_run = self.repo.update_agent_run_status(
+                        &agent_run.id,
+                        UpdateAgentRunStatus {
+                            status: AgentRunStatus::Completed,
+                            output: Some(output.clone()),
+                            error: None,
+                        },
+                    )?;
+                    let mut events = context.events();
+                    events.push(AgentRunEvent::Completed {
+                        output: output.clone(),
+                    });
+                    return Ok(AgentRunHandle {
+                        agent_run,
+                        output: Some(output),
+                        events,
+                        steps: context.steps(),
+                    });
+                }
+
                 let payload = if request.cancellation_token.is_cancelled() {
                     run_error("canceled", "runtime canceled", false, None)
                 } else {
@@ -752,6 +780,54 @@ mod tests {
         assert_eq!(
             tool_result.raw_output.as_ref().unwrap().value,
             json!({"raw": "details"})
+        );
+    }
+
+    #[tokio::test]
+    async fn max_turns_is_persisted_as_max_steps_stop() {
+        let fixture = Fixture::new("max-steps");
+        let runtime = AgentRuntime::new(fixture.repo.clone());
+        let mut request = fixture.request();
+        request.guards.max_steps = 1;
+        request
+            .tool_registry
+            .register_local_tool(EchoTool::new(ToolApprovalPolicy::Never))
+            .unwrap();
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("call_1", "echo", json!({"text": "one"})),
+            MockTurn::tool_call("call_2", "echo", json!({"text": "two"})),
+            MockTurn::tool_call("call_3", "echo", json!({"text": "three"})),
+        ]);
+
+        let handle = runtime.run_with_model(request, model).await.unwrap();
+
+        assert_eq!(handle.agent_run.status, AgentRunStatus::Completed);
+        assert_eq!(handle.agent_run.error, None);
+        assert_eq!(
+            handle.output.as_ref().unwrap().stopped_reason,
+            AgentStoppedReason::MaxSteps
+        );
+        assert!(
+            handle
+                .events
+                .iter()
+                .any(|event| matches!(event, AgentRunEvent::Completed { output } if output.stopped_reason == AgentStoppedReason::MaxSteps))
+        );
+        assert!(
+            !handle
+                .events
+                .iter()
+                .any(|event| matches!(event, AgentRunEvent::Failed { .. }))
+        );
+        let invocations = fixture
+            .repo
+            .tool_invocations_for_run(&handle.agent_run.id)
+            .unwrap();
+        assert_eq!(invocations.len(), 3);
+        assert!(
+            invocations
+                .iter()
+                .all(|invocation| invocation.status == ToolInvocationStatus::Succeeded)
         );
     }
 

--- a/crates/ai-chat-agent/src/skills.rs
+++ b/crates/ai-chat-agent/src/skills.rs
@@ -1,0 +1,205 @@
+use crate::Result;
+use ai_chat_core::*;
+use sha2::{Digest, Sha256};
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillActivationRequest {
+    pub name: String,
+}
+
+impl SkillActivationRequest {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillCatalogEntry {
+    pub name: String,
+    pub description: Option<String>,
+    pub skill_file_path: PathBuf,
+    pub directory_path: PathBuf,
+    pub source_kind: SkillSourceKind,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SkillCatalog {
+    entries: BTreeMap<String, SkillCatalogEntry>,
+}
+
+impl SkillCatalog {
+    pub fn scan(project_root: Option<&Path>) -> Result<Self> {
+        let mut catalog = Self::default();
+        if let Some(home) = std::env::var_os("HOME") {
+            catalog.scan_root(
+                PathBuf::from(home).join(".agents/skills"),
+                SkillSourceKind::User,
+            )?;
+        }
+        if let Some(project_root) = project_root {
+            catalog.scan_root(
+                project_root.join(".agents/skills"),
+                SkillSourceKind::Project,
+            )?;
+        }
+        Ok(catalog)
+    }
+
+    pub fn scan_root(
+        &mut self,
+        root: impl AsRef<Path>,
+        source_kind: SkillSourceKind,
+    ) -> Result<()> {
+        let root = root.as_ref();
+        if !root.is_dir() {
+            return Ok(());
+        }
+
+        for entry in fs::read_dir(root)? {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let skill_file_path = path.join("SKILL.md");
+            if !skill_file_path.is_file() {
+                continue;
+            }
+            let content = fs::read_to_string(&skill_file_path)?;
+            let metadata = parse_frontmatter_metadata(&content);
+            let fallback_name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("skill")
+                .to_string();
+            let name = metadata.name.unwrap_or(fallback_name);
+            self.entries.insert(
+                name.clone(),
+                SkillCatalogEntry {
+                    name,
+                    description: metadata.description,
+                    skill_file_path,
+                    directory_path: path,
+                    source_kind,
+                },
+            );
+        }
+
+        Ok(())
+    }
+
+    pub fn get(&self, name: &str) -> Option<&SkillCatalogEntry> {
+        self.entries.get(name)
+    }
+
+    pub fn entries(&self) -> impl Iterator<Item = &SkillCatalogEntry> {
+        self.entries.values()
+    }
+
+    pub fn catalog_hash(&self) -> String {
+        let mut hasher = Sha256::new();
+        for entry in self.entries.values() {
+            hasher.update(entry.name.as_bytes());
+            hasher.update(b"\0");
+            hasher.update(entry.skill_file_path.to_string_lossy().as_bytes());
+            hasher.update(b"\0");
+        }
+        hex::encode(hasher.finalize())
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SkillLoader;
+
+impl SkillLoader {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn load(&self, entry: &SkillCatalogEntry) -> Result<SkillActivationItem> {
+        let content = fs::read_to_string(&entry.skill_file_path)?;
+        let mut hasher = Sha256::new();
+        hasher.update(content.as_bytes());
+        let content_sha256 = hex::encode(hasher.finalize());
+        Ok(SkillActivationItem {
+            name: entry.name.clone(),
+            source_kind: entry.source_kind,
+            skill_file_path: entry.skill_file_path.to_string_lossy().to_string(),
+            directory_path: entry.directory_path.to_string_lossy().to_string(),
+            content_sha256,
+            content: vec![ContentPart::Text { text: content }],
+        })
+    }
+}
+
+#[derive(Default)]
+struct FrontmatterMetadata {
+    name: Option<String>,
+    description: Option<String>,
+}
+
+fn parse_frontmatter_metadata(content: &str) -> FrontmatterMetadata {
+    let mut metadata = FrontmatterMetadata::default();
+    let mut lines = content.lines();
+    if lines.next() != Some("---") {
+        return metadata;
+    }
+
+    for line in lines {
+        if line == "---" {
+            break;
+        }
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let value = value
+            .trim()
+            .trim_matches('"')
+            .trim_matches('\'')
+            .to_string();
+        match key.trim() {
+            "name" if !value.is_empty() => metadata.name = Some(value),
+            "description" if !value.is_empty() => metadata.description = Some(value),
+            _ => {}
+        }
+    }
+    metadata
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skill_loader_keeps_snapshot_when_file_changes() {
+        let temp = tempfile::tempdir().unwrap();
+        let skill_dir = temp.path().join(".agents/skills/rust");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let skill_file = skill_dir.join("SKILL.md");
+        std::fs::write(
+            &skill_file,
+            "---\nname: rust\ndescription: Rust workflow\n---\nUse cargo test.\n",
+        )
+        .unwrap();
+
+        let catalog = SkillCatalog::scan(Some(temp.path())).unwrap();
+        let entry = catalog.get("rust").unwrap();
+        let first = SkillLoader::new().load(entry).unwrap();
+        std::fs::write(&skill_file, "---\nname: rust\n---\nUse cargo clippy.\n").unwrap();
+        let second = SkillLoader::new().load(entry).unwrap();
+
+        assert_ne!(first.content_sha256, second.content_sha256);
+        assert_eq!(
+            first.content,
+            vec![ContentPart::Text {
+                text: "---\nname: rust\ndescription: Rust workflow\n---\nUse cargo test.\n"
+                    .to_string(),
+            }]
+        );
+    }
+}

--- a/crates/ai-chat-agent/src/skills.rs
+++ b/crates/ai-chat-agent/src/skills.rs
@@ -35,11 +35,8 @@ pub struct SkillCatalog {
 impl SkillCatalog {
     pub fn scan(project_root: Option<&Path>) -> Result<Self> {
         let mut catalog = Self::default();
-        if let Some(home) = std::env::var_os("HOME") {
-            catalog.scan_root(
-                PathBuf::from(home).join(".agents/skills"),
-                SkillSourceKind::User,
-            )?;
+        if let Some(root) = user_skills_root(dirs::home_dir()) {
+            catalog.scan_root(root, SkillSourceKind::User)?;
         }
         if let Some(project_root) = project_root {
             catalog.scan_root(
@@ -171,6 +168,10 @@ fn parse_frontmatter_metadata(content: &str) -> FrontmatterMetadata {
     metadata
 }
 
+fn user_skills_root(home_dir: Option<PathBuf>) -> Option<PathBuf> {
+    home_dir.map(|home| home.join(".agents").join("skills"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -201,5 +202,14 @@ mod tests {
                     .to_string(),
             }]
         );
+    }
+
+    #[test]
+    fn user_skills_root_uses_home_directory() {
+        assert_eq!(
+            user_skills_root(Some(PathBuf::from("/home/test"))),
+            Some(PathBuf::from("/home/test/.agents/skills"))
+        );
+        assert_eq!(user_skills_root(None), None);
     }
 }

--- a/crates/ai-chat-agent/src/tool_registry.rs
+++ b/crates/ai-chat-agent/src/tool_registry.rs
@@ -1,0 +1,380 @@
+use crate::{AgentRuntimeError, Result};
+use ai_chat_core::*;
+use async_trait::async_trait;
+use rig_core::{
+    completion::ToolDefinition as RigToolDefinition,
+    tool::{ToolDyn, ToolError},
+    wasm_compat::WasmBoxedFuture,
+};
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, sync::Arc};
+use tokio::time::timeout;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ToolRunPolicy {
+    pub approval_policy: ToolApprovalPolicy,
+    pub execution_policy: ToolExecutionPolicy,
+    pub timeout_ms: Option<u64>,
+}
+
+impl Default for ToolRunPolicy {
+    fn default() -> Self {
+        Self {
+            approval_policy: ToolApprovalPolicy::Never,
+            execution_policy: ToolExecutionPolicy::Foreground,
+            timeout_ms: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ToolDefinition {
+    pub source: ToolSource,
+    pub namespace: Option<String>,
+    pub name: String,
+    pub description: String,
+    pub parameters: serde_json::Value,
+    pub policy: ToolRunPolicy,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RegisteredToolDefinition {
+    pub source: ToolSource,
+    pub namespace: Option<String>,
+    pub tool_name: String,
+    pub runtime_tool_name: String,
+    pub description: String,
+    pub parameters: serde_json::Value,
+    pub policy: ToolRunPolicy,
+}
+
+#[async_trait]
+pub trait ToolExecutor: Send + Sync {
+    async fn execute(&self, arguments: serde_json::Value) -> Result<ToolInvocationOutput>;
+}
+
+#[async_trait]
+pub trait LocalTool: ToolExecutor {
+    fn definition(&self) -> ToolDefinition;
+}
+
+#[derive(Clone)]
+struct ToolEntry {
+    definition: ToolDefinition,
+    runtime_tool_name: String,
+    executor: Arc<dyn ToolExecutor>,
+}
+
+#[derive(Clone, Default)]
+pub struct ToolRegistry {
+    entries: Vec<ToolEntry>,
+    finalized: bool,
+}
+
+impl ToolRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register_local_tool<T>(&mut self, tool: T) -> Result<()>
+    where
+        T: LocalTool + 'static,
+    {
+        let definition = tool.definition();
+        self.register_tool_definition(definition, Arc::new(tool))
+    }
+
+    pub fn register_mcp_tool<T>(&mut self, definition: ToolDefinition, tool: T) -> Result<()>
+    where
+        T: ToolDyn + 'static,
+    {
+        self.register_tool_definition(definition, Arc::new(RigToolExecutor::new(tool)))
+    }
+
+    pub fn register_tool_definition(
+        &mut self,
+        definition: ToolDefinition,
+        executor: Arc<dyn ToolExecutor>,
+    ) -> Result<()> {
+        ensure_tool_name(&definition.name)?;
+        self.finalized = false;
+        self.entries.push(ToolEntry {
+            runtime_tool_name: definition.name.clone(),
+            definition,
+            executor,
+        });
+        Ok(())
+    }
+
+    pub fn finalize_names(&mut self) {
+        let mut counts = BTreeMap::<String, usize>::new();
+        for entry in &self.entries {
+            *counts.entry(entry.definition.name.clone()).or_default() += 1;
+        }
+
+        for entry in &mut self.entries {
+            entry.runtime_tool_name = if counts[&entry.definition.name] == 1 {
+                sanitize_tool_name(&entry.definition.name)
+            } else {
+                let namespace = entry
+                    .definition
+                    .namespace
+                    .clone()
+                    .unwrap_or_else(|| tool_source_namespace(&entry.definition.source));
+                format!(
+                    "{}__{}",
+                    sanitize_tool_name(&namespace),
+                    sanitize_tool_name(&entry.definition.name)
+                )
+            };
+        }
+        self.finalized = true;
+    }
+
+    pub fn registered_definitions(&self) -> Vec<RegisteredToolDefinition> {
+        self.entries
+            .iter()
+            .map(|entry| RegisteredToolDefinition {
+                source: entry.definition.source.clone(),
+                namespace: entry.definition.namespace.clone(),
+                tool_name: entry.definition.name.clone(),
+                runtime_tool_name: entry.runtime_tool_name.clone(),
+                description: entry.definition.description.clone(),
+                parameters: entry.definition.parameters.clone(),
+                policy: entry.definition.policy.clone(),
+            })
+            .collect()
+    }
+
+    pub fn lookup(&self, runtime_tool_name: &str) -> Option<RegisteredToolDefinition> {
+        self.entries
+            .iter()
+            .find(|entry| entry.runtime_tool_name == runtime_tool_name)
+            .map(|entry| RegisteredToolDefinition {
+                source: entry.definition.source.clone(),
+                namespace: entry.definition.namespace.clone(),
+                tool_name: entry.definition.name.clone(),
+                runtime_tool_name: entry.runtime_tool_name.clone(),
+                description: entry.definition.description.clone(),
+                parameters: entry.definition.parameters.clone(),
+                policy: entry.definition.policy.clone(),
+            })
+    }
+
+    pub fn into_rig_tools(mut self, default_timeout: std::time::Duration) -> Vec<Box<dyn ToolDyn>> {
+        if !self.finalized {
+            self.finalize_names();
+        }
+        self.entries
+            .into_iter()
+            .map(|entry| {
+                Box::new(RegisteredRigTool {
+                    runtime_tool_name: entry.runtime_tool_name,
+                    description: entry.definition.description,
+                    parameters: entry.definition.parameters,
+                    executor: entry.executor,
+                    timeout: entry
+                        .definition
+                        .policy
+                        .timeout_ms
+                        .map(std::time::Duration::from_millis)
+                        .unwrap_or(default_timeout),
+                }) as Box<dyn ToolDyn>
+            })
+            .collect()
+    }
+}
+
+struct RigToolExecutor {
+    tool: Arc<dyn ToolDyn>,
+}
+
+impl RigToolExecutor {
+    fn new(tool: impl ToolDyn + 'static) -> Self {
+        Self {
+            tool: Arc::new(tool),
+        }
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for RigToolExecutor {
+    async fn execute(&self, arguments: serde_json::Value) -> Result<ToolInvocationOutput> {
+        let args = serde_json::to_string(&arguments)?;
+        let output = self
+            .tool
+            .call(args)
+            .await
+            .map_err(|err| AgentRuntimeError::Mcp(err.to_string()))?;
+        Ok(ToolInvocationOutput {
+            content: vec![ContentPart::Text {
+                text: output.clone(),
+            }],
+            structured_output: serde_json::from_str::<serde_json::Value>(&output)
+                .ok()
+                .map(|value| StructuredOutput { value }),
+            raw_output: None,
+            is_error: false,
+        })
+    }
+}
+
+struct RegisteredRigTool {
+    runtime_tool_name: String,
+    description: String,
+    parameters: serde_json::Value,
+    executor: Arc<dyn ToolExecutor>,
+    timeout: std::time::Duration,
+}
+
+impl ToolDyn for RegisteredRigTool {
+    fn name(&self) -> String {
+        self.runtime_tool_name.clone()
+    }
+
+    fn definition(&self, _prompt: String) -> WasmBoxedFuture<'_, RigToolDefinition> {
+        Box::pin(async move {
+            RigToolDefinition {
+                name: self.runtime_tool_name.clone(),
+                description: self.description.clone(),
+                parameters: self.parameters.clone(),
+            }
+        })
+    }
+
+    fn call(&self, args: String) -> WasmBoxedFuture<'_, std::result::Result<String, ToolError>> {
+        Box::pin(async move {
+            let arguments =
+                serde_json::from_str::<serde_json::Value>(&args).map_err(ToolError::JsonError)?;
+            let output = timeout(self.timeout, self.executor.execute(arguments))
+                .await
+                .map_err(|_| tool_call_error("tool execution timed out"))?
+                .map_err(|err| tool_call_error(err.to_string()))?;
+            Ok(tool_output_to_model_text(&output))
+        })
+    }
+}
+
+fn ensure_tool_name(name: &str) -> Result<()> {
+    if name.trim().is_empty() {
+        return Err(AgentRuntimeError::Invariant(
+            "tool name cannot be empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn tool_source_namespace(source: &ToolSource) -> String {
+    match source {
+        ToolSource::Local => "local".to_string(),
+        ToolSource::Mcp { server_id } => format!("mcp_{server_id}"),
+        ToolSource::ProviderHosted { provider_id } => format!("provider_{provider_id}"),
+    }
+}
+
+fn sanitize_tool_name(name: &str) -> String {
+    let mut out = String::new();
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            out.push(ch.to_ascii_lowercase());
+        } else if !out.ends_with('_') {
+            out.push('_');
+        }
+    }
+    let out = out.trim_matches('_').to_string();
+    if out.is_empty() {
+        "tool".to_string()
+    } else {
+        out
+    }
+}
+
+pub(crate) fn tool_output_to_model_text(output: &ToolInvocationOutput) -> String {
+    if let Some(structured) = output.structured_output.as_ref() {
+        return structured.value.to_string();
+    }
+    output
+        .content
+        .iter()
+        .filter_map(ContentPart::search_text)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn tool_call_error(message: impl Into<String>) -> ToolError {
+    #[derive(Debug, thiserror::Error)]
+    #[error("{0}")]
+    struct RuntimeToolError(String);
+
+    ToolError::ToolCallError(Box::new(RuntimeToolError(message.into())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone)]
+    struct EchoTool {
+        source: ToolSource,
+        namespace: Option<String>,
+    }
+
+    #[async_trait]
+    impl ToolExecutor for EchoTool {
+        async fn execute(&self, arguments: serde_json::Value) -> Result<ToolInvocationOutput> {
+            Ok(ToolInvocationOutput {
+                content: vec![ContentPart::Text {
+                    text: arguments.to_string(),
+                }],
+                structured_output: Some(StructuredOutput { value: arguments }),
+                raw_output: None,
+                is_error: false,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl LocalTool for EchoTool {
+        fn definition(&self) -> ToolDefinition {
+            ToolDefinition {
+                source: self.source.clone(),
+                namespace: self.namespace.clone(),
+                name: "echo".to_string(),
+                description: "Echo arguments".to_string(),
+                parameters: serde_json::json!({"type": "object"}),
+                policy: ToolRunPolicy::default(),
+            }
+        }
+    }
+
+    #[test]
+    fn duplicate_tool_names_are_namespaced() {
+        let mut registry = ToolRegistry::new();
+        registry
+            .register_local_tool(EchoTool {
+                source: ToolSource::Mcp {
+                    server_id: "server-a".to_string(),
+                },
+                namespace: Some("server-a".to_string()),
+            })
+            .unwrap();
+        registry
+            .register_local_tool(EchoTool {
+                source: ToolSource::Mcp {
+                    server_id: "server-b".to_string(),
+                },
+                namespace: Some("server-b".to_string()),
+            })
+            .unwrap();
+        registry.finalize_names();
+        let names = registry
+            .registered_definitions()
+            .into_iter()
+            .map(|definition| definition.runtime_tool_name)
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["server_a__echo", "server_b__echo"]);
+    }
+}

--- a/crates/ai-chat-agent/src/tool_registry.rs
+++ b/crates/ai-chat-agent/src/tool_registry.rs
@@ -110,25 +110,35 @@ impl ToolRegistry {
     }
 
     pub fn finalize_names(&mut self) {
-        let mut counts = BTreeMap::<String, usize>::new();
-        for entry in &self.entries {
-            *counts.entry(entry.definition.name.clone()).or_default() += 1;
+        let sanitized_names = self
+            .entries
+            .iter()
+            .map(|entry| sanitize_tool_name(&entry.definition.name))
+            .collect::<Vec<_>>();
+
+        let mut name_counts = BTreeMap::<String, usize>::new();
+        for name in &sanitized_names {
+            *name_counts.entry(name.clone()).or_default() += 1;
         }
 
-        for entry in &mut self.entries {
-            entry.runtime_tool_name = if counts[&entry.definition.name] == 1 {
-                sanitize_tool_name(&entry.definition.name)
+        let mut assigned_counts = BTreeMap::<String, usize>::new();
+        for (entry, sanitized_name) in self.entries.iter_mut().zip(sanitized_names) {
+            let candidate = if name_counts[&sanitized_name] == 1 {
+                sanitized_name
             } else {
                 let namespace = entry
                     .definition
                     .namespace
                     .clone()
                     .unwrap_or_else(|| tool_source_namespace(&entry.definition.source));
-                format!(
-                    "{}__{}",
-                    sanitize_tool_name(&namespace),
-                    sanitize_tool_name(&entry.definition.name)
-                )
+                format!("{}__{}", sanitize_tool_name(&namespace), sanitized_name)
+            };
+            let assigned_count = assigned_counts.entry(candidate.clone()).or_default();
+            *assigned_count += 1;
+            entry.runtime_tool_name = if *assigned_count == 1 {
+                candidate
+            } else {
+                format!("{candidate}__{assigned_count}")
             };
         }
         self.finalized = true;
@@ -320,6 +330,17 @@ mod tests {
     struct EchoTool {
         source: ToolSource,
         namespace: Option<String>,
+        name: String,
+    }
+
+    impl EchoTool {
+        fn new(name: &str, source: ToolSource, namespace: Option<&str>) -> Self {
+            Self {
+                source,
+                namespace: namespace.map(ToString::to_string),
+                name: name.to_string(),
+            }
+        }
     }
 
     #[async_trait]
@@ -342,7 +363,7 @@ mod tests {
             ToolDefinition {
                 source: self.source.clone(),
                 namespace: self.namespace.clone(),
-                name: "echo".to_string(),
+                name: self.name.clone(),
                 description: "Echo arguments".to_string(),
                 parameters: serde_json::json!({"type": "object"}),
                 policy: ToolRunPolicy::default(),
@@ -354,20 +375,22 @@ mod tests {
     fn duplicate_tool_names_are_namespaced() {
         let mut registry = ToolRegistry::new();
         registry
-            .register_local_tool(EchoTool {
-                source: ToolSource::Mcp {
+            .register_local_tool(EchoTool::new(
+                "echo",
+                ToolSource::Mcp {
                     server_id: "server-a".to_string(),
                 },
-                namespace: Some("server-a".to_string()),
-            })
+                Some("server-a"),
+            ))
             .unwrap();
         registry
-            .register_local_tool(EchoTool {
-                source: ToolSource::Mcp {
+            .register_local_tool(EchoTool::new(
+                "echo",
+                ToolSource::Mcp {
                     server_id: "server-b".to_string(),
                 },
-                namespace: Some("server-b".to_string()),
-            })
+                Some("server-b"),
+            ))
             .unwrap();
         registry.finalize_names();
         let names = registry
@@ -376,5 +399,77 @@ mod tests {
             .map(|definition| definition.runtime_tool_name)
             .collect::<Vec<_>>();
         assert_eq!(names, vec!["server_a__echo", "server_b__echo"]);
+    }
+
+    #[test]
+    fn sanitized_tool_name_collisions_are_namespaced() {
+        let mut registry = ToolRegistry::new();
+        registry
+            .register_local_tool(EchoTool::new(
+                "read-file",
+                ToolSource::Mcp {
+                    server_id: "server-a".to_string(),
+                },
+                Some("server-a"),
+            ))
+            .unwrap();
+        registry
+            .register_local_tool(EchoTool::new(
+                "read_file",
+                ToolSource::Mcp {
+                    server_id: "server-b".to_string(),
+                },
+                Some("server-b"),
+            ))
+            .unwrap();
+
+        registry.finalize_names();
+        let names = registry
+            .registered_definitions()
+            .into_iter()
+            .map(|definition| definition.runtime_tool_name)
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, vec!["server_a__read_file", "server_b__read_file"]);
+    }
+
+    #[test]
+    fn namespaced_tool_name_collisions_get_stable_suffixes() {
+        let mut registry = ToolRegistry::new();
+        registry
+            .register_local_tool(EchoTool::new(
+                "read-file",
+                ToolSource::Mcp {
+                    server_id: "server-a".to_string(),
+                },
+                Some("server-a"),
+            ))
+            .unwrap();
+        registry
+            .register_local_tool(EchoTool::new(
+                "read_file",
+                ToolSource::Mcp {
+                    server_id: "server_a".to_string(),
+                },
+                Some("server_a"),
+            ))
+            .unwrap();
+
+        registry.finalize_names();
+        let definitions = registry.registered_definitions();
+        let names = definitions
+            .iter()
+            .map(|definition| definition.runtime_tool_name.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, vec!["server_a__read_file", "server_a__read_file__2"]);
+        assert_eq!(
+            registry.lookup("server_a__read_file").unwrap().tool_name,
+            "read-file"
+        );
+        assert_eq!(
+            registry.lookup("server_a__read_file__2").unwrap().tool_name,
+            "read_file"
+        );
     }
 }

--- a/crates/ai-chat-agent/src/tool_registry.rs
+++ b/crates/ai-chat-agent/src/tool_registry.rs
@@ -68,6 +68,13 @@ struct ToolEntry {
     executor: Arc<dyn ToolExecutor>,
 }
 
+#[derive(Clone)]
+pub(crate) struct RegisteredRuntimeTool {
+    pub definition: RegisteredToolDefinition,
+    pub executor: Arc<dyn ToolExecutor>,
+    pub timeout: std::time::Duration,
+}
+
 #[derive(Clone, Default)]
 pub struct ToolRegistry {
     entries: Vec<ToolEntry>,
@@ -155,6 +162,41 @@ impl ToolRegistry {
                 description: entry.definition.description.clone(),
                 parameters: entry.definition.parameters.clone(),
                 policy: entry.definition.policy.clone(),
+            })
+            .collect()
+    }
+
+    pub(crate) fn runtime_tools(
+        &self,
+        default_timeout: std::time::Duration,
+    ) -> Vec<RegisteredRuntimeTool> {
+        let mut registry = self.clone();
+        if !registry.finalized {
+            registry.finalize_names();
+        }
+        registry
+            .entries
+            .into_iter()
+            .map(|entry| {
+                let timeout = entry
+                    .definition
+                    .policy
+                    .timeout_ms
+                    .map(std::time::Duration::from_millis)
+                    .unwrap_or(default_timeout);
+                RegisteredRuntimeTool {
+                    definition: RegisteredToolDefinition {
+                        source: entry.definition.source,
+                        namespace: entry.definition.namespace,
+                        tool_name: entry.definition.name,
+                        runtime_tool_name: entry.runtime_tool_name,
+                        description: entry.definition.description,
+                        parameters: entry.definition.parameters,
+                        policy: entry.definition.policy,
+                    },
+                    executor: entry.executor,
+                    timeout,
+                }
             })
             .collect()
     }

--- a/crates/ai-chat-agent/src/types.rs
+++ b/crates/ai-chat-agent/src/types.rs
@@ -1,0 +1,106 @@
+use crate::{Result, ToolRegistry};
+use ai_chat_core::*;
+use ai_chat_db::AgentRunRecord;
+use async_trait::async_trait;
+use rig_core::completion::CompletionModel;
+use std::path::PathBuf;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, Clone)]
+pub struct RuntimeGuards {
+    pub max_steps: u32,
+    pub max_tool_calls: u32,
+    pub repeated_tool_call_limit: u32,
+    pub tool_timeout: std::time::Duration,
+    pub tool_concurrency: usize,
+}
+
+impl Default for RuntimeGuards {
+    fn default() -> Self {
+        Self {
+            max_steps: 32,
+            max_tool_calls: 128,
+            repeated_tool_call_limit: 3,
+            tool_timeout: std::time::Duration::from_secs(120),
+            tool_concurrency: 1,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct AgentRunRequest {
+    pub conversation_id: ConversationId,
+    pub user_item_id: ConversationItemId,
+    pub trigger_kind: AgentRunTriggerKind,
+    pub parent_agent_run_id: Option<AgentRunId>,
+    pub prompt_snapshot: Option<PromptContent>,
+    pub provider_id: ProviderId,
+    pub model_id: ProviderModelId,
+    pub settings_snapshot: RunSettingsSnapshot,
+    pub runtime_snapshot: AgentRuntimeSnapshot,
+    pub tool_registry: ToolRegistry,
+    pub skill_requests: Vec<SkillActivationRequest>,
+    pub provider_tools: Vec<rig_core::completion::ProviderToolDefinition>,
+    pub project_root: Option<PathBuf>,
+    pub guards: RuntimeGuards,
+    pub cancellation_token: CancellationToken,
+}
+
+impl AgentRunRequest {
+    pub fn new(
+        conversation_id: ConversationId,
+        user_item_id: ConversationItemId,
+        provider_id: ProviderId,
+        model_id: ProviderModelId,
+        settings_snapshot: RunSettingsSnapshot,
+        runtime_snapshot: AgentRuntimeSnapshot,
+    ) -> Self {
+        let max_steps = settings_snapshot.tool_policy.max_steps.max(1);
+        Self {
+            conversation_id,
+            user_item_id,
+            trigger_kind: AgentRunTriggerKind::User,
+            parent_agent_run_id: None,
+            prompt_snapshot: settings_snapshot.prompt.clone(),
+            provider_id,
+            model_id,
+            settings_snapshot,
+            runtime_snapshot,
+            tool_registry: ToolRegistry::default(),
+            skill_requests: Vec::new(),
+            provider_tools: Vec::new(),
+            project_root: None,
+            guards: RuntimeGuards {
+                max_steps,
+                ..RuntimeGuards::default()
+            },
+            cancellation_token: CancellationToken::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AgentStep {
+    ProviderStep(ProviderStepId),
+    ToolInvocation(ToolInvocationId),
+    Approval(ApprovalDecisionId),
+    ConversationItem(ConversationItemId),
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentRunHandle {
+    pub agent_run: AgentRunRecord,
+    pub output: Option<AgentRunOutput>,
+    pub events: Vec<AgentRunEvent>,
+    pub steps: Vec<AgentStep>,
+}
+
+#[async_trait]
+pub trait CompletionModelFactory<M>: Send + Sync
+where
+    M: CompletionModel,
+{
+    async fn create_model(&self, request: &AgentRunRequest) -> Result<M>;
+}
+
+pub use crate::skills::SkillActivationRequest;

--- a/crates/ai-chat-core/src/payloads.rs
+++ b/crates/ai-chat-core/src/payloads.rs
@@ -298,6 +298,7 @@ pub struct ToolResultItem {
     pub content: Vec<ContentPart>,
     pub is_error: bool,
     pub structured_output: Option<StructuredOutput>,
+    pub raw_output: Option<ProviderRawPayload>,
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/crates/ai-chat-core/src/payloads.rs
+++ b/crates/ai-chat-core/src/payloads.rs
@@ -324,6 +324,8 @@ pub struct StructuredOutput {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AgentRunInput {
     pub user_item_id: ConversationItemId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_agent_run_id: Option<AgentRunId>,
     pub prompt_snapshot: Option<PromptContent>,
     pub provider_id: ProviderId,
     pub model_id: ProviderModelId,

--- a/crates/ai-chat-db/src/migrations.rs
+++ b/crates/ai-chat-db/src/migrations.rs
@@ -324,7 +324,7 @@ fn update_metadata(conn: &mut SqliteConnection) -> Result<()> {
         created_app_version: None,
         last_opened_app_version: None,
         payload_json: payload,
-        created_at: now.clone(),
+        created_at: now,
         updated_at: now,
     };
     diesel::insert_into(schema_metadata::table)

--- a/crates/ai-chat-db/src/models.rs
+++ b/crates/ai-chat-db/src/models.rs
@@ -224,6 +224,18 @@ pub(crate) struct SqlNewAgentRunRow {
     pub(crate) updated_at: OffsetDateTime,
 }
 
+#[derive(Debug, Clone, AsChangeset)]
+#[diesel(table_name = agent_runs)]
+#[diesel(treat_none_as_null = true)]
+pub(crate) struct SqlAgentRunStatusChanges {
+    pub(crate) status: String,
+    pub(crate) output_json: Option<Value>,
+    pub(crate) error_json: Option<Value>,
+    pub(crate) started_at: Option<OffsetDateTime>,
+    pub(crate) completed_at: Option<OffsetDateTime>,
+    pub(crate) updated_at: OffsetDateTime,
+}
+
 #[derive(Debug, Clone, Queryable, Selectable)]
 #[diesel(table_name = provider_steps)]
 #[diesel(check_for_backend(diesel::sqlite::Sqlite))]
@@ -260,6 +272,19 @@ pub(crate) struct SqlNewProviderStepRow {
     pub(crate) settings_snapshot_json: Value,
     pub(crate) error_json: Option<Value>,
     pub(crate) created_at: OffsetDateTime,
+    pub(crate) started_at: Option<OffsetDateTime>,
+    pub(crate) completed_at: Option<OffsetDateTime>,
+    pub(crate) updated_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, AsChangeset)]
+#[diesel(table_name = provider_steps)]
+#[diesel(treat_none_as_null = true)]
+pub(crate) struct SqlProviderStepStatusChanges {
+    pub(crate) status: String,
+    pub(crate) response_snapshot_json: Option<Value>,
+    pub(crate) state_snapshot_json: Option<Value>,
+    pub(crate) error_json: Option<Value>,
     pub(crate) started_at: Option<OffsetDateTime>,
     pub(crate) completed_at: Option<OffsetDateTime>,
     pub(crate) updated_at: OffsetDateTime,
@@ -310,6 +335,18 @@ pub(crate) struct SqlNewToolInvocationRow {
     pub(crate) updated_at: OffsetDateTime,
 }
 
+#[derive(Debug, Clone, AsChangeset)]
+#[diesel(table_name = tool_invocations)]
+#[diesel(treat_none_as_null = true)]
+pub(crate) struct SqlToolInvocationStatusChanges {
+    pub(crate) status: String,
+    pub(crate) output_json: Option<Value>,
+    pub(crate) error_json: Option<Value>,
+    pub(crate) started_at: Option<OffsetDateTime>,
+    pub(crate) completed_at: Option<OffsetDateTime>,
+    pub(crate) updated_at: OffsetDateTime,
+}
+
 #[derive(Debug, Clone, Queryable, Selectable)]
 #[diesel(table_name = approval_decisions)]
 #[diesel(check_for_backend(diesel::sqlite::Sqlite))]
@@ -333,6 +370,16 @@ pub(crate) struct SqlNewApprovalDecisionRow {
     pub(crate) request_json: Value,
     pub(crate) decision_json: Option<Value>,
     pub(crate) requested_at: OffsetDateTime,
+    pub(crate) decided_at: Option<OffsetDateTime>,
+    pub(crate) expires_at: Option<OffsetDateTime>,
+}
+
+#[derive(Debug, Clone, AsChangeset)]
+#[diesel(table_name = approval_decisions)]
+#[diesel(treat_none_as_null = true)]
+pub(crate) struct SqlApprovalDecisionChanges {
+    pub(crate) status: String,
+    pub(crate) decision_json: Option<Value>,
     pub(crate) decided_at: Option<OffsetDateTime>,
     pub(crate) expires_at: Option<OffsetDateTime>,
 }

--- a/crates/ai-chat-db/src/records.rs
+++ b/crates/ai-chat-db/src/records.rs
@@ -146,6 +146,13 @@ pub struct NewAgentRun {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct UpdateAgentRunStatus {
+    pub status: AgentRunStatus,
+    pub output: Option<AgentRunOutput>,
+    pub error: Option<RunErrorPayload>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct ProviderStepRecord {
     pub id: ProviderStepId,
     pub agent_run_id: AgentRunId,
@@ -177,6 +184,14 @@ pub struct NewProviderStep {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct UpdateProviderStepStatus {
+    pub status: ProviderStepStatus,
+    pub response_snapshot: Option<ProviderStepResponseSnapshot>,
+    pub state_snapshot: Option<ProviderRunStateSnapshot>,
+    pub error: Option<RunErrorPayload>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct ToolInvocationRecord {
     pub id: ToolInvocationId,
     pub agent_run_id: AgentRunId,
@@ -203,6 +218,13 @@ pub struct NewToolInvocation {
     pub provider_step_id: Option<ProviderStepId>,
     pub status: ToolInvocationStatus,
     pub input: ToolInvocationInput,
+    pub output: Option<ToolInvocationOutput>,
+    pub error: Option<RunErrorPayload>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UpdateToolInvocationStatus {
+    pub status: ToolInvocationStatus,
     pub output: Option<ToolInvocationOutput>,
     pub error: Option<RunErrorPayload>,
 }

--- a/crates/ai-chat-db/src/repository.rs
+++ b/crates/ai-chat-db/src/repository.rs
@@ -60,7 +60,7 @@ impl FreshRepository {
                 display_name: input.display_name,
                 kind: db_label(&input.kind)?,
                 metadata_json: to_json(&input.metadata)?,
-                created_at: now.clone(),
+                created_at: now,
                 updated_at: now,
                 last_opened_at: None,
             };
@@ -90,7 +90,7 @@ impl FreshRepository {
                 enabled: input.enabled,
                 settings_json: to_json(&input.settings)?,
                 secret_refs_json: to_json(&input.secret_refs)?,
-                created_at: now.clone(),
+                created_at: now,
                 updated_at: now,
             };
             diesel::insert_into(providers::table)
@@ -119,8 +119,8 @@ impl FreshRepository {
                 display_name: input.display_name,
                 capabilities_json: to_json(&input.capabilities)?,
                 metadata_json: to_json(&input.metadata)?,
-                fetched_at: now.clone(),
-                created_at: now.clone(),
+                fetched_at: now,
+                created_at: now,
                 updated_at: now,
             };
             diesel::insert_into(provider_models::table)
@@ -162,7 +162,7 @@ impl FreshRepository {
                 content_json: to_json(&input.content)?,
                 enabled: input.enabled,
                 sort_order: input.sort_order,
-                created_at: now.clone(),
+                created_at: now,
                 updated_at: now,
             };
             diesel::insert_into(prompts::table)
@@ -195,7 +195,7 @@ impl FreshRepository {
                 last_item_seq: 0,
                 metadata_json: to_json(&input.metadata)?,
                 settings_snapshot_json: to_json(&input.settings_snapshot)?,
-                created_at: now.clone(),
+                created_at: now,
                 updated_at: now,
                 archived_at: None,
                 deleted_at: None,
@@ -220,40 +220,7 @@ impl FreshRepository {
         input: NewConversationItem,
     ) -> Result<ConversationItemRecord> {
         let mut conn = self.conn()?;
-        conn.immediate_transaction(|conn| {
-            let conversation = conversation_row(conn, &input.conversation_id)?
-                .ok_or_else(|| DbError::Invariant("conversation is missing".to_string()))?;
-            validate_execution_links(conn, &input.conversation_id, &input)?;
-
-            let seq = conversation.last_item_seq + 1;
-            let now = now_string()?;
-            let row = SqlNewConversationItemRow {
-                id: new_id(),
-                conversation_id: input.conversation_id.clone(),
-                seq,
-                kind: db_label(&input.payload.kind())?,
-                status: db_label(&input.status)?,
-                agent_run_id: input.agent_run_id,
-                provider_step_id: input.provider_step_id,
-                tool_invocation_id: input.tool_invocation_id,
-                provider_item_id: input.provider_item_id,
-                payload_json: to_json(&input.payload)?,
-                search_text: input.payload.search_text(),
-                created_at: now.clone(),
-                updated_at: now.clone(),
-            };
-            let item = diesel::insert_into(conversation_items::table)
-                .values(&row)
-                .returning(SqlConversationItemRow::as_returning())
-                .get_result::<SqlConversationItemRow>(conn)?;
-            diesel::update(conversations::table.find(&row.conversation_id))
-                .set((
-                    conversations::last_item_seq.eq(seq),
-                    conversations::updated_at.eq(now),
-                ))
-                .execute(conn)?;
-            item.try_into()
-        })
+        conn.immediate_transaction(|conn| append_conversation_item_with_conn(conn, input))
     }
 
     pub fn conversation_items(&self, conversation_id: &str) -> Result<Vec<ConversationItemRecord>> {
@@ -282,7 +249,7 @@ impl FreshRepository {
                 status: db_label(&status)?,
                 payload_json: to_json(&payload)?,
                 search_text: payload.search_text(),
-                updated_at: now.clone(),
+                updated_at: now,
             };
             let item = diesel::update(conversation_items::table.find(item_id))
                 .set(&changes)
@@ -313,7 +280,7 @@ impl FreshRepository {
                 sha256: input.sha256,
                 size_bytes: input.size_bytes,
                 metadata_json: to_json(&input.metadata)?,
-                created_at: now.clone(),
+                created_at: now,
                 updated_at: now,
             };
             diesel::insert_into(attachments::table)
@@ -338,7 +305,7 @@ impl FreshRepository {
                 input_json: to_json(&input.input)?,
                 output_json: None,
                 error_json: None,
-                created_at: now.clone(),
+                created_at: now,
                 started_at: None,
                 completed_at: None,
                 updated_at: now,
@@ -348,6 +315,63 @@ impl FreshRepository {
                 .returning(SqlAgentRunRow::as_returning())
                 .get_result::<SqlAgentRunRow>(conn)?
                 .try_into()
+        })
+    }
+
+    pub fn get_agent_run(&self, id: &str) -> Result<Option<AgentRunRecord>> {
+        let mut conn = self.conn()?;
+        agent_run_row(&mut conn, id)?
+            .map(TryInto::try_into)
+            .transpose()
+    }
+
+    pub fn agent_runs_for_conversation(
+        &self,
+        conversation_id: &str,
+    ) -> Result<Vec<AgentRunRecord>> {
+        let mut conn = self.conn()?;
+        agent_runs::table
+            .filter(agent_runs::conversation_id.eq(conversation_id))
+            .order(agent_runs::created_at.asc())
+            .select(SqlAgentRunRow::as_select())
+            .load::<SqlAgentRunRow>(&mut conn)?
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect()
+    }
+
+    pub fn agent_runs_by_status(&self, status: AgentRunStatus) -> Result<Vec<AgentRunRecord>> {
+        let mut conn = self.conn()?;
+        agent_runs::table
+            .filter(agent_runs::status.eq(db_label(&status)?))
+            .order(agent_runs::created_at.asc())
+            .select(SqlAgentRunRow::as_select())
+            .load::<SqlAgentRunRow>(&mut conn)?
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect()
+    }
+
+    pub fn update_agent_run_status(
+        &self,
+        id: &str,
+        update: UpdateAgentRunStatus,
+    ) -> Result<AgentRunRecord> {
+        let mut conn = self.conn()?;
+        conn.immediate_transaction(|conn| update_agent_run_status_with_conn(conn, id, update))
+    }
+
+    pub fn append_conversation_item_and_update_agent_run(
+        &self,
+        item: NewConversationItem,
+        agent_run_id: &str,
+        update: UpdateAgentRunStatus,
+    ) -> Result<(ConversationItemRecord, AgentRunRecord)> {
+        let mut conn = self.conn()?;
+        conn.immediate_transaction(|conn| {
+            let item = append_conversation_item_with_conn(conn, item)?;
+            let run = update_agent_run_status_with_conn(conn, agent_run_id, update)?;
+            Ok((item, run))
         })
     }
 
@@ -372,7 +396,7 @@ impl FreshRepository {
                 state_snapshot_json: to_json_opt(&input.state_snapshot)?,
                 settings_snapshot_json: to_json(&input.settings_snapshot)?,
                 error_json: to_json_opt(&input.error)?,
-                created_at: now.clone(),
+                created_at: now,
                 started_at: None,
                 completed_at: None,
                 updated_at: now,
@@ -382,6 +406,57 @@ impl FreshRepository {
                 .returning(SqlProviderStepRow::as_returning())
                 .get_result::<SqlProviderStepRow>(conn)?
                 .try_into()
+        })
+    }
+
+    pub fn get_provider_step(&self, id: &str) -> Result<Option<ProviderStepRecord>> {
+        let mut conn = self.conn()?;
+        provider_step_row(&mut conn, id)?
+            .map(TryInto::try_into)
+            .transpose()
+    }
+
+    pub fn provider_steps_for_run(&self, agent_run_id: &str) -> Result<Vec<ProviderStepRecord>> {
+        let mut conn = self.conn()?;
+        provider_steps::table
+            .filter(provider_steps::agent_run_id.eq(agent_run_id))
+            .order(provider_steps::seq.asc())
+            .select(SqlProviderStepRow::as_select())
+            .load::<SqlProviderStepRow>(&mut conn)?
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect()
+    }
+
+    pub fn next_provider_step_seq(&self, agent_run_id: &str) -> Result<i32> {
+        let mut conn = self.conn()?;
+        let max_seq = provider_steps::table
+            .filter(provider_steps::agent_run_id.eq(agent_run_id))
+            .select(diesel::dsl::max(provider_steps::seq))
+            .first::<Option<i32>>(&mut conn)?;
+        Ok(max_seq.unwrap_or(0) + 1)
+    }
+
+    pub fn update_provider_step_status(
+        &self,
+        id: &str,
+        update: UpdateProviderStepStatus,
+    ) -> Result<ProviderStepRecord> {
+        let mut conn = self.conn()?;
+        conn.immediate_transaction(|conn| update_provider_step_status_with_conn(conn, id, update))
+    }
+
+    pub fn append_conversation_item_and_update_provider_step(
+        &self,
+        item: NewConversationItem,
+        provider_step_id: &str,
+        update: UpdateProviderStepStatus,
+    ) -> Result<(ConversationItemRecord, ProviderStepRecord)> {
+        let mut conn = self.conn()?;
+        conn.immediate_transaction(|conn| {
+            let item = append_conversation_item_with_conn(conn, item)?;
+            let step = update_provider_step_status_with_conn(conn, provider_step_id, update)?;
+            Ok((item, step))
         })
     }
 
@@ -412,7 +487,7 @@ impl FreshRepository {
                 input_json: to_json(&input.input)?,
                 output_json: to_json_opt(&input.output)?,
                 error_json: to_json_opt(&input.error)?,
-                created_at: now.clone(),
+                created_at: now,
                 started_at: None,
                 completed_at: None,
                 updated_at: now,
@@ -422,6 +497,52 @@ impl FreshRepository {
                 .returning(SqlToolInvocationRow::as_returning())
                 .get_result::<SqlToolInvocationRow>(conn)?
                 .try_into()
+        })
+    }
+
+    pub fn get_tool_invocation(&self, id: &str) -> Result<Option<ToolInvocationRecord>> {
+        let mut conn = self.conn()?;
+        tool_invocation_row(&mut conn, id)?
+            .map(TryInto::try_into)
+            .transpose()
+    }
+
+    pub fn tool_invocations_for_run(
+        &self,
+        agent_run_id: &str,
+    ) -> Result<Vec<ToolInvocationRecord>> {
+        let mut conn = self.conn()?;
+        tool_invocations::table
+            .filter(tool_invocations::agent_run_id.eq(agent_run_id))
+            .order(tool_invocations::created_at.asc())
+            .select(SqlToolInvocationRow::as_select())
+            .load::<SqlToolInvocationRow>(&mut conn)?
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect()
+    }
+
+    pub fn update_tool_invocation_status(
+        &self,
+        id: &str,
+        update: UpdateToolInvocationStatus,
+    ) -> Result<ToolInvocationRecord> {
+        let mut conn = self.conn()?;
+        conn.immediate_transaction(|conn| update_tool_invocation_status_with_conn(conn, id, update))
+    }
+
+    pub fn append_conversation_item_and_update_tool_invocation(
+        &self,
+        item: NewConversationItem,
+        tool_invocation_id: &str,
+        update: UpdateToolInvocationStatus,
+    ) -> Result<(ConversationItemRecord, ToolInvocationRecord)> {
+        let mut conn = self.conn()?;
+        conn.immediate_transaction(|conn| {
+            let item = append_conversation_item_with_conn(conn, item)?;
+            let invocation =
+                update_tool_invocation_status_with_conn(conn, tool_invocation_id, update)?;
+            Ok((item, invocation))
         })
     }
 
@@ -439,7 +560,7 @@ impl FreshRepository {
                 status: db_label(&outcome.status)?,
                 request_json: to_json(&input.request)?,
                 decision_json: to_json_opt(&outcome.decision)?,
-                requested_at: now.clone(),
+                requested_at: now,
                 decided_at: outcome.decided_at,
                 expires_at: outcome.expires_at,
             };
@@ -449,6 +570,49 @@ impl FreshRepository {
                 .get_result::<SqlApprovalDecisionRow>(conn)?
                 .try_into()
         })
+    }
+
+    pub fn get_approval_decision(&self, id: &str) -> Result<Option<ApprovalDecisionRecord>> {
+        let mut conn = self.conn()?;
+        approval_decision_row(&mut conn, id)?
+            .map(TryInto::try_into)
+            .transpose()
+    }
+
+    pub fn approval_decisions_for_tool(
+        &self,
+        tool_invocation_id: &str,
+    ) -> Result<Vec<ApprovalDecisionRecord>> {
+        let mut conn = self.conn()?;
+        approval_decisions::table
+            .filter(approval_decisions::tool_invocation_id.eq(tool_invocation_id))
+            .order(approval_decisions::requested_at.asc())
+            .select(SqlApprovalDecisionRow::as_select())
+            .load::<SqlApprovalDecisionRow>(&mut conn)?
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect()
+    }
+
+    pub fn pending_approval_decisions(&self) -> Result<Vec<ApprovalDecisionRecord>> {
+        let mut conn = self.conn()?;
+        approval_decisions::table
+            .filter(approval_decisions::status.eq(db_label(&ApprovalStatus::Pending)?))
+            .order(approval_decisions::requested_at.asc())
+            .select(SqlApprovalDecisionRow::as_select())
+            .load::<SqlApprovalDecisionRow>(&mut conn)?
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect()
+    }
+
+    pub fn update_approval_decision(
+        &self,
+        id: &str,
+        outcome: NewApprovalDecisionOutcome,
+    ) -> Result<ApprovalDecisionRecord> {
+        let mut conn = self.conn()?;
+        conn.immediate_transaction(|conn| update_approval_decision_with_conn(conn, id, outcome))
     }
 
     pub fn insert_usage_event(&self, input: NewUsageEvent) -> Result<UsageEventRecord> {
@@ -481,6 +645,21 @@ impl FreshRepository {
         })
     }
 
+    pub fn usage_events_for_provider_step(
+        &self,
+        provider_step_id: &str,
+    ) -> Result<Vec<UsageEventRecord>> {
+        let mut conn = self.conn()?;
+        usage_events::table
+            .filter(usage_events::provider_step_id.eq(provider_step_id))
+            .order(usage_events::created_at.asc())
+            .select(SqlUsageEventRow::as_select())
+            .load::<SqlUsageEventRow>(&mut conn)?
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect()
+    }
+
     pub fn insert_shortcut(&self, input: NewShortcut) -> Result<ShortcutRecord> {
         let mut conn = self.conn()?;
         conn.immediate_transaction(|conn| {
@@ -495,7 +674,7 @@ impl FreshRepository {
                 input_source: db_label(&input.input_source)?,
                 action_json: to_json(&input.action)?,
                 settings_snapshot_json: to_json(&input.settings_snapshot)?,
-                created_at: now.clone(),
+                created_at: now,
                 updated_at: now,
             };
             diesel::insert_into(shortcuts::table)
@@ -513,7 +692,7 @@ impl FreshRepository {
             let row = SqlNewAppSettingsRow {
                 id: "default".to_string(),
                 settings_json: to_json(&settings)?,
-                created_at: now.clone(),
+                created_at: now,
                 updated_at: now,
             };
             diesel::insert_into(app_settings::table)
@@ -608,6 +787,44 @@ fn conversation_item_row(
         .optional()?)
 }
 
+fn agent_run_row(conn: &mut SqliteConnection, id: &str) -> Result<Option<SqlAgentRunRow>> {
+    Ok(agent_runs::table
+        .find(id)
+        .select(SqlAgentRunRow::as_select())
+        .first(conn)
+        .optional()?)
+}
+
+fn provider_step_row(conn: &mut SqliteConnection, id: &str) -> Result<Option<SqlProviderStepRow>> {
+    Ok(provider_steps::table
+        .find(id)
+        .select(SqlProviderStepRow::as_select())
+        .first(conn)
+        .optional()?)
+}
+
+fn tool_invocation_row(
+    conn: &mut SqliteConnection,
+    id: &str,
+) -> Result<Option<SqlToolInvocationRow>> {
+    Ok(tool_invocations::table
+        .find(id)
+        .select(SqlToolInvocationRow::as_select())
+        .first(conn)
+        .optional()?)
+}
+
+fn approval_decision_row(
+    conn: &mut SqliteConnection,
+    id: &str,
+) -> Result<Option<SqlApprovalDecisionRow>> {
+    Ok(approval_decisions::table
+        .find(id)
+        .select(SqlApprovalDecisionRow::as_select())
+        .first(conn)
+        .optional()?)
+}
+
 fn app_settings_row(conn: &mut SqliteConnection) -> Result<Option<SqlAppSettingsRow>> {
     Ok(app_settings::table
         .find("default")
@@ -641,6 +858,147 @@ fn load_tool_invocation_row(conn: &mut SqliteConnection, id: &str) -> Result<Sql
         .first(conn)
         .optional()?
         .ok_or_else(|| DbError::Invariant(format!("tool invocation {id} is missing")))
+}
+
+fn append_conversation_item_with_conn(
+    conn: &mut SqliteConnection,
+    input: NewConversationItem,
+) -> Result<ConversationItemRecord> {
+    let conversation = conversation_row(conn, &input.conversation_id)?
+        .ok_or_else(|| DbError::Invariant("conversation is missing".to_string()))?;
+    validate_execution_links(conn, &input.conversation_id, &input)?;
+
+    let seq = conversation.last_item_seq + 1;
+    let now = now_string()?;
+    let row = SqlNewConversationItemRow {
+        id: new_id(),
+        conversation_id: input.conversation_id.clone(),
+        seq,
+        kind: db_label(&input.payload.kind())?,
+        status: db_label(&input.status)?,
+        agent_run_id: input.agent_run_id,
+        provider_step_id: input.provider_step_id,
+        tool_invocation_id: input.tool_invocation_id,
+        provider_item_id: input.provider_item_id,
+        payload_json: to_json(&input.payload)?,
+        search_text: input.payload.search_text(),
+        created_at: now,
+        updated_at: now,
+    };
+    let item = diesel::insert_into(conversation_items::table)
+        .values(&row)
+        .returning(SqlConversationItemRow::as_returning())
+        .get_result::<SqlConversationItemRow>(conn)?;
+    diesel::update(conversations::table.find(&row.conversation_id))
+        .set((
+            conversations::last_item_seq.eq(seq),
+            conversations::updated_at.eq(now),
+        ))
+        .execute(conn)?;
+    item.try_into()
+}
+
+fn update_agent_run_status_with_conn(
+    conn: &mut SqliteConnection,
+    id: &str,
+    update: UpdateAgentRunStatus,
+) -> Result<AgentRunRecord> {
+    let existing = load_agent_run_row(conn, id)?;
+    let now = now_string()?;
+    let changes = SqlAgentRunStatusChanges {
+        status: db_label(&update.status)?,
+        output_json: to_json_opt(&update.output)?,
+        error_json: to_json_opt(&update.error)?,
+        started_at: next_started_at(existing.started_at, update.status, now),
+        completed_at: next_agent_run_completed_at(existing.completed_at, update.status, now),
+        updated_at: now,
+    };
+    diesel::update(agent_runs::table.find(id))
+        .set(&changes)
+        .returning(SqlAgentRunRow::as_returning())
+        .get_result::<SqlAgentRunRow>(conn)?
+        .try_into()
+}
+
+fn update_provider_step_status_with_conn(
+    conn: &mut SqliteConnection,
+    id: &str,
+    update: UpdateProviderStepStatus,
+) -> Result<ProviderStepRecord> {
+    let existing = load_provider_step_row(conn, id)?;
+    if let Some(state_snapshot) = update.state_snapshot.as_ref() {
+        ensure_equal(
+            "provider step state provider",
+            &state_snapshot.provider_id,
+            &existing.provider_id,
+        )?;
+    }
+    let now = now_string()?;
+    let changes = SqlProviderStepStatusChanges {
+        status: db_label(&update.status)?,
+        response_snapshot_json: to_json_opt(&update.response_snapshot)?,
+        state_snapshot_json: to_json_opt(&update.state_snapshot)?,
+        error_json: to_json_opt(&update.error)?,
+        started_at: next_started_at(existing.started_at, update.status, now),
+        completed_at: next_provider_step_completed_at(existing.completed_at, update.status, now),
+        updated_at: now,
+    };
+    diesel::update(provider_steps::table.find(id))
+        .set(&changes)
+        .returning(SqlProviderStepRow::as_returning())
+        .get_result::<SqlProviderStepRow>(conn)?
+        .try_into()
+}
+
+fn update_tool_invocation_status_with_conn(
+    conn: &mut SqliteConnection,
+    id: &str,
+    update: UpdateToolInvocationStatus,
+) -> Result<ToolInvocationRecord> {
+    let existing = load_tool_invocation_row(conn, id)?;
+    let now = now_string()?;
+    let changes = SqlToolInvocationStatusChanges {
+        status: db_label(&update.status)?,
+        output_json: to_json_opt(&update.output)?,
+        error_json: to_json_opt(&update.error)?,
+        started_at: next_started_at(existing.started_at, update.status, now),
+        completed_at: next_tool_invocation_completed_at(existing.completed_at, update.status, now),
+        updated_at: now,
+    };
+    diesel::update(tool_invocations::table.find(id))
+        .set(&changes)
+        .returning(SqlToolInvocationRow::as_returning())
+        .get_result::<SqlToolInvocationRow>(conn)?
+        .try_into()
+}
+
+fn update_approval_decision_with_conn(
+    conn: &mut SqliteConnection,
+    id: &str,
+    outcome: NewApprovalDecisionOutcome,
+) -> Result<ApprovalDecisionRecord> {
+    let existing = approval_decision_row(conn, id)?
+        .ok_or_else(|| DbError::Invariant(format!("approval decision {id} is missing")))?;
+    let status: ApprovalStatus = db_label_parse(existing.status)?;
+    if status != ApprovalStatus::Pending {
+        return Err(DbError::Invariant(format!(
+            "approval decision {id} is {status:?}, not pending"
+        )));
+    }
+
+    let now = now_string()?;
+    let outcome = approval_outcome_columns(outcome, &now)?;
+    let changes = SqlApprovalDecisionChanges {
+        status: db_label(&outcome.status)?,
+        decision_json: to_json_opt(&outcome.decision)?,
+        decided_at: outcome.decided_at,
+        expires_at: outcome.expires_at,
+    };
+    diesel::update(approval_decisions::table.find(id))
+        .set(&changes)
+        .returning(SqlApprovalDecisionRow::as_returning())
+        .get_result::<SqlApprovalDecisionRow>(conn)?
+        .try_into()
 }
 
 fn validate_execution_links(
@@ -834,6 +1192,86 @@ struct ApprovalOutcomeColumns {
     decision: Option<ApprovalDecisionPayload>,
     decided_at: Option<OffsetDateTime>,
     expires_at: Option<OffsetDateTime>,
+}
+
+trait ExecutionStatusTiming {
+    fn starts_clock(self) -> bool;
+}
+
+impl ExecutionStatusTiming for AgentRunStatus {
+    fn starts_clock(self) -> bool {
+        !matches!(self, AgentRunStatus::Queued)
+    }
+}
+
+impl ExecutionStatusTiming for ProviderStepStatus {
+    fn starts_clock(self) -> bool {
+        !matches!(self, ProviderStepStatus::Queued)
+    }
+}
+
+impl ExecutionStatusTiming for ToolInvocationStatus {
+    fn starts_clock(self) -> bool {
+        !matches!(self, ToolInvocationStatus::Requested)
+    }
+}
+
+fn next_started_at<T>(
+    existing: Option<OffsetDateTime>,
+    status: T,
+    now: OffsetDateTime,
+) -> Option<OffsetDateTime>
+where
+    T: ExecutionStatusTiming,
+{
+    existing.or_else(|| status.starts_clock().then_some(now))
+}
+
+fn next_agent_run_completed_at(
+    existing: Option<OffsetDateTime>,
+    status: AgentRunStatus,
+    now: OffsetDateTime,
+) -> Option<OffsetDateTime> {
+    existing.or_else(|| {
+        matches!(
+            status,
+            AgentRunStatus::Completed | AgentRunStatus::Failed | AgentRunStatus::Canceled
+        )
+        .then_some(now)
+    })
+}
+
+fn next_provider_step_completed_at(
+    existing: Option<OffsetDateTime>,
+    status: ProviderStepStatus,
+    now: OffsetDateTime,
+) -> Option<OffsetDateTime> {
+    existing.or_else(|| {
+        matches!(
+            status,
+            ProviderStepStatus::Completed
+                | ProviderStepStatus::Failed
+                | ProviderStepStatus::Canceled
+        )
+        .then_some(now)
+    })
+}
+
+fn next_tool_invocation_completed_at(
+    existing: Option<OffsetDateTime>,
+    status: ToolInvocationStatus,
+    now: OffsetDateTime,
+) -> Option<OffsetDateTime> {
+    existing.or_else(|| {
+        matches!(
+            status,
+            ToolInvocationStatus::Succeeded
+                | ToolInvocationStatus::Failed
+                | ToolInvocationStatus::Denied
+                | ToolInvocationStatus::Canceled
+        )
+        .then_some(now)
+    })
 }
 
 fn ensure_equal(entity: &str, actual: &str, expected: &str) -> Result<()> {

--- a/crates/ai-chat-db/src/repository.rs
+++ b/crates/ai-chat-db/src/repository.rs
@@ -306,8 +306,8 @@ impl FreshRepository {
                 output_json: None,
                 error_json: None,
                 created_at: now,
-                started_at: None,
-                completed_at: None,
+                started_at: next_started_at(None, input.status, now),
+                completed_at: next_agent_run_completed_at(None, input.status, now),
                 updated_at: now,
             };
             diesel::insert_into(agent_runs::table)
@@ -397,8 +397,8 @@ impl FreshRepository {
                 settings_snapshot_json: to_json(&input.settings_snapshot)?,
                 error_json: to_json_opt(&input.error)?,
                 created_at: now,
-                started_at: None,
-                completed_at: None,
+                started_at: next_started_at(None, input.status, now),
+                completed_at: next_provider_step_completed_at(None, input.status, now),
                 updated_at: now,
             };
             diesel::insert_into(provider_steps::table)
@@ -488,8 +488,8 @@ impl FreshRepository {
                 output_json: to_json_opt(&input.output)?,
                 error_json: to_json_opt(&input.error)?,
                 created_at: now,
-                started_at: None,
-                completed_at: None,
+                started_at: next_started_at(None, input.status, now),
+                completed_at: next_tool_invocation_completed_at(None, input.status, now),
                 updated_at: now,
             };
             diesel::insert_into(tool_invocations::table)

--- a/crates/ai-chat-db/src/tests.rs
+++ b/crates/ai-chat-db/src/tests.rs
@@ -955,6 +955,117 @@ fn execution_status_updates_and_pending_approval_queries_roundtrip() {
 }
 
 #[test]
+fn active_execution_inserts_stamp_start_times() {
+    let dir = tempdir().unwrap();
+    let store = FreshStore::open_in_dir(dir.path()).unwrap();
+    let repo = store.repository();
+    let project = repo.insert_project(project("active-starts")).unwrap();
+    let provider = repo.insert_provider(provider()).unwrap();
+    let model = repo
+        .upsert_provider_model(provider_model(&provider.id, "gpt-5.2", "GPT-5.2"))
+        .unwrap();
+    let conversation = repo.insert_conversation(conversation(&project)).unwrap();
+    let user_item = repo
+        .append_conversation_item(message_item(&conversation.id, "run input"))
+        .unwrap();
+
+    let agent_run = repo
+        .insert_agent_run(NewAgentRun {
+            trigger_kind: AgentRunTriggerKind::User,
+            status: AgentRunStatus::Running,
+            input: agent_run_input(&user_item.id, &provider.id, &model.model_id),
+        })
+        .unwrap();
+    assert!(agent_run.started_at.is_some());
+    assert!(agent_run.completed_at.is_none());
+
+    let provider_step = repo
+        .insert_provider_step(NewProviderStep {
+            agent_run_id: agent_run.id.clone(),
+            seq: 1,
+            status: ProviderStepStatus::Running,
+            request_snapshot: provider_step_request(&provider.id, &model.model_id, &user_item.id),
+            response_snapshot: None,
+            state_snapshot: None,
+            settings_snapshot: run_settings(&provider.id, &model.model_id),
+            error: None,
+        })
+        .unwrap();
+    assert!(provider_step.started_at.is_some());
+    assert!(provider_step.completed_at.is_none());
+    let completed_step = repo
+        .update_provider_step_status(
+            &provider_step.id,
+            UpdateProviderStepStatus {
+                status: ProviderStepStatus::Completed,
+                response_snapshot: Some(provider_step_response()),
+                state_snapshot: Some(provider_run_state(&provider.id)),
+                error: None,
+            },
+        )
+        .unwrap();
+    assert_eq!(completed_step.started_at, provider_step.started_at);
+    assert!(completed_step.completed_at.is_some());
+
+    let mut running_tool_input = tool_input();
+    running_tool_input.call_id = "call_running".to_string();
+    let running_tool = repo
+        .insert_tool_invocation(NewToolInvocation {
+            agent_run_id: agent_run.id.clone(),
+            provider_step_id: Some(provider_step.id.clone()),
+            status: ToolInvocationStatus::Running,
+            input: running_tool_input,
+            output: None,
+            error: None,
+        })
+        .unwrap();
+    assert!(running_tool.started_at.is_some());
+    assert!(running_tool.completed_at.is_none());
+    let succeeded_tool = repo
+        .update_tool_invocation_status(
+            &running_tool.id,
+            UpdateToolInvocationStatus {
+                status: ToolInvocationStatus::Succeeded,
+                output: Some(tool_output()),
+                error: None,
+            },
+        )
+        .unwrap();
+    assert_eq!(succeeded_tool.started_at, running_tool.started_at);
+    assert!(succeeded_tool.completed_at.is_some());
+
+    let mut awaiting_tool_input = tool_input();
+    awaiting_tool_input.call_id = "call_awaiting".to_string();
+    let awaiting_tool = repo
+        .insert_tool_invocation(NewToolInvocation {
+            agent_run_id: agent_run.id.clone(),
+            provider_step_id: Some(provider_step.id),
+            status: ToolInvocationStatus::AwaitingApproval,
+            input: awaiting_tool_input,
+            output: None,
+            error: None,
+        })
+        .unwrap();
+    assert!(awaiting_tool.started_at.is_some());
+    assert!(awaiting_tool.completed_at.is_none());
+
+    let mut requested_tool_input = tool_input();
+    requested_tool_input.call_id = "call_requested".to_string();
+    let requested_tool = repo
+        .insert_tool_invocation(NewToolInvocation {
+            agent_run_id: agent_run.id,
+            provider_step_id: None,
+            status: ToolInvocationStatus::Requested,
+            input: requested_tool_input,
+            output: None,
+            error: None,
+        })
+        .unwrap();
+    assert!(requested_tool.started_at.is_none());
+    assert!(requested_tool.completed_at.is_none());
+}
+
+#[test]
 fn typed_json_roundtrips_for_repository_records() {
     let dir = tempdir().unwrap();
     let store = FreshStore::open_in_dir(dir.path()).unwrap();

--- a/crates/ai-chat-db/src/tests.rs
+++ b/crates/ai-chat-db/src/tests.rs
@@ -1,7 +1,8 @@
 use crate::{
     FreshStore, NewAgentRun, NewApprovalDecision, NewApprovalDecisionOutcome, NewAttachment,
     NewConversation, NewConversationItem, NewProject, NewPrompt, NewProvider, NewProviderModel,
-    NewProviderStep, NewShortcut, NewToolInvocation, NewUsageEvent,
+    NewProviderStep, NewShortcut, NewToolInvocation, NewUsageEvent, UpdateAgentRunStatus,
+    UpdateProviderStepStatus, UpdateToolInvocationStatus,
 };
 use ai_chat_core::*;
 use diesel::{
@@ -815,6 +816,145 @@ fn approval_outcome_derives_status_and_decision_columns() {
 }
 
 #[test]
+fn execution_status_updates_and_pending_approval_queries_roundtrip() {
+    let dir = tempdir().unwrap();
+    let store = FreshStore::open_in_dir(dir.path()).unwrap();
+    let repo = store.repository();
+    let project = repo.insert_project(project("execution-updates")).unwrap();
+    let conversation = repo.insert_conversation(conversation(&project)).unwrap();
+    let provider = repo.insert_provider(provider()).unwrap();
+    let model = repo
+        .upsert_provider_model(provider_model(&provider.id, "gpt-5.2", "GPT-5.2"))
+        .unwrap();
+    let user_item = repo
+        .append_conversation_item(message_item(&conversation.id, "update input"))
+        .unwrap();
+    let agent_run = repo
+        .insert_agent_run(NewAgentRun {
+            trigger_kind: AgentRunTriggerKind::User,
+            status: AgentRunStatus::Queued,
+            input: agent_run_input(&user_item.id, &provider.id, &model.model_id),
+        })
+        .unwrap();
+
+    let running = repo
+        .update_agent_run_status(
+            &agent_run.id,
+            UpdateAgentRunStatus {
+                status: AgentRunStatus::Running,
+                output: None,
+                error: None,
+            },
+        )
+        .unwrap();
+    assert_eq!(running.status, AgentRunStatus::Running);
+    assert!(running.started_at.is_some());
+    assert!(running.completed_at.is_none());
+
+    let provider_step = repo
+        .insert_provider_step(NewProviderStep {
+            agent_run_id: agent_run.id.clone(),
+            seq: 1,
+            status: ProviderStepStatus::Queued,
+            request_snapshot: provider_step_request(&provider.id, &model.model_id, &user_item.id),
+            response_snapshot: None,
+            state_snapshot: None,
+            settings_snapshot: run_settings(&provider.id, &model.model_id),
+            error: None,
+        })
+        .unwrap();
+    let completed_step = repo
+        .update_provider_step_status(
+            &provider_step.id,
+            UpdateProviderStepStatus {
+                status: ProviderStepStatus::Completed,
+                response_snapshot: Some(provider_step_response()),
+                state_snapshot: Some(provider_run_state(&provider.id)),
+                error: None,
+            },
+        )
+        .unwrap();
+    assert_eq!(completed_step.status, ProviderStepStatus::Completed);
+    assert_eq!(
+        completed_step.response_snapshot,
+        Some(provider_step_response())
+    );
+    assert!(completed_step.started_at.is_some());
+    assert!(completed_step.completed_at.is_some());
+
+    let tool = repo
+        .insert_tool_invocation(NewToolInvocation {
+            agent_run_id: agent_run.id.clone(),
+            provider_step_id: Some(provider_step.id.clone()),
+            status: ToolInvocationStatus::Requested,
+            input: tool_input(),
+            output: None,
+            error: None,
+        })
+        .unwrap();
+    let approval = repo
+        .insert_approval_decision(NewApprovalDecision {
+            tool_invocation_id: tool.id.clone(),
+            request: approval_request(),
+            outcome: NewApprovalDecisionOutcome::Pending { expires_at: None },
+        })
+        .unwrap();
+    assert_eq!(
+        repo.pending_approval_decisions().unwrap(),
+        vec![approval.clone()]
+    );
+
+    let approved = repo
+        .update_approval_decision(
+            &approval.id,
+            NewApprovalDecisionOutcome::Approved {
+                decided_by: "user".to_string(),
+                reason: Some("ok".to_string()),
+            },
+        )
+        .unwrap();
+    assert_eq!(approved.status, ApprovalStatus::Approved);
+    assert!(repo.pending_approval_decisions().unwrap().is_empty());
+
+    let succeeded_tool = repo
+        .update_tool_invocation_status(
+            &tool.id,
+            UpdateToolInvocationStatus {
+                status: ToolInvocationStatus::Succeeded,
+                output: Some(tool_output()),
+                error: None,
+            },
+        )
+        .unwrap();
+    assert_eq!(succeeded_tool.status, ToolInvocationStatus::Succeeded);
+    assert_eq!(succeeded_tool.output, Some(tool_output()));
+    assert!(succeeded_tool.started_at.is_some());
+    assert!(succeeded_tool.completed_at.is_some());
+
+    let output = AgentRunOutput {
+        final_item_id: None,
+        stopped_reason: AgentStoppedReason::Completed,
+    };
+    let completed_run = repo
+        .update_agent_run_status(
+            &agent_run.id,
+            UpdateAgentRunStatus {
+                status: AgentRunStatus::Completed,
+                output: Some(output.clone()),
+                error: None,
+            },
+        )
+        .unwrap();
+    assert_eq!(completed_run.output, Some(output));
+    assert!(completed_run.completed_at.is_some());
+    assert_eq!(repo.provider_steps_for_run(&agent_run.id).unwrap().len(), 1);
+    assert_eq!(
+        repo.tool_invocations_for_run(&agent_run.id).unwrap().len(),
+        1
+    );
+}
+
+#[test]
 fn typed_json_roundtrips_for_repository_records() {
     let dir = tempdir().unwrap();
     let store = FreshStore::open_in_dir(dir.path()).unwrap();
@@ -1227,6 +1367,7 @@ fn attachment_metadata() -> AttachmentMetadata {
 fn agent_run_input(user_item_id: &str, provider_id: &str, model_id: &str) -> AgentRunInput {
     AgentRunInput {
         user_item_id: user_item_id.to_string(),
+        parent_agent_run_id: None,
         prompt_snapshot: Some(prompt_content()),
         provider_id: provider_id.to_string(),
         model_id: model_id.to_string(),


### PR DESCRIPTION
## Summary

- Added `crates/ai-chat-agent` for the first Rig/rmcp agent runtime and persistence layer.
- Affected crates: `ai-chat-agent`, `ai-chat-core`, `ai-chat-db`, and workspace dependency wiring.

## Motivation

- Implements the #158 runtime slice under parent #137 so ai-chat2 can run multi-step agent turns against the fresh transcript/execution model instead of legacy message persistence.

## Changes

- Adds `AgentRuntime`, `AgentRunRequest`, tool registry APIs, MCP registration helpers, file-backed skill catalog/loading, Rig prompt history reconstruction, `PersistingCompletionModel`, and persistence hooks for provider steps, tool calls/results, approvals, usage, and terminal state.
- Adds `rig-core = 0.37.0` with rmcp support and `rmcp = 1.7.0`; Rig OpenAI remains on the default Responses API path.
- Extends `AgentRunInput` with optional `parent_agent_run_id` for retry/resume lineage.
- Extends `ai-chat-db` repository APIs for agent/provider/tool status updates, pending approval decision updates, execution row queries, and atomic transcript/execution updates.
- Adds focused runtime and DB tests for no-tool runs, Rig tool calls, in-process rmcp tool calls, tool-name collisions, approval pause, skill snapshots, and execution status updates.

## Validation

- [x] `cargo build`
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
cargo fmt
cargo check -p ai-chat-agent
cargo test -p ai-chat-core
cargo test -p ai-chat-db
cargo test -p ai-chat-agent
cargo clippy -p ai-chat-core -p ai-chat-db -p ai-chat-agent --all-targets --all-features -- -D warnings
cargo build -p ai-chat-core -p ai-chat-db -p ai-chat-agent
git diff --check
```

Focused crate validation passed. Full workspace validation and manual GPUI UI verification were not run because this PR is the #158 runtime/data slice; #159 owns the ai-chat2 UI.

## Risks

- This introduces the initial agent runtime boundary and dependency set, so #159 integration may still refine app-level provider factory and approval resume wiring.
- Provider-hosted tool reporting is represented in request/runtime types; deeper provider-specific output parsing can be expanded as providers are wired into ai-chat2.

## Related Issues

- Closes #158
- Related to #137
