### PR TITLE
fix(xtask): gate macOS icon fields

### DIFF
--- a/crates/xtask/src/bundle/common.rs
+++ b/crates/xtask/src/bundle/common.rs
@@ -57,11 +57,13 @@ const ICO_FRAME_SIZES: [u32; 7] = [16, 24, 32, 48, 64, 128, 256];
 
 pub(crate) struct BundleIconAssets {
     temp_dir: PathBuf,
+    #[cfg(target_os = "macos")]
     source_icon_dir: PathBuf,
     staged_icon_dir: PathBuf,
 }
 
 impl BundleIconAssets {
+    #[cfg(target_os = "macos")]
     pub(crate) fn source_base_icon(&self) -> PathBuf {
         self.source_icon_dir.join("app-icon.png")
     }
@@ -124,7 +126,8 @@ pub(crate) fn prepare_bundle_icons(app_dir: &Path) -> Result<BundleIconAssets> {
     let assets = BundleIconAssets {
         staged_icon_dir: temp_dir.join("build-assets/icon"),
         temp_dir,
-        source_icon_dir,
+        #[cfg(target_os = "macos")]
+        source_icon_dir: source_icon_dir.clone(),
     };
 
     let iconset_dir = assets.staged_icon_dir.join("app-icon.iconset");


### PR DESCRIPTION
## Summary

- Gate the macOS-only `BundleIconAssets::source_icon_dir` field and `source_base_icon` method behind `cfg(target_os = "macos")`.
- Affected crate: `xtask`.

## Motivation

On Windows, these members are compiled but never used because their only consumer is the macOS bundling path. With warnings denied, Clippy reports them as dead code.

## Changes

- Compile the source icon directory field only on macOS.
- Compile its accessor only on macOS.
- Initialize the field conditionally when preparing bundle icons.
- Packaging behavior is unchanged on all platforms.

## Validation

- [ ] `cargo build`
- [ ] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual verification completed for the affected app or flow

Validation details:

```text
cargo fmt --all
git diff --check
cargo clippy -p xtask --all-targets --all-features -- -D warnings
Result: passed on Windows.
Full workspace build and test were not run because this change is limited to target-gating macOS-only xtask members.
```

## Risks

Low risk. The change only adjusts conditional compilation of members used exclusively by the macOS bundler; runtime and packaging logic is unchanged.

## Related Issues

None.
